### PR TITLE
Fixed bug in assignment of basis_out_tag keyword.

### DIFF
--- a/PynPoint/processing_modules/PSFSubtraction.py
+++ b/PynPoint/processing_modules/PSFSubtraction.py
@@ -24,7 +24,7 @@ class PSFSubtractionModule(ProcessingModule):
         super(PSFSubtractionModule, self).__init__(name_in)
 
         # additional keywords
-        if "basis_tag" in kwargs:
+        if "basis_out_tag" in kwargs:
             basis_tag = kwargs["basis_out_tag"]
         else:
             basis_tag = "pca_basis_set"


### PR DESCRIPTION
Typo caused basis_out_tag keyword to be inaccessible in the PSF Subtraction module.