### PR TITLE
Module added to remove every NDIT+1 frame from NACO cube data

### DIFF
--- a/PynPoint/processing_modules/__init__.py
+++ b/PynPoint/processing_modules/__init__.py
@@ -2,7 +2,7 @@ from BackgroundSubtraction import SimpleBackgroundSubtractionModule
 from BadPixelCleaning import BadPixelCleaningSigmaFilterModule, BadPixelInterpolationModule, \
     BadPixelMapCreationModule
 from DarkAndFlatSubtraction import DarkSubtractionModule, FlatSubtractionModule
-from NACOPreparation import AngleCalculationModule, CutTopTwoLinesModule
+from NACOPreparation import AngleCalculationModule, CutTopTwoLinesModule, RemoveLastFrameModule
 from PSFSubtraction import PSFSubtractionModule
 from StackingAndSubsampling import StackAndSubsetModule
 from StarAlignment import StarAlignmentModule, StarExtractionModule


### PR DESCRIPTION
The RemoveLastFrameModule is added to NACOPreparation. Simply removes every NDIT+1 frames which contains the average pixel value of a NACO cube. 