### PR TITLE
Changed CutTopTwoLinesModule to CutTopLinesModule

### DIFF
--- a/PynPoint/processing_modules/NACOPreparation.py
+++ b/PynPoint/processing_modules/NACOPreparation.py
@@ -3,19 +3,41 @@ import numpy as np
 from PynPoint.core.Processing import ProcessingModule
 
 
-class CutTopTwoLinesModule(ProcessingModule):
+class CutTopLinesModule(ProcessingModule):
+    """
+    Module to equalize the number of pixels in horizontal and vertical direction by
+    removing several rows of pixels at the top of each frame.
+    """
 
     def __init__(self,
                  name_in="NACO_cutting",
                  image_in_tag="im_arr",
                  image_out_tag="im_arr_cut",
+                 num_lines=2,
                  num_images_in_memory=100):
+        """
+        Constructor of CutTopLinesModule. It requires an input and output tag of the dataset
 
-        super(CutTopTwoLinesModule, self).__init__(name_in)
+        :param name_in: Unique name of the module instance.
+        :type name_in: str
+        :param image_in_tag: Tag of the database entry that is read as input.
+        :type image_in_tag: str
+        :param image_out_tag: Tag of the database entry that is written as output. Should be
+                              different from *image_in_tag* unless *number_of_images_in_memory*
+                              is set to *None*
+        :type image_out_tag: str
+        :param num_lines: Number of top rows to delete from each frame.
+        :type num_lines: int
+        :param num_image_in_memory: Number of frames that are simultaneously loaded into the memory.
+        :type num_image_in_memory: int
+        :return: None
+        """
+
+        super(CutTopLinesModule, self).__init__(name_in)
 
         if image_in_tag == image_out_tag and num_images_in_memory is not None:
             raise ValueError("Input and output tags need to be different since the "
-                             "CutTopTwoLinesModule changes the size of the frames. The database can"
+                             "CutTopLinesModule changes the size of the frames. The database can"
                              " not update existing frames with smaller new frames. The only way to "
                              "use the same input and output tags is to update all frames at once"
                              "(i.e. loading all frames to the memory). Set number_of_images_in_"
@@ -26,19 +48,25 @@ class CutTopTwoLinesModule(ProcessingModule):
         self.m_image_out_port = self.add_output_port(image_out_tag)
 
         self.m_num_images_in_memory = num_images_in_memory
+        self.m_num_lines = num_lines
 
     def run(self):
+        """
+        Run method of the module. Removes the top *num_lines* lines from each frame.
 
-        def cut_top_two_lines(image_in):
-            return image_in[:-2, :]
+        :return: None
+        """
 
-        self.apply_function_to_images(cut_top_two_lines,
+        def cut_top_lines(image_in):
+            return image_in[:-int(self.m_num_lines), :]
+
+        self.apply_function_to_images(cut_top_lines,
                                       self.m_image_in_port,
                                       self.m_image_out_port,
                                       num_images_in_memory=self.m_num_images_in_memory)
 
         self.m_image_out_port.add_history_information("NACO_preparation",
-                                                      "cut top two lines")
+                                                      "cut top lines")
 
         self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
 

--- a/PynPoint/processing_modules/__init__.py
+++ b/PynPoint/processing_modules/__init__.py
@@ -2,7 +2,7 @@ from BackgroundSubtraction import SimpleBackgroundSubtractionModule
 from BadPixelCleaning import BadPixelCleaningSigmaFilterModule, BadPixelInterpolationModule, \
     BadPixelMapCreationModule
 from DarkAndFlatSubtraction import DarkSubtractionModule, FlatSubtractionModule
-from NACOPreparation import AngleCalculationModule, CutTopTwoLinesModule, RemoveLastFrameModule
+from NACOPreparation import AngleCalculationModule, CutTopLinesModule, RemoveLastFrameModule
 from PSFSubtraction import PSFSubtractionModule
 from StackingAndSubsampling import StackAndSubsetModule
 from StarAlignment import StarAlignmentModule, StarExtractionModule


### PR DESCRIPTION
For some NACO data sets the number of lines to be removed is not two. I changed the module such that an arbitrary amount of lines can be removed.