### PR TITLE
Removed the dummy argument para_sort

### DIFF
--- a/PynPoint/processing_modules/PSFSubtraction.py
+++ b/PynPoint/processing_modules/PSFSubtraction.py
@@ -80,7 +80,6 @@ class PSFSubtractionModule(ProcessingModule):
                                                         image_mask_out_tag="not_needed",
                                                         mask_out_tag=cent_mask_tag,
                                                         cent_remove=cent_remove,
-                                                        para_sort=False,
                                                         cent_size=cent_size,
                                                         edge_size=edge_size)
 
@@ -92,7 +91,6 @@ class PSFSubtractionModule(ProcessingModule):
                                                            image_mask_out_tag="not_needed",
                                                            mask_out_tag=cent_mask_tag,
                                                            cent_remove=cent_remove,
-                                                           para_sort=False,
                                                            cent_size=cent_size,
                                                            edge_size=edge_size)
 

--- a/PynPoint/processing_modules/PSFsubPreparation.py
+++ b/PynPoint/processing_modules/PSFsubPreparation.py
@@ -24,7 +24,6 @@ class PSFdataPreparation(ProcessingModule):
                  resize=False,
                  cent_remove=True,
                  F_final=2.0,
-                 para_sort=True,
                  cent_size=0.05,
                  edge_size=1.0):
 
@@ -34,7 +33,6 @@ class PSFdataPreparation(ProcessingModule):
         self.m_resize = resize
         self.m_cent_remove = cent_remove
         self.m_f_final = F_final
-        self.m_para_sort = para_sort
         self.m_cent_size = cent_size
         self.m_edge_size = edge_size
 
@@ -145,7 +143,6 @@ class PSFdataPreparation(ProcessingModule):
         # save attributes
         attributes = {"cent_remove": self.m_cent_remove,
                       "resize": self.m_resize,
-                      "para_sort": self.m_para_sort,
                       "F_final": float(self.m_f_final),
                       "cent_size": float(self.m_cent_size),
                       "edge_size": float(self.m_edge_size)}


### PR DESCRIPTION
The para_sort argument in the PSFdataPreparation does not seem to do anything. Since it is not used by PSFSubtractionModule it can safely be removed.

It was used in the old PynPoint to sort the frames by their parang. I assume to make sure that a substacking is done correctly when a random selection of frames is used, @spquanz?