### PR TITLE
Added pca_module to HessianMatrixModule

### DIFF
--- a/PynPoint/core/Processing.py
+++ b/PynPoint/core/Processing.py
@@ -215,9 +215,8 @@ class ProcessingModule(PypelineModule):
         """
 
         tmp_port = InputPort(tag)
-        if tag in self._m_input_ports and tag != "hessian_res_mean":
-            print tag
-            warnings.warn('Tag already used. Updating..')
+        if tag in self._m_input_ports and tag != "hessian_res_mean" and tag != "hessian_fake":
+            warnings.warn('Tag '+tag+' already used. Updating..')
 
         if self._m_data_base is not None:
             tmp_port.set_database_connection(self._m_data_base)

--- a/PynPoint/processing_modules/PSFSubtractionPCA.py
+++ b/PynPoint/processing_modules/PSFSubtractionPCA.py
@@ -77,6 +77,11 @@ class PSFSubtractionModule(ProcessingModule):
         else:
             prep_tag = "data_prep"
 
+        if "verbose" in kwargs:
+            self.m_verbose = kwargs["verbose"]
+        else:
+            self.m_verbose = True
+
         self.m_num_components = pca_number
 
         self._m_preparation_images = PSFdataPreparation(name_in="prep_im",
@@ -150,19 +155,24 @@ class PSFSubtractionModule(ProcessingModule):
 
     def run(self):
 
-        print "Preparing data..."
+        if self.m_verbose:
+            print "Preparing data..."
         self._m_preparation_images.run()
         self._m_preparation_reference.run()
-        print "Finished preparing data..."
-        print "Creating PCA-basis set..."
+        if self.m_verbose:
+            print "Finished preparing data..."
+            print "Creating PCA-basis set..."
         self._m_make_pca_basis.run()
-        print "Finished creating PCA-basis set..."
-        print "Calculating PSF-Model..."
+        if self.m_verbose:
+            print "Finished creating PCA-basis set..."
+            print "Calculating PSF-Model..."
         self._m_make_psf_model.run()
-        print "Finished calculating PSF-model..."
-        print "Creating residuals..."
+        if self.m_verbose:
+            print "Finished calculating PSF-model..."
+            print "Creating residuals..."
         self._m_residuals_module.run()
-        print "Finished creating residuals..."
+        if self.m_verbose:
+            print "Finished creating residuals..."
 
         # Take Header Information
         input_port = self._m_residuals_module.m_im_arr_in_port


### PR DESCRIPTION
- Added optional verbose argument to PSFSubtractionModule in order to not print output to the screen for each minimization step of the HessianMatrixModule.

- Added pca_module argument to HessianMatrixModule which can be either 'PSFSubtractionModule' or 'FastPCAModule' such that the flux and position results of the two PCA modules can be compared.