### PR TITLE
fft fix and test_Documentation updated

### DIFF
--- a/PynPoint/processing_modules/StarAlignment.py
+++ b/PynPoint/processing_modules/StarAlignment.py
@@ -234,12 +234,12 @@ class StarAlignmentModule(ProcessingModule):
             else:
                 tmp_image = image_in
 
-            if self.m_interpolation == "spline":
-                tmp_image = shift(tmp_image, offset, order=5)
-
-            elif self.m_interpolation == "fft":
+            if self.m_interpolation == "fft":
                 tmp_image_spec = fourier_shift(np.fft.fftn(tmp_image), offset)
-                tmp_image = np.fft.ifftn(tmp_image_spec)
+                tmp_image = np.fft.ifftn(tmp_image_spec).real
+
+            elif self.m_interpolation == "spline":
+                tmp_image = shift(tmp_image, offset, order=5)
 
             elif self.m_interpolation == "bilinear":
                 tmp_image = shift(tmp_image, offset, order=1)

--- a/test/test_processing/test_Documentation.py
+++ b/test/test_processing/test_Documentation.py
@@ -169,14 +169,14 @@ class TestDocumentation(object):
         assert data[0, 31, 20] == -3.9392607130869333e-05
 
         data = storage.m_data_bank["im_arr_aligned"]
-        assert data[0, 61, 39] == 0.00021600121168847015
+        assert data[0, 61, 39] == 0.00021600121168846993
 
         data = storage.m_data_bank["im_arr_stacked"]
-        assert data[0, 61, 39] == 8.2429659114370023e-05
+        assert data[0, 61, 39] == 8.2430113567504408e-05
 
         data = storage.m_data_bank["res_mean"]
-        assert data[61, 39] == -4.4710338563281608e-05
-        assert np.mean(data) == 5.196570975891392e-08
+        assert data[61, 39] == -4.3970096986442451e-05
+        assert np.mean(data) == 6.4361558939463885e-08
         assert data.shape == (72, 72)
 
         storage.close_connection()


### PR DESCRIPTION
- The fft interpolation in StarAlignmentModule gave an error because the .real was missing in the inverse fft so complex numbers were outputted.
- Updated test_Documentation because the default interpolation is now fft so some of the values had (very) minor differences compared to the spline interpolation.