### PR TITLE
Updates in PSF preparation and subtraction

### DIFF
--- a/PynPoint/processing_modules/PSFSubtractionPCA.py
+++ b/PynPoint/processing_modules/PSFSubtractionPCA.py
@@ -9,7 +9,6 @@ import numpy as np
 
 from sklearn.decomposition import PCA
 from scipy import linalg, ndimage, sparse
-from astropy.io import fits
 
 from PynPoint.core.Processing import ProcessingModule
 from PynPoint.util import PcaMultiprocessingCapsule
@@ -158,6 +157,7 @@ class PSFSubtractionModule(ProcessingModule):
                                                         image_out_tag=prep_tag,
                                                         image_mask_out_tag="not_needed",
                                                         mask_out_tag=cent_mask_tag,
+                                                        norm=True,
                                                         cent_remove=cent_remove,
                                                         cent_size=cent_size,
                                                         edge_size=edge_size)
@@ -169,6 +169,7 @@ class PSFSubtractionModule(ProcessingModule):
                                                            image_out_tag=ref_prep_tag,
                                                            image_mask_out_tag="not_needed",
                                                            mask_out_tag=cent_mask_tag,
+                                                           norm=True,
                                                            cent_remove=cent_remove,
                                                            cent_size=cent_size,
                                                            edge_size=edge_size)
@@ -560,7 +561,7 @@ class MakePCABasisModule(ProcessingModule):
 
         num_entries = im_data.shape[0]
         im_size = [im_data.shape[1], im_data.shape[2]]
-        
+
         if self.m_pca_number == None:
             self.m_pca_number = num_entries-1
 
@@ -818,7 +819,8 @@ class FastPCAModule(ProcessingModule):
         self.m_pca.fit(ref_star_sklearn)
 
         if self.m_basis_tag is not None:
-            basis = self.m_pca.components_.reshape((self.m_pca.components_.shape[0], star_data.shape[1], star_data.shape[2]))
+            basis = self.m_pca.components_.reshape((self.m_pca.components_.shape[0],
+                                                    star_data.shape[1], star_data.shape[2]))
             self.m_basis_out_port.set_all(basis)
 
         if self.m_verbose:

--- a/PynPoint/processing_modules/StarAlignment.py
+++ b/PynPoint/processing_modules/StarAlignment.py
@@ -477,9 +477,6 @@ class StarCenteringModule(ProcessingModule):
             self.m_x_grid = self.m_y_grid = np.linspace(-(npix-1)/2, (npix-1)/2, npix)
 
         if self.m_method == "mean":
-            sys.stdout.write("Running StarCenteringModule...")
-            sys.stdout.flush()
-
             im_mean = np.zeros((npix, npix))
 
             for i in range(nstacks):
@@ -493,9 +490,6 @@ class StarCenteringModule(ProcessingModule):
             im_mean /= float(nimages)
 
             self.m_popt = _least_squares(im_mean)
-
-            sys.stdout.write(" [DONE]\n")
-            sys.stdout.flush()
 
         self.apply_function_to_images(_centering,
                                       self.m_image_in_port,


### PR DESCRIPTION
- FastPCAModule is now the default in ContrastModule and SimplexMinimizationModule
- PSFdataPreparation is included for the FastPCAModule in ContrastModule and SimplexMinimizationModule so the mask can also be used.
- Additional argument _norm_ in PSFdataPreparation to turn the normalization on and off (default is on)
- Tested the ContrastModule and SimplexMinimizationModule to make sure that the results are indeed identical for FastPCAModule and PSFSubtractionModule which is indeed the case.
- Test cases OK.