### PR TITLE
Updates in CombineTagsModule

### DIFF
--- a/PynPoint/core/DataIO.py
+++ b/PynPoint/core/DataIO.py
@@ -994,11 +994,9 @@ class OutputPort(Port):
         if not self._check_status_and_activate():
             return
 
-        if not self._m_tag in self._m_data_storage.m_data_bank:
-            return
-
         # static attributes
-        self._m_data_storage.m_data_bank[self._m_tag].attrs.clear()
+        if self._m_tag in self._m_data_storage.m_data_bank:
+            self._m_data_storage.m_data_bank[self._m_tag].attrs.clear()
 
         # non-static attributes
         if "header_" + self._m_tag + "/" in self._m_data_storage.m_data_bank:

--- a/PynPoint/processing_modules/BackgroundSubtraction.py
+++ b/PynPoint/processing_modules/BackgroundSubtraction.py
@@ -877,6 +877,7 @@ class PCABackgroundDitheringModule(ProcessingModule):
             tags.append("pca_bg_sub"+str(i+1))
 
         combine = CombineTagsModule(name_in="combine",
+                                    check_attr=True,
                                     image_in_tags=tags,
                                     image_out_tag=self.m_image_out_tag)
 

--- a/PynPoint/processing_modules/StarAlignment.py
+++ b/PynPoint/processing_modules/StarAlignment.py
@@ -71,8 +71,8 @@ class StarExtractionModule(ProcessingModule):
         """
 
         memory = self._m_config_port.get_attribute("MEMORY")
-
         pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
+
         psf_radius = int((self.m_image_size / 2.0) / pixscale)
 
         self.m_fwhm_star /= pixscale


### PR DESCRIPTION
- Small update in del_all_attributes. The data tag and header_ tag are both checked on their presence in the database.
- Added _check_attr_ in CombineTagsModule (default is True). This boolean checks if the non-static attributes (excepts NFRAMES, STAR_POSITION and NEW_PARA) are the same in the tags that are combined. This will be the case if the tags descent from the same data (e.g. when used by the PCABackgroundDitheringModule) but it can be set to False if one wants to combine different data sets.