### PR TITLE
Added normalization for cross correlation in StarAlignmentModule

### DIFF
--- a/PynPoint/processing_modules/StarAlignment.py
+++ b/PynPoint/processing_modules/StarAlignment.py
@@ -211,11 +211,10 @@ class StarAlignmentModule(ProcessingModule):
 
             offset = np.array([0.0, 0.0])
             for i in range(self.m_num_references):
-                ref_norm = np.amax(np.abs(ref_images[i, ]))
-                im_norm = np.amax(np.abs(image_in[i, ]))
+                norm = max(np.amax(np.abs(ref_images[i, ])), np.amax(np.abs(image_in[i, ])))
 
-                tmp_offset, _, _ = register_translation(ref_images[i, ]/ref_norm,
-                                                        image_in/im_norm,
+                tmp_offset, _, _ = register_translation(ref_images[i, ]/norm,
+                                                        image_in/norm,
                                                         upsample_factor=self.m_accuracy)
                 offset += tmp_offset
 


### PR DESCRIPTION
Bug fix in the StarAlignmentModule for a newer (?) version of skimage. Images and reference images are normalized by the maximum value such that absolute pixel values are not larger than 1.0.

@majobodo can you test this with your version of skimage?

Test cases OK.