### PR TITLE
Using DITHER_X and DITHER_Y in PCABackgroundDitheringModule

### DIFF
--- a/PynPoint/IOmodules/FitsReading.py
+++ b/PynPoint/IOmodules/FitsReading.py
@@ -67,7 +67,9 @@ class FitsReadingModule(ReadingModule):
                                   'NDIT',
                                   'PARANG_START',
                                   'PARANG_END',
-                                  'NEW_PARA']
+                                  'NEW_PARA',
+                                  'DITHER_X',
+                                  'DITHER_Y' ]
 
     def _read_single_file(self,
                           fits_file,

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -58,6 +58,11 @@ class FakePlanetModule(ProcessingModule):
         :type psf_in_tag: str
         :param image_out_tag: Tag of the database entry with images that are written as output.
         :type image_out_tag: str
+        :param \**kwargs:
+            See below.
+
+        :Keyword arguments:
+             * **verbose** (*bool*) -- Print progress.
 
         :return: None
         """

--- a/PynPoint/ProcessingModules/ImageResizing.py
+++ b/PynPoint/ProcessingModules/ImageResizing.py
@@ -260,6 +260,9 @@ class RemoveLinesModule(ProcessingModule):
         """
         Constructor of RemoveLinesModule.
 
+        :param lines: Tuple with the number of lines to be removed in left, right, bottom,
+                      and top direction.
+        :type lines: tuple, int
         :param name_in: Unique name of the module instance.
         :type name_in: str
         :param image_in_tag: Tag of the database entry that is read as input.
@@ -267,8 +270,6 @@ class RemoveLinesModule(ProcessingModule):
         :param image_out_tag: Tag of the database entry that is written as output. Should be
                               different from *image_in_tag*.
         :type image_out_tag: str
-        :param num_lines: Number of top rows to delete from each frame.
-        :type num_lines: int
 
         :return: None
         """

--- a/PynPoint/ProcessingModules/PSFSubtractionPCA.py
+++ b/PynPoint/ProcessingModules/PSFSubtractionPCA.py
@@ -719,7 +719,7 @@ class FastPCAModule(ProcessingModule):
         self.m_res_median_out_port.set_all(tmp_output, keep_attributes=False)
         self.m_res_rot_mean_clip_out_port.set_all(tmp_output, keep_attributes=False)
 
-        cpu_count = self._m_config_port.get_attribute("CPU_COUNT")
+        cpu_count = self._m_config_port.get_attribute("CPU")
 
         rotations = -1.*self.m_star_in_port.get_attribute("NEW_PARA")
         rotations += np.ones(rotations.shape[0]) * self.m_extra_rot

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -60,6 +60,8 @@ class PSFpreparationModule(ProcessingModule):
         :param edge_size: Fractional outer radius relative to the image size. The images are
                           masked beyond this radius. Currently this parameter is not used.
         :type edge_size: float
+        :param \**kwargs:
+            See below.
 
         :Keyword arguments:
              * **verbose** (*bool*) -- Print progress to the standard output.

--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -372,6 +372,13 @@ class StarCenteringModule(ProcessingModule):
         :param interpolation: Type of interpolation that is used for shifting the images (fft,
                               spline, or bilinear).
         :type interpolation: str
+        :param \**kwargs:
+            See below.
+
+        :Keyword arguments:
+             * **guess** (*tuple*) -- Tuple with the initial parameter values for the least
+                                      squares fit: center x (pix), center y (pix), FWHM x (pix),
+                                      FWHM y (pix), amplitude (counts), angle (deg).
 
         :return: None
         """

--- a/PynPoint/core/Processing.py
+++ b/PynPoint/core/Processing.py
@@ -315,7 +315,7 @@ class ProcessingModule(PypelineModule):
                                data_dim=3,
                                keep_attributes=False)  # overwrite old existing attributes
 
-        num_processors = self._m_config_port.get_attribute("CPU_COUNT")
+        num_processors = self._m_config_port.get_attribute("CPU")
 
         print "Database prepared. Starting analysis with " + str(num_processors) + " processes."
 

--- a/PynPoint/core/Pypeline.py
+++ b/PynPoint/core/Pypeline.py
@@ -134,9 +134,11 @@ class Pypeline(object):
                        'NDIT': 'ESO DET NDIT',
                        'PARANG_START': 'ESO ADA POSANG',
                        'PARANG_END': 'ESO ADA POSANG END',
+                       'DITHER_X': 'ESO SEQ CUMOFFSETX',
+                       'DITHER_Y': 'ESO SEQ CUMOFFSETY',
                        'PIXSCALE': 0.027,
                        'MEMORY': 1000,
-                       'CPU_COUNT': max_cpu_count}
+                       'CPU': max_cpu_count}
 
         config_file = self._m_working_place+"/PynPoint_config.ini"
 
@@ -162,6 +164,12 @@ class Pypeline(object):
             if config.has_option('header', 'PARANG_END'):
                 config_dict['PARANG_END'] = str(config.get('header', 'PARANG_END'))
 
+            if config.has_option('header', 'DITHER_X'):
+                config_dict['DITHER_X'] = str(config.get('header', 'DITHER_X'))
+
+            if config.has_option('header', 'DITHER_Y'):
+                config_dict['DITHER_Y'] = str(config.get('header', 'DITHER_Y'))
+
             if config.has_option('settings', 'PIXSCALE'):
                 config_dict['PIXSCALE'] = float(config.get('settings', 'PIXSCALE'))
 
@@ -171,8 +179,8 @@ class Pypeline(object):
                 else:
                     config_dict['MEMORY'] = int(config.get('settings', 'MEMORY'))
 
-            if config.has_option('settings', 'CPU_COUNT'):
-                config_dict['CPU_COUNT'] = int(config.get('settings', 'CPU_COUNT'))
+            if config.has_option('settings', 'CPU'):
+                config_dict['CPU'] = int(config.get('settings', 'CPU'))
 
         else:
             warnings.warn("Configuration file not found so creating PynPoint_config.ini with "
@@ -185,11 +193,13 @@ class Pypeline(object):
             file_obj.write('EXP_NO: ESO DET EXP NO\n')
             file_obj.write('NDIT: ESO DET NDIT\n')
             file_obj.write('PARANG_START: ESO ADA POSANG\n')
-            file_obj.write('PARANG_END: ESO ADA POSANG END\n\n')
+            file_obj.write('PARANG_END: ESO ADA POSANG END\n')
+            file_obj.write('DITHER_X: ESO SEQ CUMOFFSETX\n')
+            file_obj.write('DITHER_Y: ESO SEQ CUMOFFSETY\n\n')
             file_obj.write('[settings]\n\n')
             file_obj.write('PIXSCALE: 0.027\n')
             file_obj.write('MEMORY: 1000\n')
-            file_obj.write('CPU_COUNT: 1')
+            file_obj.write('CPU: '+str(max_cpu_count))
             file_obj.close()
 
         hdf = h5py.File(self._m_working_place+'/PynPoint_database.hdf5', 'a')
@@ -229,7 +239,8 @@ class Pypeline(object):
         pipeline_module.connect_database(self.m_data_storage)
 
         if pipeline_module.name in self._m_modules:
-            warnings.warn('Processing module names need to be unique. Overwriting the old Module')
+            warnings.warn("Processing module names need to be unique. Overwriting module '%s'."
+                          % pipeline_module.name)
 
         self._m_modules[pipeline_module.name] = pipeline_module
 


### PR DESCRIPTION
- Added DITHER_X and DITHER_Y keywords in the central config which are the dither positions in pixels with respect to the detector center. Default are the NACO keywords ESO SEQ CUMOFFSETX and ESO SEQ CUMOFFSETY.
- DITHER_X and DITHER_Y can be used by PCABackgroundDitheringModule if center=None and cubes_per_position=None. In that case, the dither positions are automatically selected and sorted in star and background frames. So an irregular or interrupted dithering pattern will cause no problem. When mean_only=True, only the mean background subtraction is done.
- Changed frame_indices argument in RemoveFramesModule to frames.
- Change CPU_COUNT config parameter to CPU.
- Small updates in the docs.