### PR TITLE
Test cases fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ clean-test:
 	rm -rf PynPoint_exoplanet.egg-info/
 	rm -f junit-docs-ci.xml
 	rm -f junit-py27.xml
+	rm -rf .pytest_cache/
 
 test:
 	py.test

--- a/PynPoint/IOmodules/Hdf5Writing.py
+++ b/PynPoint/IOmodules/Hdf5Writing.py
@@ -22,7 +22,8 @@ class Hdf5WritingModule(WritingModule):
                  name_in="hdf5_writing",
                  output_dir=None,
                  tag_dictionary=None,
-                 keep_attributes=True):
+                 keep_attributes=True,
+                 overwrite=False):
         """
         Constructor of Hdf5WritingModule.
 
@@ -41,6 +42,8 @@ class Hdf5WritingModule(WritingModule):
         :type tag_dictionary: dict
         :param keep_attributes: If True all static and non-static attributes will be exported.
         :type keep_attributes: bool
+        :param overwrite: Overwrite an existing HDF5 file.
+        :type overwrite: bool
 
         :return: None
         """
@@ -53,6 +56,7 @@ class Hdf5WritingModule(WritingModule):
         self.m_file_name = file_name
         self.m_tag_dictionary = tag_dictionary
         self.m_keep_attributes = keep_attributes
+        self.m_overwrite = overwrite
 
     def run(self):
         """
@@ -65,7 +69,10 @@ class Hdf5WritingModule(WritingModule):
         sys.stdout.write("Running Hdf5WritingModule...")
         sys.stdout.flush()
 
-        out_file = h5py.File(os.path.join(self.m_output_location, self.m_file_name), mode='w')
+        if self.m_overwrite:
+            out_file = h5py.File(os.path.join(self.m_output_location, self.m_file_name), mode='w')
+        else:
+            out_file = h5py.File(os.path.join(self.m_output_location, self.m_file_name), mode='a')
 
         for in_tag, out_tag in self.m_tag_dictionary.iteritems():
 

--- a/test/test_PSF_subtraction/test_Residuals.py
+++ b/test/test_PSF_subtraction/test_Residuals.py
@@ -61,6 +61,6 @@ class TestResidual(object):
     def test_residuals_save_restore(self):
         temp_file = os.path.join(self.test_data_dir, 'tmp_res_hdf5.h5')
         self.res.save(temp_file)
-        temp_res = PynPoint.residuals.create_restore(temp_file) 
+        temp_res = PynPoint.residuals.create_restore(temp_file)
         assert np.array_equal(self.res.res_rot_mean(1), temp_res.res_rot_mean(1))
         os.remove(temp_file)

--- a/test/test_processing/test_Documentation.py
+++ b/test/test_processing/test_Documentation.py
@@ -329,14 +329,14 @@ class TestDocumentation(object):
         assert data[0, 10, 10] == 0.053192109122463471
 
         data = storage.m_data_bank["im_arr_aligned"]
-        assert data[0, 10, 10] == 1.1461552763624375e-05
+        assert data[0, 10, 10] == 1.1461552763624318e-05
 
         data = storage.m_data_bank["im_arr_stacked"]
-        assert data[0, 10, 10] == 2.5664613034485687e-05
+        assert data[0, 10, 10] == 2.566579724822762e-05
 
         data = storage.m_data_bank["res_mean"]
-        assert data[38, 22] == 0.00014649717419019682
-        assert np.mean(data) == -2.2033043765704249e-07
+        assert data[38, 22] == 0.00014540689748814158
+        assert np.mean(data) == -2.0205490383929854e-07
         assert data.shape == (44, 44)
 
         storage.close_connection()


### PR DESCRIPTION
- Changed back the default mode in Hdf5WritingModule to 'append' because one of the test cases was not working because of that. Added the _overwrite_ argument in Hdf5WritingModule such that a file can be overwritten.
- Updated a test case which includes an interpolation. Negligible change in one of the test case value because of spline instead of fft.