### PR TITLE
Test cases for BadPixelCleaning, bug fix in BadPixelMapModule

### DIFF
--- a/PynPoint/ProcessingModules/BadPixelCleaning.py
+++ b/PynPoint/ProcessingModules/BadPixelCleaning.py
@@ -333,7 +333,7 @@ class BadPixelMapModule(ProcessingModule):
 
         bpmap = np.ones(dark.shape)
         bpmap[np.where(dark > max_dark * self.m_dark_threshold)] = 0
-        bpmap[np.where(flat < max_flat * self.m_flat_threshold)] = 0
+        bpmap[np.where(flat > max_flat * self.m_flat_threshold)] = 0
 
         self.m_bp_map_out_port.set_all(bpmap)
         self.m_bp_map_out_port.close_database()
@@ -457,7 +457,7 @@ class BadPixelRefinementModule(ProcessingModule):
         self.m_image_out_port = self.add_output_port(image_out_tag)
 
         self.m_iterations = iterations
-        self.m_current_pos = 0  # TODO fix this for multithreading
+        self.m_current_pos = 0
         self.m_box_size = box_size
         self.m_sigma = sigma
 
@@ -486,8 +486,6 @@ class BadPixelRefinementModule(ProcessingModule):
 
         def _bad_pixel_refinement(image_in):
             current_pos = positions[self.m_current_pos]
-
-            # TODO why is the +1 needed?
             self.m_current_pos += 1
 
             start_x = int(current_pos[0] - bp_shape[0]/2)

--- a/tests/test_processing/test_BadPixelCleaning.py
+++ b/tests/test_processing/test_BadPixelCleaning.py
@@ -1,0 +1,179 @@
+import os
+import math
+import h5py
+import warnings
+
+import numpy as np
+
+from astropy.io import fits
+
+from PynPoint import Pypeline
+from PynPoint.Core.DataIO import DataStorage
+from PynPoint.IOmodules.FitsReading import FitsReadingModule
+from PynPoint.ProcessingModules.BadPixelCleaning import BadPixelSigmaFilterModule, BadPixelMapModule, \
+                                                        BadPixelInterpolationModule, BadPixelRefinementModule
+
+warnings.simplefilter("always")
+
+def setup_module():
+    file_in = os.path.dirname(__file__) + "/PynPoint_database.hdf5"
+    config_file = os.path.dirname(__file__) + "/PynPoint_config.ini"
+
+    np.random.seed(1)
+    images = np.random.normal(loc=0, scale=2e-4, size=(40, 100, 100))
+    dark = np.random.normal(loc=0, scale=2e-4, size=(40, 100, 100))
+    flat = np.random.normal(loc=0, scale=2e-4, size=(40, 100, 100))
+
+    images[0, 10, 10] = 1.
+    images[0, 12, 12] = 1.
+    images[0, 14, 14] = 1.
+    images[0, 20, 20] = 1.
+    images[0, 22, 22] = 1.
+    images[0, 24, 24] = 1.
+    dark[:, 10, 10] = 1.
+    dark[:, 12, 12] = 1.
+    dark[:, 14, 14] = 1.
+    flat[:, 20, 20] = 1.
+    flat[:, 22, 22] = 1.
+    flat[:, 24, 24] = 1.
+
+    h5f = h5py.File(file_in, "w")
+    h5f.create_dataset("images", data=images)
+    h5f.create_dataset("dark", data=dark)
+    h5f.create_dataset("flat", data=flat)
+    h5f.create_dataset("header_images/STAR_POSITION", data=np.full((40, 2), 50.))
+    h5f.close()
+
+    f = open(config_file, 'w')
+    f.write('[header]\n\n')
+    f.write('INSTRUMENT: INSTRUME\n')
+    f.write('NFRAMES: NAXIS3\n')
+    f.write('EXP_NO: ESO DET EXP NO\n')
+    f.write('NDIT: ESO DET NDIT\n')
+    f.write('PARANG_START: ESO ADA POSANG\n')
+    f.write('PARANG_END: ESO ADA POSANG END\n')
+    f.write('DITHER_X: ESO SEQ CUMOFFSETX\n')
+    f.write('DITHER_Y: ESO SEQ CUMOFFSETY\n\n')
+    f.write('[settings]\n\n')
+    f.write('PIXSCALE: 0.01\n')
+    f.write('MEMORY: 100\n')
+    f.write('CPU: 1')
+    f.close()
+
+def teardown_module():
+    file_in = os.path.dirname(__file__) + "/PynPoint_database.hdf5"
+    config_file = os.path.dirname(__file__) + "/PynPoint_config.ini"
+
+    os.remove(file_in)
+    os.remove(config_file)
+
+class TestBadPixelCleaning(object):
+
+    def setup(self):
+        self.test_dir = os.path.dirname(__file__) + "/"
+        self.pipeline = Pypeline(self.test_dir, self.test_dir, self.test_dir)
+
+    def test_bad_pixel_sigma_filter(self):
+
+        sigma = BadPixelSigmaFilterModule(name_in="sigma",
+                                          image_in_tag="images",
+                                          image_out_tag="sigma",
+                                          box=9,
+                                          sigma=5,
+                                          iterate=1)
+
+        self.pipeline.add_module(sigma)
+
+        self.pipeline.run()
+
+        storage = DataStorage(self.test_dir+"/PynPoint_database.hdf5")
+        storage.open_connection()
+
+        data = storage.m_data_bank["sigma"]
+
+        assert data[0, 0, 0] == 0.00032486907273264834
+        assert data[0, 10, 10] == 0.025022559679385093
+        assert data[0, 20, 20] == 0.024962143884217046
+        assert np.mean(data) == 6.721637736047109e-07
+
+        storage.close_connection()
+
+    def test_bad_pixel_map(self):
+
+        bp_map = BadPixelMapModule(name_in="bp_map",
+                                   dark_in_tag="dark",
+                                   flat_in_tag="flat",
+                                   bp_map_out_tag="bp_map",
+                                   dark_threshold=0.99,
+                                   flat_threshold=0.99)
+
+        self.pipeline.add_module(bp_map)
+
+        self.pipeline.run()
+
+        storage = DataStorage(self.test_dir+"/PynPoint_database.hdf5")
+        storage.open_connection()
+
+        data = storage.m_data_bank["bp_map"]
+
+        assert data[0, 0] == 1.
+        assert data[30, 30] == 1.
+        assert data[10, 10] == 0.
+        assert data[12, 12] == 0.
+        assert data[14, 14] == 0.
+        assert data[20, 20] == 0.
+        assert data[22, 22] == 0.
+        assert data[24, 24] == 0.
+        assert np.mean(data) == 0.9994
+
+        storage.close_connection()
+
+    def test_bad_pixel_interpolation(self):
+
+        interpolation = BadPixelInterpolationModule(name_in="interpolation",
+                                                    image_in_tag="images",
+                                                    bad_pixel_map_tag="bp_map",
+                                                    image_out_tag="interpolation",
+                                                    iterations=100)
+
+        self.pipeline.add_module(interpolation)
+
+        self.pipeline.run()
+
+        storage = DataStorage(self.test_dir+"/PynPoint_database.hdf5")
+        storage.open_connection()
+
+        data = storage.m_data_bank["interpolation"]
+
+        assert data[0, 0, 0] == 0.00032486907273264834
+        assert data[0, 10, 10] == -2.0996572238644483e-06
+        assert data[0, 20, 20] == -5.634391873243546e-05
+        assert np.mean(data) == 3.0065791509420055e-07
+
+        storage.close_connection()
+
+    def test_bad_pixel_refinement(self):
+
+        refinement = BadPixelRefinementModule(name_in="refinement",
+                                              image_in_tag="images",
+                                              bad_pixel_map_tag="bp_map",
+                                              image_out_tag="refinement",
+                                              box_size=5,
+                                              sigma=4.,
+                                              iterations=100)
+
+        self.pipeline.add_module(refinement)
+
+        self.pipeline.run()
+
+        storage = DataStorage(self.test_dir+"/PynPoint_database.hdf5")
+        storage.open_connection()
+
+        data = storage.m_data_bank["refinement"]
+
+        assert data[0, 0, 0] == 0.00032486907273264834
+        assert data[0, 10, 10] == 8.690175950157586e-06
+        assert data[0, 20, 20] == -8.72447640628821e-05
+        assert np.mean(data) == 2.9593312144792264e-07
+
+        storage.close_connection()


### PR DESCRIPTION
- Added basic test cases for all modules in BadPixelCleaning
- Bug fix in BadPixelMap which was flagging pixel values **smaller** than a given threshold for the flat frames. I assume this should be pixel values **larger** than the threshold (similar to the dark threshold).