### PR TITLE
Change in reference for StarAlignmentModule

### DIFF
--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -253,17 +253,20 @@ class StarAlignmentModule(ProcessingModule):
             im_dim = np.size(self.m_ref_image_in_port.get_shape())
 
             if im_dim == 3:
-                if self.m_ref_image_in_port.get_shape()[0]>self.m_num_references:
+                if self.m_ref_image_in_port.get_shape()[0] > self.m_num_references:
                     ref_images = self.m_ref_image_in_port[np.sort(
                         np.random.choice(self.m_ref_image_in_port.get_shape()[0],
                                          self.m_num_references,
                                          replace=False)), :, :]
+
                 else:
                     ref_images = np.array([self.m_ref_image_in_port.get_all(),])
                     self.m_num_references = self.m_ref_image_in_port.get_shape()[0]
+
             elif im_dim == 2:
                 ref_images = np.array([self.m_ref_image_in_port.get_all(),])
                 self.m_num_references = 1
+
             else:
                 raise ValueError("reference Image needs to be 2 D or 3 D.")
 

--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -253,8 +253,14 @@ class StarAlignmentModule(ProcessingModule):
             im_dim = np.size(self.m_ref_image_in_port.get_shape())
 
             if im_dim == 3:
-                ref_images = np.asarray(self.m_ref_image_in_port.get_all())
-                self.m_num_references = self.m_ref_image_in_port.get_shape()[0]
+                if self.m_ref_image_in_port.get_shape()[0]>self.m_num_references:
+                    ref_images = self.m_ref_image_in_port[np.sort(
+                        np.random.choice(self.m_ref_image_in_port.get_shape()[0],
+                                         self.m_num_references,
+                                         replace=False)), :, :]
+                else:
+                    ref_images = np.array([self.m_ref_image_in_port.get_all(),])
+                    self.m_num_references = self.m_ref_image_in_port.get_shape()[0]
             elif im_dim == 2:
                 ref_images = np.array([self.m_ref_image_in_port.get_all(),])
                 self.m_num_references = 1


### PR DESCRIPTION
If reference tag is different from the image tag, it uses only a subsample of this stack to align the images and not all of them. Previously (for AGPM data) if one used SCIENCE frames to align SKY frames, the module was using all the 20k already aligned images... 