### PR TITLE
Added SDIPreparationModule

### DIFF
--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -12,6 +12,7 @@ from scipy import ndimage
 
 from PynPoint.Util.Progress import progress
 from PynPoint.Core.Processing import ProcessingModule
+from PynPoint.ProcessingModules.ImageResizing import ScaleImagesModule, CropImagesModule
 
 
 class PSFpreparationModule(ProcessingModule):
@@ -304,3 +305,95 @@ class AngleCalculationModule(ProcessingModule):
         self.m_data_out_port.add_attribute("PARANG",
                                            new_angles,
                                            static=False)
+
+
+
+
+class SDIPreparationModule(ProcessingModule):
+    """
+        Module for preparing continuum for subtraction.
+        """
+
+    def __init__(self,
+                 line_wvl,
+                 cnt_wvl,
+                 line_width,
+                 cnt_width,
+                 name_in="SDI_preparation",
+                 image_in_tag="im_arr_cnt",
+                 image_out_tag="im_arr_cnt2"):
+        """
+            Constructor of RemoveFramesModule.
+
+            :param line_wvl: central wavelength of the line filter.
+            :type line_wvl: float
+            :param cnt_wvl: central wavelength of the continuum filter.
+            :type cnt_wvl: float
+            :param line_width: equivalent width of the line filter.
+            :type line_width: float
+            :param cnt_width: equivalent width of the continuum filter.
+            :type cnt_width: float
+            :param name_in: Unique name of the module instance.
+            :type name_in: str
+            :param image_in_tag: Tag of the database entry that is read as input.
+            :type image_in_tag: str
+            :param image_out_tag: Tag of the database entry that is written as output. Should be
+            different from *image_in_tag*.
+            :type image_out_tag: str
+
+            :return: None
+            """
+
+        super(SDIPreparationModule, self).__init__(name_in)
+
+        self.m_image_in_port = self.add_input_port(image_in_tag)
+
+        self.m_image_out_port = self.add_output_port(image_out_tag)
+
+        self.m_line_wvl = line_wvl
+        self.m_cnt_wvl = cnt_wvl
+        self.m_line_width = line_width
+        self.m_cnt_width = cnt_width
+        self.m_image_in_tag = image_in_tag
+        self.m_image_out_tag = image_out_tag
+
+    def run(self):
+        """
+            Run method of the module. Normalizes for different filter widths, upscales the
+            images to align PSF patterns and crops them to be of the same dimension as before.
+
+            :return: None
+            """
+
+        self.m_image_out_port.del_all_data()
+        self.m_image_out_port.del_all_attributes()
+
+        pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
+
+        width_factor = self.m_line_width/self.m_cnt_width
+        wvl_factor = self.m_line_wvl/self.m_cnt_wvl
+        im_size = self.m_image_in_port.get_shape()[1]
+
+        sys.stdout.write("Starting SDI preparation... \n")
+
+        scaling = ScaleImagesModule(scaling_dim=wvl_factor,
+                                    scaling_flux=width_factor,
+                                    name_in="scaling",
+                                    image_in_tag=self.m_image_in_tag,
+                                    image_out_tag="im_arr_scaled")
+
+        scaling.connect_database(self._m_data_base)
+        scaling.run()
+
+
+        crop = CropImagesModule(im_size*pixscale,
+                                center=None,
+                                name_in="crop",
+                                image_in_tag="im_arr_scaled",
+                                image_out_tag=self.m_image_out_tag)
+
+        crop.connect_database(self._m_data_base)
+        crop.run()
+        sys.stdout.write("SDI preparation finished... \n")
+
+        self.m_image_in_port.close_database()

--- a/PynPoint/ProcessingModules/SDI.py
+++ b/PynPoint/ProcessingModules/SDI.py
@@ -1,0 +1,115 @@
+"""
+Modules with tools for preparation to SDI analysis.
+"""
+
+import numpy as np
+
+from PynPoint.Core.Processing import ProcessingModule
+
+
+class SDIPreparationModule(ProcessingModule):
+    """
+    Module for preparing continuum for subtraction.
+    """
+
+    def __init__(self,
+                 line_wvl,
+                 cnt_wvl,
+                 line_width,
+                 cnt_width,
+                 name_in="remove_frames",
+                 image_in_tag="im_arr_cnt",
+                 image_out_tag="im_arr_cnt2"):
+        """
+        Constructor of RemoveFramesModule.
+
+        :param line_wvl: central wavelength of the line filter.
+        :type line_wvl: float
+        :param cnt_wvl: central wavelength of the continuum filter.
+        :type cnt_wvl: float
+        :param line_width: equivalent width of the line filter.
+        :type line_width: float
+        :param cnt_width: equivalent width of the continuum filter.
+        :type cnt_width: float
+        :param name_in: Unique name of the module instance.
+        :type name_in: str
+        :param image_in_tag: Tag of the database entry that is read as input.
+        :type image_in_tag: str
+        :param image_out_tag: Tag of the database entry that is written as output. Should be
+                              different from *image_in_tag*.
+        :type image_out_tag: str
+
+        :return: None
+        """
+
+        super(SDIPreparationModule, self).__init__(name_in)
+
+        self.m_cnt_in_port = self.add_input_port(image_cnt_in_tag)
+        
+        self.m_stack_out_port = self.add_output_port(image_out_tag)
+
+        self.m_line_wvl = line_wvl
+        self.m_cnt_wvl = cnt_wvl
+        self.m_line_width = line_width
+        self.m_cnt_width = cnt_width
+
+    def run(self):
+        """
+        Run method of the module. Normalizes for different filter widths, upscales the images to align PSF patterns and crops them to be of the same dimension as before.
+
+        :return: None
+        """
+
+        self.m_image_out_port.del_all_data()
+        self.m_image_out_port.del_all_attributes()
+        
+        memory = self._m_config_port.get_attribute("MEMORY")
+        cnt_size = self.m_cnt_in_port.get_shape()[1]
+        
+        def image_cutting(image_in, size):
+            
+            x_off = (image_in.shape[0] - size) / 2
+            y_off = (image_in.shape[1] - size) / 2
+                
+            if size > image_in.shape[0] or size > image_in.shape[1]:
+                raise ValueError("Input frame resolution smaller than target image resolution.")
+                
+            image_out = image_in[y_off:y_off+size, x_off:x_off+size]
+            return image_out
+
+        def prepare_cnt_images(image):
+            
+            width_factor = self.m_line_width/slef.m_cnt_width
+            image *= width_factor
+        
+            wvl_factor = self.m_line_wvl/self.m_cnt_wvl
+            sum_before = np.sum(tmp_cnt_im, axis=(1,2))
+            tmp_cnt_im_rescaled = rescale(image=np.asarray(tmp_cnt_im, dtype=np.float64),
+                                          scale = wvl_factor,
+                                          order=5,
+                                          mode="reflect")
+            sum_after = np.sum(tmp_cnt_im_rescaled, axis=(1,2))
+            tmp_cnt_im_rescaled *= (sum_before/sum_after)
+        
+            cnt_out=image_cutting(tmp_cnt_im_rescaled, cnt_size)
+        
+        return cnt_out
+        
+        
+        self.apply_function_to_images(prepare_cnt_images,
+                                      self.m_cnt_in_port,
+                                      self.m_image_out_port,
+                                      "Running SDI Preparation...",
+                                      num_images_in_memory=memory)
+        
+        self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
+            
+        self.m_image_out_port.add_history_information("SDI", "continuum subtraction")
+            
+        self.m_image_in_port.close_database()
+            
+            
+            
+            
+
+

--- a/PynPoint/ProcessingModules/SDI.py
+++ b/PynPoint/ProcessingModules/SDI.py
@@ -3,8 +3,10 @@ Modules with tools for preparation to SDI analysis.
 """
 
 import numpy as np
+import sys
 
 from PynPoint.Core.Processing import ProcessingModule
+from PynPoint.ProcessingModules import CropImagesModule, ScaleImagesModule
 
 
 class SDIPreparationModule(ProcessingModule):
@@ -17,7 +19,7 @@ class SDIPreparationModule(ProcessingModule):
                  cnt_wvl,
                  line_width,
                  cnt_width,
-                 name_in="remove_frames",
+                 name_in="SDI_preparation",
                  image_in_tag="im_arr_cnt",
                  image_out_tag="im_arr_cnt2"):
         """
@@ -44,14 +46,16 @@ class SDIPreparationModule(ProcessingModule):
 
         super(SDIPreparationModule, self).__init__(name_in)
 
-        self.m_cnt_in_port = self.add_input_port(image_cnt_in_tag)
+        self.m_image_in_port = self.add_input_port(image_in_tag)
         
-        self.m_stack_out_port = self.add_output_port(image_out_tag)
+        self.m_image_out_port = self.add_output_port(image_out_tag)
 
         self.m_line_wvl = line_wvl
         self.m_cnt_wvl = cnt_wvl
         self.m_line_width = line_width
         self.m_cnt_width = cnt_width
+        self.m_image_in_tag = image_in_tag
+        self.m_cnt_out_tag = image_out_tag
 
     def run(self):
         """
@@ -59,52 +63,37 @@ class SDIPreparationModule(ProcessingModule):
 
         :return: None
         """
-
+        
         self.m_image_out_port.del_all_data()
         self.m_image_out_port.del_all_attributes()
         
-        memory = self._m_config_port.get_attribute("MEMORY")
-        cnt_size = self.m_cnt_in_port.get_shape()[1]
+        pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
         
-        def image_cutting(image_in, size):
-            
-            x_off = (image_in.shape[0] - size) / 2
-            y_off = (image_in.shape[1] - size) / 2
-                
-            if size > image_in.shape[0] or size > image_in.shape[1]:
-                raise ValueError("Input frame resolution smaller than target image resolution.")
-                
-            image_out = image_in[y_off:y_off+size, x_off:x_off+size]
-            return image_out
-
-        def prepare_cnt_images(image):
-            
-            width_factor = self.m_line_width/slef.m_cnt_width
-            image *= width_factor
+        width_factor = self.m_line_width/self.m_cnt_width
+        wvl_factor = self.m_line_wvl/self.m_cnt_wvl
+        im_size = self.m_image_in_port.get_shape()[1]
         
-            wvl_factor = self.m_line_wvl/self.m_cnt_wvl
-            sum_before = np.sum(tmp_cnt_im, axis=(1,2))
-            tmp_cnt_im_rescaled = rescale(image=np.asarray(tmp_cnt_im, dtype=np.float64),
-                                          scale = wvl_factor,
-                                          order=5,
-                                          mode="reflect")
-            sum_after = np.sum(tmp_cnt_im_rescaled, axis=(1,2))
-            tmp_cnt_im_rescaled *= (sum_before/sum_after)
+        sys.stdout.write("Starting SDI preparation... \n")
         
-            cnt_out=image_cutting(tmp_cnt_im_rescaled, cnt_size)
-        
-        return cnt_out
+        scaling = ScaleImagesModule(scaling_dim = wvl_factor,
+                                      scaling_flux = width_factor,
+                                      name_in="scaling",
+                                      image_in_tag=self.m_image_in_tag,
+                                      image_out_tag="im_arr_scaled")
+                                      
+        scaling.connect_database(self._m_data_base)
+        scaling.run()
         
         
-        self.apply_function_to_images(prepare_cnt_images,
-                                      self.m_cnt_in_port,
-                                      self.m_image_out_port,
-                                      "Running SDI Preparation...",
-                                      num_images_in_memory=memory)
+        crop = CropImagesModule(im_size*pixscale,
+                                center=None,
+                                name_in="crop",
+                                image_in_tag="im_arr_scaled",
+                                image_out_tag=self.m_cnt_out_tag)
         
-        self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
-            
-        self.m_image_out_port.add_history_information("SDI", "continuum subtraction")
+        crop.connect_database(self._m_data_base)
+        crop.run()
+        sys.stdout.write("SDI preparation finished... \n")
             
         self.m_image_in_port.close_database()
             

--- a/PynPoint/ProcessingModules/__init__.py
+++ b/PynPoint/ProcessingModules/__init__.py
@@ -16,3 +16,4 @@ from TimeDenoising import CwtWaveletConfiguration, DwtWaveletConfiguration, \
 from FrameSelection import RemoveFramesModule, FrameSelectionModule, RemoveLastFrameModule, RemoveStartFramesModule
 from FluxAndPosition import FakePlanetModule, SimplexMinimizationModule, FalsePositiveModule, MCMCsamplingModule
 from DetectionLimits import ContrastModule
+from SDI import SDIPreparationModule

--- a/PynPoint/ProcessingModules/__init__.py
+++ b/PynPoint/ProcessingModules/__init__.py
@@ -10,10 +10,9 @@ from StarAlignment import StarAlignmentModule, StarExtractionModule, StarCenteri
                           ShiftForCenteringModule
 from ImageResizing import CropImagesModule, ScaleImagesModule, AddLinesModule, RemoveLinesModule, \
                           CombineTagsModule
-from PSFpreparation import PSFpreparationModule, AngleCalculationModule
+from PSFpreparation import PSFpreparationModule, AngleCalculationModule, SDIPreparationModule
 from TimeDenoising import CwtWaveletConfiguration, DwtWaveletConfiguration, \
                           WaveletTimeDenoisingModule, TimeNormalizationModule
-from FrameSelection import RemoveFramesModule, FrameSelectionModule, RemoveLastFrameModule, RemoveStartFramesModule
+from FrameSelection import RemoveFramesModule, FrameSelectionModule, RemoveLastFrameModule, RemoveStartFramesModule, StellarPhotometryModule
 from FluxAndPosition import FakePlanetModule, SimplexMinimizationModule, FalsePositiveModule, MCMCsamplingModule
 from DetectionLimits import ContrastModule
-from SDI import SDIPreparationModule


### PR DESCRIPTION
- Module that prepares the continuum images for the subtraction from the line filter images. 

- Still to be tested on Halpha dataset

- the images are normalized by the filter width, then upscaled and finally cropped to the initial dimensions

- This module has to be combined to the SubtractionImagesModule. Between them an alignment between the two stacks is necessary

- I don't like the fact that there is a new file with only this module. Maybe we can add it to the PSF Subtraction.py? We can discuss it later..