### PR TITLE
AngleCalculationModule to calculate parang

### DIFF
--- a/PynPoint/Core/Pypeline.py
+++ b/PynPoint/Core/Pypeline.py
@@ -131,6 +131,7 @@ class Pypeline(object):
         config_dict = {'INSTRUMENT': 'INSTRUME',
                        'NFRAMES': 'NAXIS3',
                        'EXP_NO': 'ESO DET EXP NO',
+                       'DIT': 'ESO DET DIT',
                        'NDIT': 'ESO DET NDIT',
                        'PARANG_START': 'ESO ADA POSANG',
                        'PARANG_END': 'ESO ADA POSANG END',
@@ -142,7 +143,6 @@ class Pypeline(object):
                        'LONGITUDE': 'ESO TEL GEOLON',
                        'RA': 'RA',
                        'DEC': 'DEC',
-                       'DIT': 'ESO DET DIT',
                        'PIXSCALE': 0.027,
                        'MEMORY': 1000,
                        'CPU': max_cpu_count}
@@ -161,6 +161,9 @@ class Pypeline(object):
 
             if config.has_option('header', 'EXP_NO'):
                 config_dict['EXP_NO'] = str(config.get('header', 'EXP_NO'))
+
+            if config.has_option('header', 'DIT'):
+                config_dict['DIT'] = str(config.get('header', 'DIT'))
 
             if config.has_option('header', 'NDIT'):
                 config_dict['NDIT'] = str(config.get('header', 'NDIT'))
@@ -198,9 +201,6 @@ class Pypeline(object):
             if config.has_option('header', 'DEC'):
                 config_dict['DEC'] = str(config.get('header', 'DEC'))
 
-            if config.has_option('header', 'DIT'):
-                config_dict['DIT'] = str(config.get('header', 'DIT'))
-
             if config.has_option('settings', 'MEMORY'):
                 if config.get('settings', 'MEMORY') == "None":
                     config_dict['MEMORY'] = int(0)
@@ -219,6 +219,7 @@ class Pypeline(object):
             file_obj.write('INSTRUMENT: INSTRUME\n')
             file_obj.write('NFRAMES: NAXIS3\n')
             file_obj.write('EXP_NO: ESO DET EXP NO\n')
+            file_obj.write('DIT: ESO DET DIT\n')
             file_obj.write('NDIT: ESO DET NDIT\n')
             file_obj.write('PARANG_START: ESO ADA POSANG\n')
             file_obj.write('PARANG_END: ESO ADA POSANG END\n')
@@ -229,8 +230,7 @@ class Pypeline(object):
             file_obj.write('LATITUDE: ESO TEL GEOLAT\n')
             file_obj.write('LONGITUDE: ESO TEL GEOLON\n')
             file_obj.write('RA: RA\n')
-            file_obj.write('DEC: DEC\n')
-            file_obj.write('DIT: ESO DET DIT\n\n')
+            file_obj.write('DEC: DEC\n\n')
             file_obj.write('[settings]\n\n')
             file_obj.write('PIXSCALE: 0.027\n')
             file_obj.write('MEMORY: 1000\n')

--- a/PynPoint/Core/Pypeline.py
+++ b/PynPoint/Core/Pypeline.py
@@ -136,6 +136,13 @@ class Pypeline(object):
                        'PARANG_END': 'ESO ADA POSANG END',
                        'DITHER_X': 'ESO SEQ CUMOFFSETX',
                        'DITHER_Y': 'ESO SEQ CUMOFFSETY',
+                       'PUPIL': 'ESO ADA PUPILPOS',
+                       'DATE': 'DATE-OBS',
+                       'LATITUDE': 'ESO TEL GEOLAT',
+                       'LONGITUDE': 'ESO TEL GEOLON',
+                       'RA': 'RA',
+                       'DEC': 'DEC',
+                       'DIT': 'ESO DET DIT',
                        'PIXSCALE': 0.027,
                        'MEMORY': 1000,
                        'CPU': max_cpu_count}
@@ -173,6 +180,27 @@ class Pypeline(object):
             if config.has_option('settings', 'PIXSCALE'):
                 config_dict['PIXSCALE'] = float(config.get('settings', 'PIXSCALE'))
 
+            if config.has_option('header', 'DATE'):
+                config_dict['DATE'] = str(config.get('header', 'DATE'))
+
+            if config.has_option('header', 'PUPIL'):
+                config_dict['PUPIL'] = str(config.get('header', 'PUPIL'))
+
+            if config.has_option('header', 'LATITUDE'):
+                config_dict['LATITUDE'] = str(config.get('header', 'LATITUDE'))
+
+            if config.has_option('header', 'LONGITUDE'):
+                config_dict['LONGITUDE'] = str(config.get('header', 'LONGITUDE'))
+
+            if config.has_option('header', 'RA'):
+                config_dict['RA'] = str(config.get('header', 'RA'))
+
+            if config.has_option('header', 'DEC'):
+                config_dict['DEC'] = str(config.get('header', 'DEC'))
+
+            if config.has_option('header', 'DIT'):
+                config_dict['DIT'] = str(config.get('header', 'DIT'))
+
             if config.has_option('settings', 'MEMORY'):
                 if config.get('settings', 'MEMORY') == "None":
                     config_dict['MEMORY'] = int(0)
@@ -195,7 +223,14 @@ class Pypeline(object):
             file_obj.write('PARANG_START: ESO ADA POSANG\n')
             file_obj.write('PARANG_END: ESO ADA POSANG END\n')
             file_obj.write('DITHER_X: ESO SEQ CUMOFFSETX\n')
-            file_obj.write('DITHER_Y: ESO SEQ CUMOFFSETY\n\n')
+            file_obj.write('DITHER_Y: ESO SEQ CUMOFFSETY\n')
+            file_obj.write('PUPIL: ESO ADA PUPILPOS\n')
+            file_obj.write('DATE: DATE-OBS\n')
+            file_obj.write('LATITUDE: ESO TEL GEOLAT\n')
+            file_obj.write('LONGITUDE: ESO TEL GEOLON\n')
+            file_obj.write('RA: RA\n')
+            file_obj.write('DEC: DEC\n')
+            file_obj.write('DIT: ESO DET DIT\n\n')
             file_obj.write('[settings]\n\n')
             file_obj.write('PIXSCALE: 0.027\n')
             file_obj.write('MEMORY: 1000\n')

--- a/PynPoint/IOmodules/FitsReading.py
+++ b/PynPoint/IOmodules/FitsReading.py
@@ -66,9 +66,9 @@ class FitsReadingModule(ReadingModule):
         self.m_overwrite = overwrite
 
         self.m_static = ['INSTRUMENT',
+                         'DIT',
                          'LATITUDE',
-                         'LONGITUDE',
-                         'DIT']
+                         'LONGITUDE']
 
         self.m_non_static = ['NFRAMES',
                              'EXP_NO',

--- a/PynPoint/IOmodules/FitsReading.py
+++ b/PynPoint/IOmodules/FitsReading.py
@@ -65,7 +65,10 @@ class FitsReadingModule(ReadingModule):
         self.m_image_tag = image_tag
         self.m_overwrite = overwrite
 
-        self.m_static = ['INSTRUMENT']
+        self.m_static = ['INSTRUMENT',
+                         'LATITUDE',
+                         'LONGITUDE',
+                         'DIT']
 
         self.m_non_static = ['NFRAMES',
                              'EXP_NO',
@@ -74,7 +77,11 @@ class FitsReadingModule(ReadingModule):
                              'PARANG_END',
                              'PARANG',
                              'DITHER_X',
-                             'DITHER_Y']
+                             'DITHER_Y',
+                             'PUPIL',
+                             'DATE',
+                             'RA',
+                             'DEC']
 
         self.m_attr_check = np.ones(len(self.m_non_static), dtype=bool)
 

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -494,6 +494,9 @@ class AngleCalculationModule(ProcessingModule):
                           "steps. A frame selection should be applied after the parallactic "
                           "angles are calculated.")
 
+        if self.m_instrument == "SPHERE/IFS":
+            warnings.warn("AngleCalculationModule has not been tested yet for SPHERE/IFS data.")
+
         # Load exposure time in hours
         exptime = self.m_data_in_port.get_attribute("DIT")/3600.
 

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -398,9 +398,9 @@ class SortParangModule(ProcessingModule):
 
 class AngleCalculationModule(ProcessingModule):
     """
-    Module for calculating the parallactic angle values. The start time of the observation is
-    taken and multiples of the exposure time are added to receive the parallactic angle of each
-    frame inside the cube. Instrument specific overheads are added.
+    Module for calculating the parallactic angles. The start time of the observation is taken and
+    multiples of the exposure time are added to derive the parallactic angle of each frame inside
+    the cube. Instrument specific overheads are included.
     """
 
     def __init__(self,
@@ -410,7 +410,7 @@ class AngleCalculationModule(ProcessingModule):
         """
         Constructor of AngleCalculationModule.
 
-        :param instrument: Instrument name (*NACO* or *SPHERE/IRDIS* or *SPHERE/IFS*)
+        :param instrument: Instrument name (*NACO*, *SPHERE/IRDIS*, or *SPHERE/IFS*)
         :type instrument: str
         :param name_in: Unique name of the module instance.
         :type name_in: str
@@ -476,10 +476,10 @@ class AngleCalculationModule(ProcessingModule):
 
     def run(self):
         """
-        Run method of the module. Caluclates the parallactic angle from the position of the object
-        in sky and the telescope on earth The values are written. The start of the observation is
-        used to extrapolate for the observation time of each individual image of a datacube. The
-        values are written as attributes to *data_tag*.
+        Run method of the module. Calculates the parallactic angles from the position of the object
+        on the sky and the telescope location on earth. The start of the observation is used to
+        extrapolate for the observation time of each individual image of a data cube. The values
+        are written as PARANG attributes to *data_tag*.
 
         :return: None
         """

--- a/PynPoint/ProcessingModules/__init__.py
+++ b/PynPoint/ProcessingModules/__init__.py
@@ -10,8 +10,8 @@ from StackingAndSubsampling import StackAndSubsetModule, MeanCubeModule, Derotat
 from StarAlignment import StarAlignmentModule, StarExtractionModule, StarCenteringModule, \
                           ShiftForCenteringModule
 from ImageResizing import CropImagesModule, ScaleImagesModule, AddLinesModule, RemoveLinesModule
-from PSFpreparation import PSFpreparationModule, AngleCalculationModule, SortParangModule, \
-                          SDIpreparationModule
+from PSFpreparation import PSFpreparationModule, AngleInterpolationModule, AngleCalculationModule, \
+                          SortParangModule, SDIpreparationModule
 from TimeDenoising import CwtWaveletConfiguration, DwtWaveletConfiguration, \
                           WaveletTimeDenoisingModule, TimeNormalizationModule
 from FrameSelection import RemoveFramesModule, FrameSelectionModule, RemoveLastFrameModule, RemoveStartFramesModule

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ statsmodels
 PyWavelets
 matplotlib
 emcee
+ephem

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ requirements = ['configparser',
                 'statsmodels',
                 'PyWavelets',
                 'matplotlib',
-                'emcee']
+                'emcee',
+                'ephem']
 
 setup(
     name='PynPoint',

--- a/tests/test_processing/test_Documentation.py
+++ b/tests/test_processing/test_Documentation.py
@@ -14,7 +14,7 @@ from PynPoint.IOmodules.FitsWriting import FitsWritingModule
 from PynPoint.ProcessingModules.BadPixelCleaning import BadPixelSigmaFilterModule
 from PynPoint.ProcessingModules.DarkAndFlatCalibration import DarkCalibrationModule, FlatCalibrationModule
 from PynPoint.ProcessingModules.ImageResizing import RemoveLinesModule
-from PynPoint.ProcessingModules.PSFpreparation import AngleCalculationModule
+from PynPoint.ProcessingModules.PSFpreparation import AngleInterpolationModule
 from PynPoint.ProcessingModules.BackgroundSubtraction import MeanBackgroundSubtractionModule
 from PynPoint.ProcessingModules.StarAlignment import StarExtractionModule, StarAlignmentModule
 from PynPoint.ProcessingModules.PSFSubtractionPCA import PSFSubtractionModule
@@ -270,7 +270,7 @@ class TestDocumentation(object):
         self.pipeline.add_module(ref_extract)
         self.pipeline.add_module(alignment)
 
-        angle_calc = AngleCalculationModule(name_in="angle_calculation",
+        angle_calc = AngleInterpolationModule(name_in="angle_calculation",
                                             data_tag="im_arr_aligned")
 
         self.pipeline.add_module(angle_calc)

--- a/tests/test_processing/test_EndToEnd.py
+++ b/tests/test_processing/test_EndToEnd.py
@@ -12,7 +12,7 @@ from PynPoint.Core.DataIO import DataStorage, InputPort
 from PynPoint.IOmodules import FitsReadingModule
 from PynPoint.ProcessingModules.FrameSelection import RemoveLastFrameModule, RemoveFramesModule
 from PynPoint.ProcessingModules.PSFSubtractionPCA import PSFSubtractionModule
-from PynPoint.ProcessingModules.PSFpreparation import AngleCalculationModule
+from PynPoint.ProcessingModules.PSFpreparation import AngleInterpolationModule
 from PynPoint.ProcessingModules.ImageResizing import RemoveLinesModule
 from PynPoint.ProcessingModules.BackgroundSubtraction import MeanBackgroundSubtractionModule
 from PynPoint.ProcessingModules.BadPixelCleaning import BadPixelSigmaFilterModule
@@ -152,7 +152,7 @@ class TestEndToEnd(object):
         storage.close_connection()
 
     def test_parang(self):
-        angle = AngleCalculationModule(name_in="angle",
+        angle = AngleInterpolationModule(name_in="angle",
                                        data_tag="im_last")
 
         self.pipeline.add_module(angle)


### PR DESCRIPTION
New module by @18alex96 to calculate the parang from the target coordinates, telescope location and observation date+time. Currently the module works for SPHERE/IRDIS, SPHERE/IFS, and NACO data. Not tested yet for the IFS.

Note that the previous AngleCalculationModule is now called AngleInterpolationModule.