### PR TITLE
Renamed FastPCAModule to PcaPsfSubtractionModule

### DIFF
--- a/PynPoint/ProcessingModules/DetectionLimits.py
+++ b/PynPoint/ProcessingModules/DetectionLimits.py
@@ -14,7 +14,7 @@ from scipy.stats import t
 
 from PynPoint.Core.Processing import ProcessingModule
 from PynPoint.ProcessingModules.PSFpreparation import PSFpreparationModule
-from PynPoint.ProcessingModules.PSFSubtractionPCA import FastPCAModule
+from PynPoint.ProcessingModules.PSFSubtractionPCA import PcaPsfSubtractionModule
 from PynPoint.ProcessingModules.FluxAndPosition import FakePlanetModule
 
 
@@ -281,16 +281,16 @@ class ContrastCurveModule(ProcessingModule):
                     prep.connect_database(self._m_data_base)
                     prep.run()
 
-                    psf_sub = FastPCAModule(name_in="pca_contrast",
-                                            pca_numbers=self.m_pca_number,
-                                            images_in_tag="contrast_prep",
-                                            reference_in_tag="contrast_prep",
-                                            res_mean_tag="contrast_res_mean",
-                                            res_median_tag=None,
-                                            res_arr_out_tag=None,
-                                            res_rot_mean_clip_tag=None,
-                                            extra_rot=self.m_extra_rot,
-                                            verbose=False)
+                    psf_sub = PcaPsfSubtractionModule(name_in="pca_contrast",
+                                                      pca_numbers=self.m_pca_number,
+                                                      images_in_tag="contrast_prep",
+                                                      reference_in_tag="contrast_prep",
+                                                      res_mean_tag="contrast_res_mean",
+                                                      res_median_tag=None,
+                                                      res_arr_out_tag=None,
+                                                      res_rot_mean_clip_tag=None,
+                                                      extra_rot=self.m_extra_rot,
+                                                      verbose=False)
 
                     psf_sub.connect_database(self._m_data_base)
                     psf_sub.run()

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -20,7 +20,7 @@ from photutils import aperture_photometry, CircularAperture
 from PynPoint.Util.Progress import progress
 from PynPoint.Core.Processing import ProcessingModule
 from PynPoint.ProcessingModules.PSFpreparation import PSFpreparationModule
-from PynPoint.ProcessingModules.PSFSubtractionPCA import FastPCAModule
+from PynPoint.ProcessingModules.PSFSubtractionPCA import PcaPsfSubtractionModule
 
 
 class FakePlanetModule(ProcessingModule):
@@ -396,16 +396,16 @@ class SimplexMinimizationModule(ProcessingModule):
             prep.connect_database(self._m_data_base)
             prep.run()
 
-            psf_sub = FastPCAModule(name_in="pca_simplex",
-                                    pca_numbers=self.m_pca_number,
-                                    images_in_tag="simplex_prep",
-                                    reference_in_tag="simplex_prep",
-                                    res_mean_tag="simplex_res_mean",
-                                    res_median_tag=None,
-                                    res_arr_out_tag=None,
-                                    res_rot_mean_clip_tag=None,
-                                    extra_rot=self.m_extra_rot,
-                                    verbose=False)
+            psf_sub = PcaPsfSubtractionModule(name_in="pca_simplex",
+                                              pca_numbers=self.m_pca_number,
+                                              images_in_tag="simplex_prep",
+                                              reference_in_tag="simplex_prep",
+                                              res_mean_tag="simplex_res_mean",
+                                              res_median_tag=None,
+                                              res_arr_out_tag=None,
+                                              res_rot_mean_clip_tag=None,
+                                              extra_rot=self.m_extra_rot,
+                                              verbose=False)
 
             psf_sub.connect_database(self._m_data_base)
             psf_sub.run()

--- a/PynPoint/ProcessingModules/PSFSubtractionPCA.py
+++ b/PynPoint/ProcessingModules/PSFSubtractionPCA.py
@@ -225,8 +225,9 @@ class PSFSubtractionModule(ProcessingModule):
         :return: None
         """
 
-        warnings.warn("PSFSubtractionModule will be deprecated in the future. Please use "
-                      "PcaPsfSubtractionModule instead.", PendingDeprecationWarning)
+        warnings.warn("PSFSubtractionModule is deprecated and will be removed in the next "
+                      "release. Please use PcaPsfSubtractionModule instead.",
+                      DeprecationWarning)
 
         if self.m_verbose:
             stdout.write("Preparing PSF subtraction...")

--- a/PynPoint/ProcessingModules/PSFSubtractionPCA.py
+++ b/PynPoint/ProcessingModules/PSFSubtractionPCA.py
@@ -2,6 +2,7 @@
 Modules for PSF subtraction with principle component analysis.
 """
 
+import warnings
 from copy import deepcopy
 from sys import platform, stdout
 
@@ -223,6 +224,9 @@ class PSFSubtractionModule(ProcessingModule):
 
         :return: None
         """
+
+        warnings.warn("PSFSubtractionModule will be deprecated in the future. Please use "
+                      "PcaPsfSubtractionModule instead.", PendingDeprecationWarning)
 
         if self.m_verbose:
             stdout.write("Preparing PSF subtraction...")
@@ -585,7 +589,7 @@ class MakePCABasisModule(ProcessingModule):
         self._m_basis_out_port.flush()
 
 
-class FastPCAModule(ProcessingModule):
+class PcaPsfSubtractionModule(ProcessingModule):
     """
     Module for fast (compared to PSFSubtractionModule) PCA subtraction. The multiprocessing
     implementation is only supported for Linux and Windows. Mac only runs in single processing
@@ -604,7 +608,7 @@ class FastPCAModule(ProcessingModule):
                  extra_rot=0.,
                  **kwargs):
         """
-        Constructor of FastPCAModule.
+        Constructor of PcaPsfSubtractionModule.
 
         :param pca_numbers: Number of PCA components used for the PSF model. Can be a single value
                             or a list of integers. A list of PCAs will be processed (if supported)
@@ -643,7 +647,7 @@ class FastPCAModule(ProcessingModule):
         :return: None
         """
 
-        super(FastPCAModule, self).__init__(name_in)
+        super(PcaPsfSubractionModule, self).__init__(name_in)
 
         if "basis_out_tag" in kwargs:
             self.m_basis_tag = kwargs["basis_out_tag"]
@@ -777,7 +781,7 @@ class FastPCAModule(ProcessingModule):
                 self.m_res_arr_out_ports[pca_number].copy_attributes_from_input_port(
                     self.m_star_in_port)
                 self.m_res_arr_out_ports[pca_number].add_history_information("PSF subtraction",
-                                                                             "Fast PCA")
+                                                                             "PcaPsfSubtractionModule")
 
             # 2.) mean
             tmp_res_rot_mean = np.mean(res_array, axis=0)
@@ -864,8 +868,8 @@ class FastPCAModule(ProcessingModule):
         self.m_res_median_out_port.copy_attributes_from_input_port(self.m_star_in_port)
         self.m_res_rot_mean_clip_out_port.copy_attributes_from_input_port(self.m_star_in_port)
 
-        self.m_res_mean_out_port.add_history_information("PSF subtraction", "Fast PCA")
-        self.m_res_median_out_port.add_history_information("PSF subtraction", "Fast PCA")
-        self.m_res_rot_mean_clip_out_port.add_history_information("PSF subtraction", "Fast PCA")
+        self.m_res_mean_out_port.add_history_information("PSF subtraction", "PcaPsfSubtractionModule")
+        self.m_res_median_out_port.add_history_information("PSF subtraction", "PcaPsfSubtractionModule")
+        self.m_res_rot_mean_clip_out_port.add_history_information("PSF subtraction", "PcaPsfSubtractionModule")
 
         self.m_res_mean_out_port.close_port()

--- a/PynPoint/ProcessingModules/__init__.py
+++ b/PynPoint/ProcessingModules/__init__.py
@@ -4,7 +4,7 @@ from BackgroundSubtraction import SimpleBackgroundSubtractionModule, MeanBackgro
 from BadPixelCleaning import BadPixelSigmaFilterModule, BadPixelInterpolationModule, \
                              BadPixelMapModule
 from DarkAndFlatCalibration import DarkCalibrationModule, FlatCalibrationModule, SubtractImagesModule
-from PSFSubtractionPCA import PSFSubtractionModule, FastPCAModule
+from PSFSubtractionPCA import PSFSubtractionModule, PcaPsfSubtractionModule
 from StackingAndSubsampling import StackAndSubsetModule, MeanCubeModule, DerotateAndStackModule, \
                                    CombineTagsModule
 from StarAlignment import StarAlignmentModule, StarExtractionModule, StarCenteringModule, \


### PR DESCRIPTION
- Renamed FastPCAModule to PcaPsfSubtractionModule (new PCA)
- Added a DeprecationWarning in the PSFSubtractionModule (old PCA)

After a discussion today with @aboehle and @majobodo today we agreed that the old PCA implementation (PSFSubtractionModule) is no longer needed and will be removed in the (near) future. The DeprecationWarning is meant for the users that still use the old PCA implementation to make them aware of the PcaPsfSubtractionModule which is faster and calculates the residuals for a range of components. The basis and residuals that are calculated by PcaPsfSubtractionModule and PSFSubtractionModule are the same with high precision so it makes sense to continue only with one PCA module for the PSF subtraction to avoid unnecessary confusion.