### PR TITLE
Frame selection updates

### DIFF
--- a/PynPoint/IOmodules/TextWriting.py
+++ b/PynPoint/IOmodules/TextWriting.py
@@ -72,7 +72,11 @@ class TextWritingModule(WritingModule):
         if data.ndim > 2:
             raise ValueError("Only 1D or 2D arrays can be written to a text file.")
 
-        np.savetxt(out_name, data, header=self.m_header, comments='# ')
+        if data.dtype == "int32" or data.dtype == "int64":
+            np.savetxt(out_name, data, header=self.m_header, comments='# ', fmt="%i")
+
+        elif data.dtype == "float32" or data.dtype == "float64":
+            np.savetxt(out_name, data, header=self.m_header, comments='# ')
 
         sys.stdout.write(" [DONE]\n")
         sys.stdout.flush()

--- a/PynPoint/ProcessingModules/FrameSelection.py
+++ b/PynPoint/ProcessingModules/FrameSelection.py
@@ -217,9 +217,9 @@ class FrameSelectionModule(ProcessingModule):
                  index_out_tag=None,
                  method="median",
                  threshold=4.,
-                 fwhm=0.2,
-                 aperture=0.5,
-                 position=None):
+                 fwhm=0.1,
+                 aperture=0.2,
+                 position=(None, None, 0.5)):
         """
         Constructor of FrameSelectionModule.
 
@@ -311,8 +311,11 @@ class FrameSelectionModule(ProcessingModule):
         nimages = self.m_image_in_port.get_shape()[0]
         npix = self.m_image_in_port.get_shape()[1]
 
-        if self.m_position is None or (self.m_position[0] is None and self.m_position[1] is None):
-            self.m_position = (float(npix)/2., float(npix)/2.)
+        if self.m_position is None:
+            self.m_position = (float(npix)/2., float(npix)/2., None)
+
+        elif self.m_position[0] is None and self.m_position[1] is None:
+            self.m_position = (float(npix)/2., float(npix)/2., self.m_position[2])
 
         if memory == 0 or memory >= nimages:
             frames = [0, nimages]
@@ -330,7 +333,9 @@ class FrameSelectionModule(ProcessingModule):
         phot = np.zeros(nimages)
 
         if self.m_fwhm is None:
-            starpos = np.full((nimages, 2), self.m_position, dtype=np.int64)
+            starpos = np.zeros((nimages, 2), dtype=np.int64)
+            starpos[:, 0] = self.m_position[0]
+            starpos[:, 1] = self.m_position[1]
 
         else:
             star = StarExtractionModule(name_in="star",

--- a/PynPoint/ProcessingModules/FrameSelection.py
+++ b/PynPoint/ProcessingModules/FrameSelection.py
@@ -399,13 +399,14 @@ class FrameSelectionModule(ProcessingModule):
 
         index_rm[np.isnan(phot)] = True
         indices = np.where(index_rm)
+        indices = np.asarray(indices, dtype=np.int)
 
         sys.stdout.write("Running FrameSelectionModule... [DONE]\n")
         sys.stdout.flush()
 
         if np.size(indices) > 0:
             if self.m_index_out_port is not None:
-                self.m_index_out_port.set_all(indices)
+                self.m_index_out_port.set_all(np.transpose(indices))
                 self.m_index_out_port.copy_attributes_from_input_port(self.m_image_in_port)
                 self.m_index_out_port.add_history_information("Frames removed",
                                                               str(np.size(indices)))

--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -50,11 +50,11 @@ class StarExtractionModule(ProcessingModule):
                           to convolve the images.
         :type fwhm_star: float
         :param position: Subframe that is selected to search for the star. The tuple can contain a
-                         single position in pixels and size as (pos_x, pos_y, size), or the position
-                         and size can be defined for each image separately in which case the tuple
-                         should be 2D (nframes x 3). Setting *position* to None will use the
-                         full image to search for the star. If position=(None, None, size) then
-                         the center of the image will be used.
+                         single position (pix) and size (arcsec) as (pos_x, pos_y, size), or the
+                         position and size can be defined for each image separately in which case
+                         the tuple should be 2D (nframes x 3). Setting *position* to None will use
+                         the full image to search for the star. If *position=(None, None, size)*
+                         then the center of the image will be used.
         :type position: tuple, float
 
         :return: None
@@ -120,21 +120,21 @@ class StarExtractionModule(ProcessingModule):
                 if self.m_position.ndim == 1:
                     pos_x = self.m_position[0]
                     pos_y = self.m_position[1]
-                    width = self.m_position[2]
+                    width = self.m_position[2]/pixscale
 
                     if pos_x > self.m_image_in_port.get_shape()[1] or \
                             pos_y > self.m_image_in_port.get_shape()[2]:
-                        raise ValueError('The indicated position lays outside the image')
+                        raise ValueError('The specified position is outside the image.')
 
                 elif self.m_position.ndim == 2:
                     pos_x = self.m_position[self.m_count, 0]
                     pos_y = self.m_position[self.m_count, 1]
-                    width = self.m_position[self.m_count, 2]
+                    width = self.m_position[self.m_count, 2]/pixscale
 
                 if pos_y <= width/2. or pos_x <= width/2. \
                         or pos_y+width/2. >= self.m_image_in_port.get_shape()[2]\
                         or pos_x+width/2. >= self.m_image_in_port.get_shape()[1]:
-                    warnings.warn("The region for the star extraction exceeds the image")
+                    warnings.warn("The region for the star extraction exceeds the image.")
 
                 subimage = image[int(pos_y-width/2.):int(pos_y+width/2.),
                                  int(pos_x-width/2.):int(pos_x+width/2.)]

--- a/tests/test_processing/test_EndToEnd.py
+++ b/tests/test_processing/test_EndToEnd.py
@@ -281,10 +281,11 @@ class TestEndToEnd(object):
         storage.close_connection()
 
     def test_remove_frames(self):
-        remove_frames = RemoveFramesModule((0, 15, 49, 66),
+        remove_frames = RemoveFramesModule(frames=(0, 15, 49, 66),
                                            name_in="remove_frames",
                                            image_in_tag="im_center",
-                                           image_out_tag="im_remove")
+                                           selected_out_tag="im_remove",
+                                           removed_out_tag=None)
 
         self.pipeline.add_module(remove_frames)
         self.pipeline.run_module("remove_frames")


### PR DESCRIPTION
- RemoveFramesModule has two output tags, _selected_out_tag_ and _removed_out_tag_, which both can be set to None.
- The _frames_ parameter in RemoveFramesModule can also be an input tag (instead of a tuple/array with frame indices) that points a list with frame indices in the database.
- FrameSelectionModule calls RemoveFramesModule instead of writing/removing the images and attributes by itself.
- Optional _index_out_tag_ in FrameSelectionModule which contains the frames indices that are removed. _selected_out_tag_ and _removed_out_tag_ can be set to None in FrameSelectionModule.
- Updated use of _position_ and _aperture_ in FrameSelectionModule (see docs for details) which makes the frame selection more flexible.
- _aperture_ is a tuple which can be circular, annular, or ratio of core-to-halo.
- TextWritingModule writes integers in the integer format.
- The _position_ size in FrameSelectionModule and StarExtractionModule is now given in arcsec instead of pix.