### PR TITLE
Small fixes in CropImagesModule, AngleCalculationModule, DerotateAndS…

### DIFF
--- a/PynPoint/ProcessingModules/ImageResizing.py
+++ b/PynPoint/ProcessingModules/ImageResizing.py
@@ -74,7 +74,7 @@ class CropImagesModule(ProcessingModule):
                 if size > image_in.shape[0] or size > image_in.shape[1]:
                     raise ValueError("Input frame resolution smaller than target image resolution.")
 
-                image_out = image_in[y_off:y_off+size, x_off:x_off+size]
+                image_out = image_in[x_off:x_off+size, y_off:y_off+size]
 
             else:
                 x_in = int(center[0] - size/2)

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -519,10 +519,10 @@ class AngleCalculationModule(ProcessingModule):
             pupil_pos = self.m_data_in_port.get_attribute("PUPIL")
 
         elif self.m_instrument == "SPHERE/IRDIS":
-            pupil_pos = None
+            pupil_pos = np.zeros(np.size(steps))
 
         elif self.m_instrument == "SPHERE/IFS":
-            pupil_pos = None
+            pupil_pos = np.zeros(np.size(steps))
 
         new_angles = np.array([])
         pupil_pos_arr = np.array([])

--- a/PynPoint/ProcessingModules/StackingAndSubsampling.py
+++ b/PynPoint/ProcessingModules/StackingAndSubsampling.py
@@ -290,10 +290,12 @@ class DerotateAndStackModule(ProcessingModule):
             progress(i, len(frames[:-1]), "Running DerotateAndStackModule...")
 
             if self.m_derotate:
+                im_rot = np.zeros(self.m_image_in_port.get_shape()[-2:])
+
                 for j in range(frames[i+1]-frames[i]):
-                    im_rot = rotate(self.m_image_in_port[frames[i]+j, ],
-                                    -parang[frames[i]+j]+self.m_extra_rot,
-                                    reshape=False)
+                    im_rot += rotate(input=self.m_image_in_port[frames[i]+j,],
+                                     angle=-parang[frames[i]+j]+self.m_extra_rot,
+                                     reshape=False)
 
             else:
                 im_rot = self.m_image_in_port[frames[i]:frames[i+1], ]

--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -259,7 +259,7 @@ class StarAlignmentModule(ProcessingModule):
                                          replace=False)), :, :]
 
                 else:
-                    ref_images = np.array([self.m_ref_image_in_port.get_all(),])
+                    ref_images = self.m_ref_image_in_port.get_all()
                     self.m_num_references = self.m_ref_image_in_port.get_shape()[0]
 
             elif im_dim == 2:


### PR DESCRIPTION
Small fixes in following modules:
- CropImagesModule: x and y must be switched, when cropping around the center of an image (_center=None_). Tested on non-quadratic SPHERE/IRDIS images (pixelscale: 2048x1024)
- AngleCalculationModule: pupil_pos must be an array filled with zeros in case of SPHERE data. Otherwise an error is raised, when the pupil position is calculated.
- DerotateAndStackModule: In case of _derotate=True_ the variable _im_rot_ is overwritten each step of the for loop without using it. This way it is summed up, so that the average can be calculated correctly afterwards.
- StarAlignment: The old way of importing the reference images creates a 4 dimensional array, which results in problems later on.