### PR TITLE
Improved StarCenteringModule and added ModuleTools

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,5 @@
+comment:
+  require_changes: yes
+
 ignore:
   - "PynPoint/OldVersion"

--- a/PynPoint/Core/Processing.py
+++ b/PynPoint/Core/Processing.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from PynPoint.Core.DataIO import OutputPort, InputPort, ConfigPort
 from PynPoint.Util.Multiprocessing import LineProcessingCapsule, apply_function
-from PynPoint.Util.Progress import progress
+from PynPoint.Util.ModuleTools import progress
 
 
 class PypelineModule:

--- a/PynPoint/IOmodules/FitsReading.py
+++ b/PynPoint/IOmodules/FitsReading.py
@@ -11,7 +11,7 @@ import numpy as np
 from astropy.io import fits
 
 from PynPoint.Core.Processing import ReadingModule
-from PynPoint.Util.Progress import progress
+from PynPoint.Util.ModuleTools import progress
 
 
 class FitsReadingModule(ReadingModule):

--- a/PynPoint/IOmodules/Hdf5Reading.py
+++ b/PynPoint/IOmodules/Hdf5Reading.py
@@ -9,7 +9,7 @@ import h5py
 import numpy as np
 
 from PynPoint.Core.Processing import ReadingModule
-from PynPoint.Util.Progress import progress
+from PynPoint.Util.ModuleTools import progress
 
 
 class Hdf5ReadingModule(ReadingModule):

--- a/PynPoint/ProcessingModules/BackgroundSubtraction.py
+++ b/PynPoint/ProcessingModules/BackgroundSubtraction.py
@@ -690,9 +690,10 @@ class DitheringBackgroundModule(ProcessingModule):
         :param gaussian: Full width at half maximum (arcsec) of the Gaussian kernel that is used
                          to smooth the image before the star is located.
         :type gaussian: float
-        :param subframe: Size (pix) of the subframe that is used to search for the star. Cropping
-                         of the subframe is done around the center of the dithering position. If
-                         set to None then the full frame size (*size*) will be used.
+        :param subframe: Size (arcsec) of the subframe that is used to search for the star.
+                         Cropping of the subframe is done around the center of the dithering
+                         position. If set to None then the full frame size (*size*) will be
+                         used.
         :type subframe: float
         :param pca_number: Number of principle components.
         :type pca_number: int
@@ -829,7 +830,9 @@ class DitheringBackgroundModule(ProcessingModule):
                 if self.m_subframe is None:
                     position = None
                 else:
-                    position = (None, None, self.m_subframe/pixscale)
+                    position = (None, None, self.m_subframe)
+
+                print position
 
                 star = StarExtractionModule(name_in="star"+str(i),
                                             image_in_tag="star"+str(i+1),

--- a/PynPoint/ProcessingModules/BackgroundSubtraction.py
+++ b/PynPoint/ProcessingModules/BackgroundSubtraction.py
@@ -761,8 +761,6 @@ class DitheringBackgroundModule(ProcessingModule):
         :return: None
         """
 
-        pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
-
         if self.m_cubes is None:
             dither_x = self.m_image_in_port.get_attribute("DITHER_X")
             dither_y = self.m_image_in_port.get_attribute("DITHER_Y")

--- a/PynPoint/ProcessingModules/DarkAndFlatCalibration.py
+++ b/PynPoint/ProcessingModules/DarkAndFlatCalibration.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 
 from PynPoint.Core.Processing import ProcessingModule
-from PynPoint.Util.Progress import progress
+from PynPoint.Util.ModuleTools import progress, memory_frames
 
 
 def _master_frame(data,
@@ -219,21 +219,9 @@ class SubtractImagesModule(ProcessingModule):
             raise ValueError("The shape of the two input tags have to be equal.")
 
         memory = self._m_config_port.get_attribute("MEMORY")
-
         nimages = self.m_image_in1_port.get_shape()[0]
 
-        if memory == 0 or memory >= nimages:
-            frames = [0, nimages]
-
-        else:
-            frames = np.linspace(0,
-                                 nimages-nimages%memory,
-                                 int(float(nimages)/float(memory))+1,
-                                 endpoint=True,
-                                 dtype=np.int)
-
-            if nimages%memory > 0:
-                frames = np.append(frames, nimages)
+        frames = memory_frames(memory, nimages)
 
         for i, _ in enumerate(frames[:-1]):
             progress(i, len(frames[:-1]), "Running SubtractImagesModule...")

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -17,10 +17,10 @@ from skimage.feature import hessian_matrix
 from astropy.nddata import Cutout2D
 from photutils import aperture_photometry, CircularAperture
 
-from PynPoint.Util.Progress import progress
 from PynPoint.Core.Processing import ProcessingModule
 from PynPoint.ProcessingModules.PSFpreparation import PSFpreparationModule
 from PynPoint.ProcessingModules.PSFSubtractionPCA import PcaPsfSubtractionModule
+from PynPoint.Util.ModuleTools import progress, memory_frames
 
 
 class FakePlanetModule(ProcessingModule):
@@ -121,21 +121,10 @@ class FakePlanetModule(ProcessingModule):
         if ndim_image == 3:
             nimages = self.m_image_in_port.get_shape()[0]
 
-            if memory == 0 or memory >= nimages:
-                frames = [0, nimages]
-
-            else:
-                frames = np.linspace(0,
-                                     nimages-nimages%memory,
-                                     int(float(nimages)/float(memory))+1,
-                                     endpoint=True,
-                                     dtype=np.int)
-
-                if nimages%memory > 0:
-                    frames = np.append(frames, nimages)
-
             im_size = (self.m_image_in_port.get_shape()[1],
                        self.m_image_in_port.get_shape()[2])
+
+            frames = memory_frames(memory, nimages)
 
         else:
             raise ValueError("The image_in_tag should contain a cube of images.")
@@ -165,18 +154,7 @@ class FakePlanetModule(ProcessingModule):
             psf = np.zeros((self.m_psf_in_port.get_shape()[1],
                             self.m_psf_in_port.get_shape()[2]))
 
-            if memory == 0 or memory >= npsf:
-                frames_psf = [0, npsf]
-
-            else:
-                frames_psf = np.linspace(0,
-                                         npsf-npsf%memory,
-                                         int(float(npsf)/float(memory))+1,
-                                         endpoint=True,
-                                         dtype=np.int)
-
-                if npsf%memory > 0:
-                    frames_psf = np.append(frames_psf, npsf)
+            frames_psf = memory_frames(memory, npsf)
 
             for i, _ in enumerate(frames_psf[:-1]):
                 psf += np.sum(self.m_psf_in_port[frames_psf[i]:frames_psf[i+1]], axis=0)

--- a/PynPoint/ProcessingModules/FrameSelection.py
+++ b/PynPoint/ProcessingModules/FrameSelection.py
@@ -183,8 +183,8 @@ class RemoveFramesModule(ProcessingModule):
         if "NFRAMES" in non_static:
             nframes = self.m_image_in_port.get_attribute("NFRAMES")
 
-            nframes_sel = np.zeros(nframes.shape)
-            nframes_del = np.zeros(nframes.shape)
+            nframes_sel = np.zeros(nframes.shape, dtype=np.int)
+            nframes_del = np.zeros(nframes.shape, dtype=np.int)
 
             for i, frames in enumerate(nframes):
                 total = np.sum(nframes[0:i])
@@ -226,7 +226,7 @@ class FrameSelectionModule(ProcessingModule):
                  method="median",
                  threshold=4.,
                  fwhm=0.1,
-                 aperture=0.2,
+                 aperture=("circular", 0.2),
                  position=(None, None, 0.5)):
         """
         Constructor of FrameSelectionModule.
@@ -513,6 +513,9 @@ class RemoveLastFrameModule(ProcessingModule):
 
             images = self.m_image_in_port[frame_start:frame_end, ]
             self.m_image_out_port.append(images)
+
+        nframes_new = np.asarray(nframes_new, dtype=np.int)
+        index_new = np.asarray(index_new, dtype=np.int)
 
         sys.stdout.write("Running RemoveLastFrameModule... [DONE]\n")
         sys.stdout.flush()

--- a/PynPoint/ProcessingModules/FrameSelection.py
+++ b/PynPoint/ProcessingModules/FrameSelection.py
@@ -320,8 +320,6 @@ class FrameSelectionModule(ProcessingModule):
         elif self.m_position[0] is None and self.m_position[1] is None:
             self.m_position = (float(npix)/2., float(npix)/2., self.m_position[2])
 
-        frames = memory_frames(memory, nimages)
-
         phot = np.zeros(nimages)
 
         if self.m_fwhm is None:

--- a/PynPoint/ProcessingModules/FrameSelection.py
+++ b/PynPoint/ProcessingModules/FrameSelection.py
@@ -11,7 +11,7 @@ from astropy.nddata import Cutout2D
 
 from PynPoint.Core.Processing import ProcessingModule
 from PynPoint.ProcessingModules.StarAlignment import StarExtractionModule
-from PynPoint.Util.Progress import progress
+from PynPoint.Util.ModuleTools import progress, memory_frames
 
 
 class RemoveFramesModule(ProcessingModule):
@@ -101,19 +101,10 @@ class RemoveFramesModule(ProcessingModule):
         memory = self._m_config_port.get_attribute("MEMORY")
         nimages = self.m_image_in_port.get_shape()[0]
 
+        frames = memory_frames(memory, nimages)
+
         if memory == 0 or memory >= nimages:
-            frames = [0, nimages]
             memory = nimages
-
-        else:
-            frames = np.linspace(0,
-                                 nimages-nimages%memory,
-                                 int(float(nimages)/float(memory))+1,
-                                 endpoint=True,
-                                 dtype=np.int)
-
-            if nimages%memory > 0:
-                frames = np.append(frames, nimages)
 
         for i, _ in enumerate(frames[:-1]):
             progress(i, len(frames[:-1]), "Running RemoveFramesModule...")
@@ -329,18 +320,7 @@ class FrameSelectionModule(ProcessingModule):
         elif self.m_position[0] is None and self.m_position[1] is None:
             self.m_position = (float(npix)/2., float(npix)/2., self.m_position[2])
 
-        if memory == 0 or memory >= nimages:
-            frames = [0, nimages]
-
-        else:
-            frames = np.linspace(0,
-                                 nimages-nimages%memory,
-                                 int(float(nimages)/float(memory))+1,
-                                 endpoint=True,
-                                 dtype=np.int)
-
-            if nimages%memory > 0:
-                frames = np.append(frames, nimages)
+        frames = memory_frames(memory, nimages)
 
         phot = np.zeros(nimages)
 

--- a/PynPoint/ProcessingModules/PSFSubtractionPCA.py
+++ b/PynPoint/ProcessingModules/PSFSubtractionPCA.py
@@ -11,7 +11,7 @@ import numpy as np
 from sklearn.decomposition import PCA
 from scipy import linalg, ndimage, sparse
 
-from PynPoint.Util.Progress import progress
+from PynPoint.Util.ModuleTools import progress
 from PynPoint.Util.MultiprocessingPCA import PcaMultiprocessingCapsule
 from PynPoint.Core.Processing import ProcessingModule
 from PynPoint.ProcessingModules.PSFpreparation import PSFpreparationModule

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -12,9 +12,9 @@ import numpy as np
 
 from scipy import ndimage
 
-from PynPoint.Util.Progress import progress
 from PynPoint.Core.Processing import ProcessingModule
 from PynPoint.ProcessingModules.ImageResizing import CropImagesModule, ScaleImagesModule
+from PynPoint.Util.ModuleTools import progress, memory_frames
 
 
 class PSFpreparationModule(ProcessingModule):
@@ -348,18 +348,7 @@ class SortParangModule(ProcessingModule):
 
         nimages = self.m_image_in_port.get_shape()[0]
 
-        if memory == 0 or memory >= nimages:
-            frames = [0, nimages]
-
-        else:
-            frames = np.linspace(0,
-                                 nimages-nimages%memory,
-                                 int(float(nimages)/float(memory))+1,
-                                 endpoint=True,
-                                 dtype=np.int)
-
-            if nimages%memory > 0:
-                frames = np.append(frames, nimages)
+        frames = memory_frames(memory, nimages)
 
         for i, _ in enumerate(frames[:-1]):
             progress(i, len(frames[:-1]), "Running SortParangModule...")

--- a/PynPoint/ProcessingModules/StackingAndSubsampling.py
+++ b/PynPoint/ProcessingModules/StackingAndSubsampling.py
@@ -9,8 +9,8 @@ import numpy as np
 
 from scipy.ndimage import rotate
 
-from PynPoint.Util.Progress import progress
 from PynPoint.Core.Processing import ProcessingModule
+from PynPoint.Util.ModuleTools import progress, memory_frames
 
 
 class StackAndSubsetModule(ProcessingModule):
@@ -79,14 +79,7 @@ class StackAndSubsetModule(ProcessingModule):
         parang = self.m_image_in_port.get_attribute("PARANG")
 
         if self.m_stacking is not None:
-            frames = np.linspace(0,
-                                 nimages-nimages%self.m_stacking,
-                                 int(float(nimages)/float(self.m_stacking))+1,
-                                 endpoint=True,
-                                 dtype=np.int)
-
-            if nimages%self.m_stacking > 0:
-                frames = np.append(frames, nimages)
+            frames = memory_frames(self.m_stacking, nimages)
 
             nimages_new = np.size(frames)-1
             parang_new = np.zeros(nimages_new)
@@ -272,18 +265,7 @@ class DerotateAndStackModule(ProcessingModule):
 
         nimages = self.m_image_in_port.get_shape()[0]
 
-        if memory == 0 or memory >= nimages:
-            frames = [0, nimages]
-
-        else:
-            frames = np.linspace(0,
-                                 nimages-nimages%memory,
-                                 int(float(nimages)/float(memory))+1,
-                                 endpoint=True,
-                                 dtype=np.int)
-
-            if nimages%memory > 0:
-                frames = np.append(frames, nimages)
+        frames = memory_frames(memory, nimages)
 
         count = 0.
         for i, _ in enumerate(frames[:-1]):
@@ -381,18 +363,7 @@ class CombineTagsModule(ProcessingModule):
             image_in_port = self.add_input_port(item)
             nimages = image_in_port.get_shape()[0]
 
-            if memory == 0 or memory >= nimages:
-                frames = [0, nimages]
-
-            else:
-                frames = np.linspace(0,
-                                     nimages-nimages%memory,
-                                     int(float(nimages)/float(memory))+1,
-                                     endpoint=True,
-                                     dtype=np.int)
-
-                if nimages%memory > 0:
-                    frames = np.append(frames, nimages)
+            frames = memory_frames(memory, nimages)
 
             for j, _ in enumerate(frames[:-1]):
                 im_tmp = image_in_port[frames[j]:frames[j+1], ]

--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -15,6 +15,7 @@ from scipy.ndimage import shift
 from scipy.optimize import curve_fit
 
 from PynPoint.Core.Processing import ProcessingModule
+from PynPoint.Util.ModuleTools import memory_frames
 
 
 class StarExtractionModule(ProcessingModule):
@@ -539,18 +540,7 @@ class StarCenteringModule(ProcessingModule):
 
         npix = self.m_image_in_port.get_shape()[1]
 
-        if memory == 0 or memory >= nimages:
-            frames = [0, nimages]
-
-        else:
-            frames = np.linspace(0,
-                                 nimages-nimages%memory,
-                                 int(float(nimages)/float(memory))+1,
-                                 endpoint=True,
-                                 dtype=np.int)
-
-            if nimages%memory > 0:
-                frames = np.append(frames, nimages)
+        frames = memory_frames(memory, nimages)
 
         if self.m_method == "mean":
             im_mean = np.zeros((npix, npix))

--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -353,10 +353,11 @@ class StarCenteringModule(ProcessingModule):
                  name_in="centering",
                  image_in_tag="im_arr",
                  image_out_tag="im_center",
+                 mask_out_tag=None,
                  fit_out_tag="center_fit",
                  method="full",
                  interpolation="spline",
-                 radius=None,
+                 radius=0.1,
                  sign="positive",
                  **kwargs):
         """
@@ -369,6 +370,10 @@ class StarCenteringModule(ProcessingModule):
         :param image_out_tag: Tag of the database entry with the centered images that are written
                               as output. Should be different from *image_in_tag*.
         :type image_out_tag: str
+        :param mask_out_tag: Tag of the database entry with the masked images that are written as
+                             output. The unmasked part of the images is used for the fit. Data is
+                             not written when set to None.
+        :type mask_out_tag: str
         :param fit_out_tag: Tag of the database entry with the best-fit results of the 2D Gaussian
                             fit and the 1sigma errors. Data is written in the following format:
                             x offset (arcsec), x offset error (arcsec), y offset (arcsec), y offset
@@ -385,10 +390,9 @@ class StarCenteringModule(ProcessingModule):
         :param interpolation: Type of interpolation that is used for shifting the images (spline,
                               bilinear, or fft).
         :type interpolation: str
-        :param radius: Radius around the center of the image beyond which pixel values are set to
-                       zero when fitting the 2D Gaussian. The full image is used when set to None.
-                       The radius is centered on the position specified in *guess*, which is the
-                       center of the image by default.
+        :param radius: Radius (arcsec) around the center of the image beyond which pixels are
+                       neglected with the fit. The radius is centered on the position specified
+                       in *guess*, which is the center of the image by default.
         :type radius: float
         :param sign: Fit a positive (*"positive"*) or negative (*"negative"*) Gaussian. A negative
                      Gaussian could be used to center coronagraphic data.
@@ -414,6 +418,10 @@ class StarCenteringModule(ProcessingModule):
 
         self.m_image_in_port = self.add_input_port(image_in_tag)
         self.m_image_out_port = self.add_output_port(image_out_tag)
+        if mask_out_tag is None:
+            self.m_mask_out_port = None
+        else:
+            self.m_mask_out_port = self.add_output_port(mask_out_tag)
         self.m_fit_out_port = self.add_output_port(fit_out_tag)
 
         self.m_method = method
@@ -434,6 +442,7 @@ class StarCenteringModule(ProcessingModule):
 
         def _2d_gaussian((x_grid, y_grid), x_center, y_center, fwhm_x, fwhm_y, amp, theta):
             xx_grid, yy_grid = np.meshgrid(x_grid, y_grid)
+            rr_grid = np.sqrt(xx_grid**2+yy_grid**2)
 
             x_diff = xx_grid - x_center
             y_diff = yy_grid - y_center
@@ -446,6 +455,7 @@ class StarCenteringModule(ProcessingModule):
             c_gauss = 0.5 * ((np.sin(theta)/sigma_x)**2 + (np.cos(theta)/sigma_y)**2)
 
             gaussian = amp*np.exp(-(a_gauss*x_diff**2 + b_gauss*x_diff*y_diff + c_gauss*y_diff**2))
+            gaussian = gaussian[rr_grid < self.m_radius]
 
             return np.ravel(gaussian)
 
@@ -468,16 +478,24 @@ class StarCenteringModule(ProcessingModule):
             if self.m_sign == "negative":
                 image = -image + np.abs(np.min(-image))
 
-            if self.m_radius is not None:
-                image[rr_ap > self.m_radius] = 0.
+            if self.m_mask_out_port is not None:
+                mask = np.copy(image)
+                mask[rr_ap > self.m_radius] = 0.
 
-            im_ravel = np.ravel(image)
+                if self.m_method == "mean":
+                    self.m_mask_out_port.append(mask, data_dim=2)
+                elif self.m_method == "full":
+                    self.m_mask_out_port.append(mask, data_dim=3)
+
+            image = image[rr_ap < self.m_radius]
+
+            init = (0., 0., self.m_guess[2], self.m_guess[3], self.m_guess[4], self.m_guess[5])
 
             try:
                 popt, pcov = curve_fit(_2d_gaussian,
                                        (x_grid, y_grid),
-                                       im_ravel,
-                                       p0=self.m_guess,
+                                       image,
+                                       p0=init,
                                        sigma=None,
                                        method='lm')
 
@@ -487,6 +505,9 @@ class StarCenteringModule(ProcessingModule):
                 popt = np.zeros(6)
                 perr = np.zeros(6)
                 self.m_count += 1
+
+            popt[0] += self.m_guess[0]
+            popt[1] += self.m_guess[1]
 
             res = np.asarray((popt[0]*pixscale, perr[0]*pixscale,
                               popt[1]*pixscale, perr[1]*pixscale,
@@ -525,6 +546,10 @@ class StarCenteringModule(ProcessingModule):
         self.m_fit_out_port.del_all_data()
         self.m_fit_out_port.del_all_attributes()
 
+        if self.m_mask_out_port is not None:
+            self.m_mask_out_port.del_all_data()
+            self.m_mask_out_port.del_all_attributes()
+
         memory = self._m_config_port.get_attribute("MEMORY")
         pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
 
@@ -539,6 +564,12 @@ class StarCenteringModule(ProcessingModule):
             nimages = self.m_image_in_port.get_shape()[0]
 
         npix = self.m_image_in_port.get_shape()[1]
+
+        if npix/2.+self.m_guess[0]+self.m_radius > npix or \
+                npix/2.+self.m_guess[1]+self.m_radius > npix or \
+                npix/2.+self.m_guess[1]-self.m_radius < 0. or \
+                npix/2.+self.m_guess[1]-self.m_radius < 0.:
+            raise ValueError("Mask radius extends beyond the size of the image.")
 
         frames = memory_frames(memory, nimages)
 
@@ -565,13 +596,19 @@ class StarCenteringModule(ProcessingModule):
             print "2D Gaussian fit could not converge on %s images. [WARNING]\n" % self.m_count
 
         self.m_image_out_port.add_history_information("Centering", "2D Gaussian fit")
-        self.m_fit_out_port.add_history_information("Centering", "2D Gaussian fit")
         self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
+
+        self.m_fit_out_port.add_history_information("Centering", "2D Gaussian fit")
         self.m_fit_out_port.copy_attributes_from_input_port(self.m_image_in_port)
+
+        if self.m_mask_out_port is not None:
+            self.m_mask_out_port.add_history_information("Centering", "2D Gaussian fit")
+            self.m_mask_out_port.copy_attributes_from_input_port(self.m_image_in_port)
+
         self.m_image_out_port.close_port()
 
 
-class ShiftForCenteringModule(ProcessingModule):
+class ShiftImagesModule(ProcessingModule):
     """
     Module for shifting of an image.
     """
@@ -582,9 +619,9 @@ class ShiftForCenteringModule(ProcessingModule):
                  image_in_tag="im_arr",
                  image_out_tag="im_arr_shifted"):
         """
-        Constructor of ShiftForCenteringModule.
+        Constructor of ShiftImagesModule.
 
-        :param shift_xy: Tuple (delta_x, delta_y) with the shift in both directions.
+        :param shift_xy: Tuple (delta_x, delta_y) with the shift (pix) in both directions.
         :type shift_xy: tuple, float
         :param name_in: Unique name of the module instance.
         :type name_in: str
@@ -597,7 +634,7 @@ class ShiftForCenteringModule(ProcessingModule):
         :return: None
         """
 
-        super(ShiftForCenteringModule, self).__init__(name_in=name_in)
+        super(ShiftImagesModule, self).__init__(name_in=name_in)
 
         self.m_image_in_port = self.add_input_port(image_in_tag)
         self.m_image_out_port = self.add_output_port(image_out_tag)
@@ -617,8 +654,8 @@ class ShiftForCenteringModule(ProcessingModule):
         self.apply_function_to_images(image_shift,
                                       self.m_image_in_port,
                                       self.m_image_out_port,
-                                      "Running ShiftForCenteringModule...")
+                                      "Running ShiftImagesModule...")
 
-        self.m_image_out_port.add_history_information("Shifted", str(self.m_shift))
+        self.m_image_out_port.add_history_information("Images shifted", str(self.m_shift))
         self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
         self.m_image_out_port.close_port()

--- a/PynPoint/ProcessingModules/__init__.py
+++ b/PynPoint/ProcessingModules/__init__.py
@@ -8,7 +8,7 @@ from PSFSubtractionPCA import PSFSubtractionModule, PcaPsfSubtractionModule
 from StackingAndSubsampling import StackAndSubsetModule, MeanCubeModule, DerotateAndStackModule, \
                                    CombineTagsModule
 from StarAlignment import StarAlignmentModule, StarExtractionModule, StarCenteringModule, \
-                          ShiftForCenteringModule
+                          ShiftImagesModule
 from ImageResizing import CropImagesModule, ScaleImagesModule, AddLinesModule, RemoveLinesModule
 from PSFpreparation import PSFpreparationModule, AngleInterpolationModule, AngleCalculationModule, \
                           SortParangModule, SDIpreparationModule

--- a/PynPoint/Util/ModuleTools.py
+++ b/PynPoint/Util/ModuleTools.py
@@ -1,0 +1,27 @@
+import sys
+
+import numpy as np
+
+
+def progress(current, total, message):
+    fraction = float(current)/float(total)
+    percentage = round(fraction*100., 1)
+
+    sys.stdout.write("%s %s%s \r" % (message, percentage, "%"))
+    sys.stdout.flush()
+
+def memory_frames(memory, nimages):
+    if memory == 0 or memory >= nimages:
+        frames = [0, nimages]
+
+    else:
+        frames = np.linspace(0,
+                             nimages-nimages%memory,
+                             int(float(nimages)/float(memory))+1,
+                             endpoint=True,
+                             dtype=np.int)
+
+        if nimages%memory > 0:
+            frames = np.append(frames, nimages)
+
+    return frames

--- a/PynPoint/Util/Progress.py
+++ b/PynPoint/Util/Progress.py
@@ -1,8 +1,0 @@
-import sys
-
-def progress(current, total, message):
-    fraction = float(current)/float(total)
-    percentage = round(fraction*100., 1)
-
-    sys.stdout.write("%s %s%s \r" % (message, percentage, "%"))
-    sys.stdout.flush()

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,9 @@ PynPoint
 .. image:: https://codecov.io/gh/PynPoint/PynPoint/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/PynPoint/PynPoint
 
+.. image:: https://www.codefactor.io/repository/github/pynpoint/pynpoint/badge
+    :target: https://www.codefactor.io/repository/github/pynpoint/pynpoint
+
 .. image:: https://readthedocs.org/projects/pynpoint/badge/?version=latest
     :target: http://pynpoint.readthedocs.io/en/latest/?badge=latest
 

--- a/docs/PynPoint.Util.rst
+++ b/docs/PynPoint.Util.rst
@@ -12,6 +12,14 @@ PynPoint.Util.CWT module
     :undoc-members:
     :show-inheritance:
 
+PynPoint.Util.ModuleTools module
+--------------------------------
+
+.. automodule:: PynPoint.Util.ModuleTools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 PynPoint.Util.Multiprocessing module
 ------------------------------------
 
@@ -24,14 +32,6 @@ PynPoint.Util.MultiprocessingPCA module
 ---------------------------------------
 
 .. automodule:: PynPoint.Util.MultiprocessingPCA
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-PynPoint.Util.Progress module
------------------------------
-
-.. automodule:: PynPoint.Util.Progress
     :members:
     :undoc-members:
     :show-inheritance:

--- a/tests/test_processing/test_StarAlignment.py
+++ b/tests/test_processing/test_StarAlignment.py
@@ -10,7 +10,7 @@ from PynPoint import Pypeline
 from PynPoint.Core.DataIO import DataStorage
 from PynPoint.IOmodules.FitsReading import FitsReadingModule
 from PynPoint.ProcessingModules.StarAlignment import StarExtractionModule, StarAlignmentModule, \
-                                                     ShiftForCenteringModule, StarCenteringModule
+                                                     ShiftImagesModule, StarCenteringModule
 
 warnings.simplefilter("always")
 
@@ -120,19 +120,22 @@ class TestStarAlignment(object):
 
         self.pipeline.add_module(align)
 
-        shift = ShiftForCenteringModule((6., 4.),
-                                        name_in="shift",
-                                        image_in_tag="align",
-                                        image_out_tag="shift")
+        shift = ShiftImagesModule((6., 4.),
+                                  name_in="shift",
+                                  image_in_tag="align",
+                                  image_out_tag="shift")
 
         self.pipeline.add_module(shift)
 
         center = StarCenteringModule(name_in="center",
                                      image_in_tag="shift",
                                      image_out_tag="center",
+                                     mask_out_tag=None,
                                      fit_out_tag="center_fit",
                                      method="full",
                                      interpolation="spline",
+                                     radius=0.1,
+                                     sign="positive",
                                      guess=(6., 4., 1., 1., 1., 0.))
 
         self.pipeline.add_module(center)
@@ -159,6 +162,6 @@ class TestStarAlignment(object):
 
         data = storage.m_data_bank["center"]
         assert np.allclose(data[0, 10, 10], 4.128859892625027e-05, rtol=1e-4, atol=0.)
-        assert np.allclose(np.mean(data), 0.0005163769620309259, rtol=1e-7, atol=0.)
+        assert np.allclose(np.mean(data), 0.0005163806188663894, rtol=1e-7, atol=0.)
 
         storage.close_connection()


### PR DESCRIPTION
- Renamed ShiftForCenteringModule to ShiftImagesModule
- Updated codecov.yml
- Added Util.ModuleTools which contains small functions that a regularly used by IO and/or processing modules
- Improved the implementation of the StarCenteringModule. The _radius_ parameter can no longer be set to *None* and is used to select a subset of pixels to which the 2D Gaussian is fitted. Setting _sign="negative"_ works fine now on AGPM-like data, as long as there is a clear minimum at the coronagraph position.