### PR TITLE
Small fixes in module descriptions and AddLinesModule

### DIFF
--- a/PynPoint/ProcessingModules/BackgroundSubtraction.py
+++ b/PynPoint/ProcessingModules/BackgroundSubtraction.py
@@ -284,7 +284,7 @@ class PCABackgroundPreparationModule(ProcessingModule):
                        first cube which contains the star (Python indexing starts at zero). Sorting
                        is based on the DITHER_X and DITHER_Y attributes  when *cubes_per_position*
                        is set to None.
-        :type select: tuple
+        :type dither: tuple
         :param mean: Subtract the mean pixel value from each image separately, both star and
                      background frames.
         :type mean: bool

--- a/PynPoint/ProcessingModules/ImageResizing.py
+++ b/PynPoint/ProcessingModules/ImageResizing.py
@@ -225,16 +225,17 @@ class AddLinesModule(ProcessingModule):
         """
 
         shape_in = self.m_image_in_port.get_shape()
+        ndim_in = self.m_image_in_port.get_ndim()
 
         if any(np.asarray(self.m_lines) < 0.):
             raise ValueError("The lines argument should contain values equal to or larger than "
                              "zero.")
 
-        if len(shape_in) == 3:
+        if ndim_in == 3:
             shape_out = (shape_in[1]+int(self.m_lines[2])+int(self.m_lines[3]),
                          shape_in[2]+int(self.m_lines[0])+int(self.m_lines[1]))
 
-        elif len(shape_in) == 2:
+        elif ndim_in == 2:
             shape_out = (shape_in[0]+int(self.m_lines[2])+int(self.m_lines[3]),
                          shape_in[1]+int(self.m_lines[0])+int(self.m_lines[1]))
 

--- a/PynPoint/ProcessingModules/ImageResizing.py
+++ b/PynPoint/ProcessingModules/ImageResizing.py
@@ -230,11 +230,11 @@ class AddLinesModule(ProcessingModule):
             raise ValueError("The lines argument should contain values equal to or larger than "
                              "zero.")
 
-        if shape_in.ndim == 3:
+        if len(shape_in) == 3:
             shape_out = (shape_in[1]+int(self.m_lines[2])+int(self.m_lines[3]),
                          shape_in[2]+int(self.m_lines[0])+int(self.m_lines[1]))
 
-        elif shape_in.ndim == 2:
+        elif len(shape_in) == 2:
             shape_out = (shape_in[0]+int(self.m_lines[2])+int(self.m_lines[3]),
                          shape_in[1]+int(self.m_lines[0])+int(self.m_lines[1]))
 

--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -373,9 +373,9 @@ class StarCenteringModule(ProcessingModule):
                             x offset (arcsec), x offset error (arcsec), y offset (arcsec), y offset
                             error (arcsec), FWHM major axis (arcsec), FWHM major axis error
                             (arcsec), FWHM minor axis (arcsec), FWHM minor axis error
-                            (arcsec), amplitude (counts), amplitude error (counts), angle (deg)
-                            measured in counterclockwise direction with respect to the upward
-                            direction (i.e., East of North).
+                            (arcsec), amplitude (counts), amplitude error (counts), angle (deg),
+                            angle error (deg) measured in counterclockwise direction with respect
+                            to the upward direction (i.e., East of North).
         :type fit_out_tag: str
         :param method: Fit and shift all the images individually ("full") or only fit the mean of
                        the cube and shift all images to that location ("mean"). The "mean" method


### PR DESCRIPTION
- 2 small changes in module description

- AddLinesModule did not work since .ndim could not be used to calculate the dimension of a tuple.