### PR TITLE
Fix in StarExtract

### DIFF
--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -117,6 +117,12 @@ class StarExtractionModule(ProcessingModule):
             if self.m_position is None:
                 subimage = image
 
+            elif self.m_position[2] is None:
+                pos_x = self.m_position[0]
+                pos_y = self.m_position[1]
+                subimage = image
+                width = np.shape(image)[0]
+
             else:
                 if self.m_position.ndim == 1:
                     pos_x = self.m_position[0]


### PR DESCRIPTION
- When using FrameSelectionModule with position=None, the StarExtractionModule is called, with the position parameter (pos_x, pos_y, None). This case, where the aperture size is none but the position In pixels is given was not considered. 