### PR TITLE
several small updates

### DIFF
--- a/PynPoint/Core/DataIO.py
+++ b/PynPoint/Core/DataIO.py
@@ -223,7 +223,7 @@ class ConfigPort(Port):
             return False
 
         if self._check_if_data_exists() is False:
-            warnings.warn("No data under the tag which is linked by the InputPort")
+            warnings.warn("No data under the tag which is linked by the InputPort.")
             return False
 
         return True
@@ -246,7 +246,7 @@ class ConfigPort(Port):
         if name in self._m_data_storage.m_data_bank["config"].attrs:
             return self._m_data_storage.m_data_bank["config"].attrs[name]
 
-        warnings.warn('No attribute found - requested: %s' % name)
+        warnings.warn('No attribute found - requested: %s.' % name)
 
         return None
 
@@ -319,7 +319,7 @@ class InputPort(Port):
         """
 
         if self._m_data_storage is None:
-            warnings.warn("InputPort can not load data unless a database is connected")
+            warnings.warn("InputPort can not load data unless a database is connected.")
             return False
 
         if not self._m_data_base_active:
@@ -343,7 +343,7 @@ class InputPort(Port):
             return False
 
         if self._check_if_data_exists() is False:
-            warnings.warn("No data under the tag which is linked by the InputPort")
+            warnings.warn("No data under the tag which is linked by the InputPort.")
             return False
 
         return True

--- a/PynPoint/ProcessingModules/DetectionLimits.py
+++ b/PynPoint/ProcessingModules/DetectionLimits.py
@@ -93,10 +93,10 @@ class ContrastCurveModule(ProcessingModule):
         :type pca_number: int
         :param norm: Normalization of each image by its Frobenius norm.
         :type norm: bool
-        :param cent_size: Radius of the central mask (arcsec). No mask is used when set to None.
+        :param cent_size: Central mask radius (arcsec). No mask is used when set to None.
         :type cent_size: float
-        :param edge_size: Outer radius (arcsec) beyond which pixels are masked. No outer mask is
-                          used when set to None. If the value is larger than half the image size
+        :param edge_size: Outer edge radius (arcsec) beyond which pixels are masked. No outer mask
+                          is used when set to None. If the value is larger than half the image size
                           then it will be set to half the image size.
         :type edge_size: float
         :param extra_rot: Additional rotation angle of the images in clockwise direction (deg).
@@ -219,7 +219,11 @@ class ContrastCurveModule(ProcessingModule):
                           self.m_angle[1]+self.m_extra_rot,
                           self.m_angle[2])
 
-        index_del = np.argwhere(pos_r-self.m_aperture <= self.m_cent_size/pixscale)
+        if self.m_cent_size is None:
+            index_del = np.argwhere(pos_r-self.m_aperture <= 0.)
+        else:
+            index_del = np.argwhere(pos_r-self.m_aperture <= self.m_cent_size/pixscale)
+
         pos_r = np.delete(pos_r, index_del)
 
         if self.m_edge_size is None:

--- a/PynPoint/ProcessingModules/DetectionLimits.py
+++ b/PynPoint/ProcessingModules/DetectionLimits.py
@@ -39,7 +39,9 @@ class ContrastCurveModule(ProcessingModule):
                  aperture=0.05,
                  ignore=False,
                  pca_number=20,
-                 mask=0.,
+                 norm=False,
+                 cent_size=None,
+                 edge_size=None,
                  extra_rot=0.):
         """
         Constructor of ContrastCurveModule.
@@ -89,8 +91,14 @@ class ContrastCurveModule(ProcessingModule):
         :type ignore: bool
         :param pca_number: Number of principle components used for the PSF subtraction.
         :type pca_number: int
-        :param mask: Mask radius (arcsec) for the PSF subtraction.
-        :type mask: float
+        :param norm: Normalization of each image by its Frobenius norm.
+        :type norm: bool
+        :param cent_size: Radius of the central mask (arcsec). No mask is used when set to None.
+        :type cent_size: float
+        :param edge_size: Outer radius (arcsec) beyond which pixels are masked. No outer mask is
+                          used when set to None. If the value is larger than half the image size
+                          then it will be set to half the image size.
+        :type edge_size: float
         :param extra_rot: Additional rotation angle of the images in clockwise direction (deg).
         :type extra_rot: float
 
@@ -120,7 +128,9 @@ class ContrastCurveModule(ProcessingModule):
         self.m_aperture = aperture
         self.m_ignore = ignore
         self.m_pca_number = pca_number
-        self.m_mask = mask
+        self.m_norm = norm
+        self.m_cent_size = cent_size
+        self.m_edge_size = edge_size
         self.m_extra_rot = extra_rot
 
     def _false_alarm(self,
@@ -194,7 +204,6 @@ class ContrastCurveModule(ProcessingModule):
         pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
 
         self.m_aperture /= pixscale
-        self.m_mask /= pixscale
 
         if psf.ndim == 3 and psf.shape[0] != images.shape[0]:
             warnings.warn('The number of frames in psf_in_tag does not match with the number of '
@@ -210,10 +219,14 @@ class ContrastCurveModule(ProcessingModule):
                           self.m_angle[1]+self.m_extra_rot,
                           self.m_angle[2])
 
-        index_del = np.argwhere(pos_r-self.m_aperture <= self.m_mask)
+        index_del = np.argwhere(pos_r-self.m_aperture <= self.m_cent_size/pixscale)
         pos_r = np.delete(pos_r, index_del)
 
-        index_del = np.argwhere(pos_r+self.m_aperture >= images.shape[1]/2.)
+        if self.m_edge_size is None:
+            index_del = np.argwhere(pos_r+self.m_aperture >= images.shape[1]/2.)
+        else:
+            index_del = np.argwhere(pos_r+self.m_aperture >= self.m_edge_size/pixscale)
+
         pos_r = np.delete(pos_r, index_del)
 
         fake_mag = np.zeros((len(pos_r), len(pos_t)))
@@ -272,10 +285,10 @@ class ContrastCurveModule(ProcessingModule):
                                                 image_out_tag="contrast_prep",
                                                 image_mask_out_tag=None,
                                                 mask_out_tag=None,
-                                                norm=True,
+                                                norm=self.m_norm,
                                                 resize=None,
-                                                cent_size=self.m_mask*pixscale,
-                                                edge_size=1e10,
+                                                cent_size=self.m_cent_size,
+                                                edge_size=self.m_edge_size,
                                                 verbose=False)
 
                     prep.connect_database(self._m_data_base)

--- a/PynPoint/ProcessingModules/DetectionLimits.py
+++ b/PynPoint/ProcessingModules/DetectionLimits.py
@@ -226,7 +226,7 @@ class ContrastCurveModule(ProcessingModule):
 
         pos_r = np.delete(pos_r, index_del)
 
-        if self.m_edge_size is None:
+        if self.m_edge_size is None or self.m_edge_size/pixscale > images.shape[1]/2.:
             index_del = np.argwhere(pos_r+self.m_aperture >= images.shape[1]/2.)
         else:
             index_del = np.argwhere(pos_r+self.m_aperture >= self.m_edge_size/pixscale)

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -241,7 +241,8 @@ class SimplexMinimizationModule(ProcessingModule):
                  sigma=0.027,
                  tolerance=0.1,
                  pca_number=20,
-                 mask=0.,
+                 cent_size=None,
+                 edge_size=None,
                  extra_rot=0.):
         """
         Constructor of SimplexMinimizationModule.
@@ -295,8 +296,12 @@ class SimplexMinimizationModule(ProcessingModule):
         :type tolerance: float
         :param pca_number: Number of principle components used for the PSF subtraction.
         :type pca_number: int
-        :param mask: Mask radius (arcsec) for the PSF subtraction.
-        :type mask: float
+        :param cent_size: Radius of the central mask (arcsec). No mask is used when set to None.
+        :type cent_size: float
+        :param edge_size: Outer radius (arcsec) beyond which pixels are masked. No outer mask is
+                          used when set to None. If the value is larger than half the image size
+                          then it will be set to half the image size.
+        :type edge_size: float
         :param extra_rot: Additional rotation angle of the images in clockwise direction (deg).
         :type extra_rot: float
 
@@ -321,7 +326,8 @@ class SimplexMinimizationModule(ProcessingModule):
         self.m_sigma = sigma
         self.m_tolerance = tolerance
         self.m_pca_number = pca_number
-        self.m_mask = mask
+        self.m_cent_size = cent_size
+        self.m_edge_size = edge_size
         self.m_extra_rot = extra_rot
 
         self.m_image_in_tag = image_in_tag
@@ -377,8 +383,8 @@ class SimplexMinimizationModule(ProcessingModule):
                                         image_mask_out_tag=None,
                                         mask_out_tag=None,
                                         norm=False,
-                                        cent_size=self.m_mask,
-                                        edge_size=1e10,
+                                        cent_size=self.m_cent_size,
+                                        edge_size=self.m_edge_size,
                                         verbose=False)
 
             prep.connect_database(self._m_data_base)
@@ -476,12 +482,12 @@ class SimplexMinimizationModule(ProcessingModule):
             raise ValueError("The image_in_tag should contain a cube of images.")
 
         if ndim_psf == 2:
-            psf_size = (self.m_image_in_port.get_shape()[0],
-                        self.m_image_in_port.get_shape()[1])
+            psf_size = (self.m_psf_in_port.get_shape()[0],
+                        self.m_psf_in_port.get_shape()[1])
 
         elif ndim_psf == 3:
-            psf_size = (self.m_image_in_port.get_shape()[1],
-                        self.m_image_in_port.get_shape()[2])
+            psf_size = (self.m_psf_in_port.get_shape()[1],
+                        self.m_psf_in_port.get_shape()[2])
 
         center = (psf_size[0]/2., psf_size[1]/2.)
 

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -299,8 +299,8 @@ class SimplexMinimizationModule(ProcessingModule):
         :param cent_size: Radius of the central mask (arcsec). No mask is used when set to None.
         :type cent_size: float
         :param edge_size: Outer radius (arcsec) beyond which pixels are masked. No outer mask is
-                          used when set to None. If the value is larger than half the image size
-                          then it will be set to half the image size.
+                          used when set to None. The radius will be set to half the image size if
+                          the *edge_size* value is larger than half the image size.
         :type edge_size: float
         :param extra_rot: Additional rotation angle of the images in clockwise direction (deg).
         :type extra_rot: float

--- a/PynPoint/ProcessingModules/FrameSelection.py
+++ b/PynPoint/ProcessingModules/FrameSelection.py
@@ -94,7 +94,7 @@ class RemoveFramesModule(ProcessingModule):
 
     def _write_attributes(self):
         if "INDEX" not in self.m_image_in_port.get_all_non_static_attributes():
-            raise ValueError("The INDEX attributes is not found.")
+            raise ValueError("The INDEX attribute is not found.")
 
         index = self.m_image_in_port.get_attribute("INDEX")
 

--- a/PynPoint/ProcessingModules/PSFSubtractionPCA.py
+++ b/PynPoint/ProcessingModules/PSFSubtractionPCA.py
@@ -53,16 +53,15 @@ class PSFSubtractionModule(ProcessingModule):
         :param reference_in_tag: Tag of the database entry with the reference images that are
                                  read as input.
         :type reference_in_tag: str
-        :param res_arr_out_tag: Tag of the database entry with the image residuals from the PSF
-                                subtraction.
+        :param res_arr_out_tag: Tag of the database entry with the image residuals.
         :type res_arr_out_tag: str
         :param res_arr_rot_out_tag: Tag of the database entry with the image residuals from the
                                     PSF subtraction that are rotated by PARANG to a common
                                     orientation.
         :type res_arr_rot_out_tag: str
-        :param res_mean_tag: Tag of the database entry with the mean collapsed residuals.
+        :param res_mean_tag: Tag of the database entry with the mean combined residuals.
         :type res_mean_tag: str
-        :param res_median_tag: Tag of the database entry with the median collapsed residuals.
+        :param res_median_tag: Tag of the database entry with the median combined residuals.
         :type res_median_tag: str
         :param res_var_tag: Tag of the database entry with the variance of the pixel values across
                             the stack of residuals.

--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -368,7 +368,8 @@ class StarCenteringModule(ProcessingModule):
         :param image_in_tag: Tag of the database entry with images that are read as input.
         :type image_in_tag: str
         :param image_out_tag: Tag of the database entry with the centered images that are written
-                              as output. Should be different from *image_in_tag*.
+                              as output. Should be different from *image_in_tag*. Data is not
+                              written when set to *None*.
         :type image_out_tag: str
         :param mask_out_tag: Tag of the database entry with the masked images that are written as
                              output. The unmasked part of the images is used for the fit. Data is
@@ -417,7 +418,10 @@ class StarCenteringModule(ProcessingModule):
         super(StarCenteringModule, self).__init__(name_in)
 
         self.m_image_in_port = self.add_input_port(image_in_tag)
-        self.m_image_out_port = self.add_output_port(image_out_tag)
+        if image_out_tag is None:
+            self.m_image_out_port = None
+        else:
+            self.m_image_out_port = self.add_output_port(image_out_tag)
         if mask_out_tag is None:
             self.m_mask_out_port = None
         else:
@@ -536,8 +540,9 @@ class StarCenteringModule(ProcessingModule):
 
             return im_center
 
-        self.m_image_out_port.del_all_data()
-        self.m_image_out_port.del_all_attributes()
+        if self.m_image_out_port is not None:
+            self.m_image_out_port.del_all_data()
+            self.m_image_out_port.del_all_attributes()
 
         self.m_fit_out_port.del_all_data()
         self.m_fit_out_port.del_all_attributes()
@@ -595,8 +600,9 @@ class StarCenteringModule(ProcessingModule):
         if self.m_count > 0:
             print "2D Gaussian fit could not converge on %s image(s). [WARNING]" % self.m_count
 
-        self.m_image_out_port.add_history_information("Centering", "2D Gaussian fit")
-        self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
+        if self.m_mask_out_port is not None:
+            self.m_image_out_port.add_history_information("Centering", "2D Gaussian fit")
+            self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
 
         self.m_fit_out_port.add_history_information("Centering", "2D Gaussian fit")
         self.m_fit_out_port.copy_attributes_from_input_port(self.m_image_in_port)
@@ -605,7 +611,7 @@ class StarCenteringModule(ProcessingModule):
             self.m_mask_out_port.add_history_information("Centering", "2D Gaussian fit")
             self.m_mask_out_port.copy_attributes_from_input_port(self.m_image_in_port)
 
-        self.m_image_out_port.close_port()
+        self.m_fit_out_port.close_port()
 
 
 class ShiftImagesModule(ProcessingModule):


### PR DESCRIPTION
- norm, cent_size and edge_size parameters in ContrastCurveModule
- cent_size and edge_size parameters in SimplexMinimizationModule
- image_out_tag can be set to None in StarCenteringModule, e.g. when only the fit results are needed and images do not have to be shifted