### PR TITLE
planet mask in PCABackgroundSubtractionModule

### DIFF
--- a/PynPoint/Core/Pypeline.py
+++ b/PynPoint/Core/Pypeline.py
@@ -404,18 +404,27 @@ class Pypeline(object):
 
     def get_attribute(self,
                       data_tag,
-                      attr_name):
+                      attr_name,
+                      static=True):
         """
-        Function for accessing static attributes in the central database.
+        Function for accessing attributes in the central database.
 
         :param data_tag: Database tag.
         :type data_tag: str
-        :param attr_name: Name of the static attribute.
+        :param attr_name: Name of the attribute.
         :type attr_name: str
+        :param static: Static or non-static attribute.
+        :type static: bool
 
         :return: The attribute value(s).
         """
 
         self.m_data_storage.open_connection()
 
-        return self.m_data_storage.m_data_bank[data_tag].attrs[attr_name]
+        if static:
+            attr = self.m_data_storage.m_data_bank[data_tag].attrs[attr_name]
+
+        else:
+            attr = self.m_data_storage.m_data_bank["header_"+data_tag+"/"+attr_name]
+
+        return attr

--- a/PynPoint/ProcessingModules/BackgroundSubtraction.py
+++ b/PynPoint/ProcessingModules/BackgroundSubtraction.py
@@ -279,11 +279,11 @@ class PCABackgroundPreparationModule(ProcessingModule):
 
         :param dither: Tuple with the parameters for separating the star and background frames.
                        The tuple should contain three values (positions, cubes, first) with
-                       *dither* the number of unique dithering position, *cubes* the number of
+                       *positions* the number of unique dithering position, *cubes* the number of
                        consecutive cubes per dithering position, and *first* the index value of the
                        first cube which contains the star (Python indexing starts at zero). Sorting
-                       is based on the DITHER_X and DITHER_Y attributes  when *cubes_per_position*
-                       is set to None.
+                       is based on the DITHER_X and DITHER_Y attributes when *cubes* is set to
+                       None.
         :type dither: tuple
         :param mean: Subtract the mean pixel value from each image separately, both star and
                      background frames.

--- a/PynPoint/ProcessingModules/BackgroundSubtraction.py
+++ b/PynPoint/ProcessingModules/BackgroundSubtraction.py
@@ -508,31 +508,41 @@ class PCABackgroundSubtractionModule(ProcessingModule):
 
     def __init__(self,
                  pca_number=60,
-                 mask=0.7,
+                 mask_star=0.7,
+                 mask_planet=None,
                  name_in="pca_background",
                  star_in_tag="im_star",
                  background_in_tag="im_background",
-                 subtracted_out_tag="background_subtracted",
-                 residuals_out_tag=None):
+                 residuals_out_tag="background_subtracted",
+                 fit_out_tag=None,
+                 mask_out_tag=None):
         """
         Constructor of PCABackgroundSubtractionModule.
 
         :param pca_number: Number of principle components.
         :type pca_number: int
-        :param mask: Radius of the mask (arcsec).
-        :type mask: float
+        :param mask_star: Radius of the central mask (arcsec).
+        :type mask_star: float
+        :param mask_planet: Separation (arcsec), position angle (deg) measured in counterclockwise
+                            direction with respect to upward direction, additional rotation angle
+                            (deg), and radius (arcsec) of the mask, (sep, angle, extra_rot,
+                            radius). No mask is used when set to None.
+        :type mask_planet: tuple(float, float, float, float)
         :param name_in: Unique name of the module instance.
         :type name_in: str
-        :param star_in_tag: Tag of the input database entry with star frames.
+        :param star_in_tag: Tag of the database entry with the star images.
         :type star_in_tag: str
-        :param background_in_tag: Tag of the input database entry with the background frames.
+        :param background_in_tag: Tag of the database entry with the background images.
         :type background_in_tag: str
-        :param subtracted_out_tag: Tag of the output database entry with the background
-                                   subtracted star frames.
-        :type subtracted_out_tag: str
-        :param residuals_out_tag: Tag of the output database entry with the residuals of the
-                                  background subtraction.
+        :param residuals_out_tag: Tag of the database entry with the residuals of the star images
+                                  after the background subtraction.
         :type residuals_out_tag: str
+        :param fit_out_tag: Tag of the database entry with the fitted background. No data is
+                            written when set to None.
+        :type fit_out_tag: str
+        :param mask_out_tag: Tag of the database entry with the mask. No data is written when set
+                             to None.
+        :type mask_out_tag: str
 
         :return: None
         """
@@ -541,44 +551,52 @@ class PCABackgroundSubtractionModule(ProcessingModule):
 
         self.m_star_in_port = self.add_input_port(star_in_tag)
         self.m_background_in_port = self.add_input_port(background_in_tag)
-        self.m_subtracted_out_port = self.add_output_port(subtracted_out_tag)
-        if residuals_out_tag is not None:
-            self.m_residuals_out_port = self.add_output_port(residuals_out_tag)
+        self.m_residuals_out_port = self.add_output_port(residuals_out_tag)
+
+        if fit_out_tag is None:
+            self.m_fit_out_port = None
+        else:
+            self.m_fit_out_port = self.add_output_port(fit_out_tag)
+
+        if mask_out_tag is None:
+            self.m_mask_out_port = None
+        else:
+            self.m_mask_out_port = self.add_output_port(mask_out_tag)
 
         self.m_pca_number = pca_number
-        self.m_mask = mask
-        self.m_residuals_out_tag = residuals_out_tag
+        self.m_mask_star = mask_star
+        self.m_mask_planet = mask_planet
 
     def run(self):
         """
         Run method of the module. Creates a PCA basis set of the background frames, masks the PSF
-        in the star frames, fits the star frames with a linear combination of the principle
-        components, and writes the background subtracted star frames and the background residuals
-        that are subtracted.
+        in the star frames and optionally an off-axis point source, fits the star frames with a
+        linear combination of the principle components, and writes the residuals of the background
+        subtracted images.
 
         :return: None
         """
 
-        def _create_mask(mask_radius, star_position, num_frames):
+        def _create_mask(radius, position, nimages):
             """
-            Method for creating a circular mask at the star position.
+            Method for creating a circular mask at the star or planet position.
             """
 
-            im_dim = self.m_star_in_port[0, ].shape
+            npix = self.m_star_in_port.get_shape()[1]
 
-            x_grid = np.arange(0, im_dim[0], 1)
-            y_grid = np.arange(0, im_dim[1], 1)
+            x_grid = np.arange(0, npix, 1)
+            y_grid = np.arange(0, npix, 1)
 
             xx_grid, yy_grid = np.meshgrid(x_grid, y_grid)
 
-            mask = np.ones((num_frames, im_dim[0], im_dim[1]))
+            mask = np.ones((nimages, npix, npix))
 
-            cent_x = star_position[:, 0]
-            cent_y = star_position[:, 1]
+            cent_x = position[:, 1]
+            cent_y = position[:, 0]
 
-            for i in range(num_frames):
+            for i in range(nimages):
                 rr_grid = np.sqrt((xx_grid - cent_x[i])**2 + (yy_grid - cent_y[i])**2)
-                mask[i, ][rr_grid < mask_radius] = 0.
+                mask[i, ][rr_grid < radius] = 0.
 
             return mask
 
@@ -630,22 +648,34 @@ class PCABackgroundSubtractionModule(ProcessingModule):
 
             return fit_im_chi
 
-        self.m_subtracted_out_port.del_all_data()
-        self.m_subtracted_out_port.del_all_attributes()
+        self.m_residuals_out_port.del_all_data()
+        self.m_residuals_out_port.del_all_attributes()
 
-        if self.m_residuals_out_tag is not None:
-            self.m_residuals_out_port.del_all_data()
-            self.m_residuals_out_port.del_all_attributes()
+        if self.m_fit_out_port is not None:
+            self.m_fit_out_port.del_all_data()
+            self.m_fit_out_port.del_all_attributes()
+
+        if self.m_mask_out_port is not None:
+            self.m_mask_out_port.del_all_data()
+            self.m_mask_out_port.del_all_attributes()
 
         memory = self._m_config_port.get_attribute("MEMORY")
         pixscale = self.m_star_in_port.get_attribute("PIXSCALE")
         star = self.m_star_in_port.get_attribute("STAR_POSITION")
 
-        self.m_mask /= pixscale
+        self.m_mask_star /= pixscale
+
+        if self.m_mask_planet is not None:
+            parang = self.m_star_in_port.get_attribute("PARANG")
+
+            self.m_mask_planet = np.asarray(self.m_mask_planet)
+
+            self.m_mask_planet[0] /= pixscale
+            self.m_mask_planet[3] /= pixscale
 
         sys.stdout.write("Creating PCA basis set...")
         sys.stdout.flush()
-
+        
         basis_pca = _create_basis(self.m_background_in_port.get_all(),
                                   self.m_pca_number)
 
@@ -661,27 +691,58 @@ class PCABackgroundSubtractionModule(ProcessingModule):
 
             im_star = self.m_star_in_port[frames[i]:frames[i+1], ]
 
-            mask = _create_mask(self.m_mask,
-                                star[frames[i]:frames[i+1], ],
-                                frames[i+1]-frames[i])
+            mask_star = _create_mask(self.m_mask_star,
+                                     star[frames[i]:frames[i+1], ],
+                                     frames[i+1]-frames[i])
 
-            fit_im = _model_background(basis_pca, im_star*mask, mask)
+            if self.m_mask_planet is None:
+                mask_planet = np.ones(im_star.shape)
 
-            self.m_subtracted_out_port.append(im_star-fit_im)
-            if self.m_residuals_out_tag is not None:
-                self.m_residuals_out_port.append(fit_im)
+            else:
+                npix = im_star.shape[1]
+
+                cent_x = star[frames[i]:frames[i+1], 1]
+                cent_y = star[frames[i]:frames[i+1], 0]
+
+                theta = np.radians(self.m_mask_planet[1] + 90. - \
+                            parang[frames[i]:frames[i+1]] + self.m_mask_planet[2])
+
+                x_planet = self.m_mask_planet[0]*np.cos(theta) + cent_x
+                y_planet = self.m_mask_planet[0]*np.sin(theta) + cent_y
+
+                planet = np.stack((y_planet, x_planet))
+
+                mask_planet = _create_mask(self.m_mask_planet[3],
+                                           np.transpose(planet),
+                                           frames[i+1]-frames[i])
+
+            fit_im = _model_background(basis_pca,
+                                       im_star*mask_star*mask_planet,
+                                       mask_star*mask_planet)
+
+            self.m_residuals_out_port.append(im_star-fit_im)
+
+            if self.m_fit_out_port is not None:
+                self.m_fit_out_port.append(fit_im)
+
+            if self.m_mask_out_port is not None:
+                self.m_mask_out_port.append(mask_star*mask_planet)
 
         sys.stdout.write("Calculating background model... [DONE]\n")
         sys.stdout.flush()
 
-        self.m_subtracted_out_port.copy_attributes_from_input_port(self.m_star_in_port)
-        self.m_subtracted_out_port.add_history_information("Background subtraction", "PCA")
+        self.m_residuals_out_port.copy_attributes_from_input_port(self.m_star_in_port)
+        self.m_residuals_out_port.add_history_information("Background subtraction", "PCA")
 
-        if self.m_residuals_out_tag is not None:
-            self.m_residuals_out_port.copy_attributes_from_input_port(self.m_star_in_port)
-            self.m_residuals_out_port.add_history_information("Background subtraction", "PCA")
+        if self.m_fit_out_port is not None:
+            self.m_fit_out_port.copy_attributes_from_input_port(self.m_star_in_port)
+            self.m_fit_out_port.add_history_information("Background subtraction", "PCA")
 
-        self.m_subtracted_out_port.close_port()
+        if self.m_mask_out_port is not None:
+            self.m_mask_out_port.copy_attributes_from_input_port(self.m_star_in_port)
+            self.m_mask_out_port.add_history_information("Background subtraction", "PCA")
+
+        self.m_residuals_out_port.close_port()
 
 
 class DitheringBackgroundModule(ProcessingModule):
@@ -700,7 +761,7 @@ class DitheringBackgroundModule(ProcessingModule):
                  gaussian=0.15,
                  subframe=None,
                  pca_number=60,
-                 mask=0.7,
+                 mask_star=0.7,
                  **kwargs):
         """
         Constructor of DitheringBackgroundModule.
@@ -735,21 +796,24 @@ class DitheringBackgroundModule(ProcessingModule):
         :type subframe: float
         :param pca_number: Number of principle components.
         :type pca_number: int
-        :param mask: Radius of the mask that is placed at the location of the star (arcsec).
-        :type mask: float
+        :param mask_star: Radius of the central mask (arcsec).
+        :type mask_star: float
         :param \**kwargs:
             See below.
 
         :Keyword arguments:
              **crop** (*bool*) -- Skip the step of selecting and cropping of the dithering
-                                  positions if set to False.
+             positions if set to False.
              **prepare** (*bool*) -- Skip the step of preparing the PCA background subtraction if
-                                     set to False.
+             set to False.
              **pca_background** (*bool*) -- Skip the step of the PCA background subtraction if set
-                                            to False.
+             to False.
              **combine** (*str*) -- Combine the mean background subtracted ("mean") or PCA
-                                    background subtracted ("pca") frames. This step is ignored if
-                                    set to None.
+             background subtracted ("pca") frames. This step is ignored if set to None.
+             **mask_planet** (*tuple(float, float, float)*) -- Separation (arcsec), position angle
+             (deg) measured in counterclockwise direction with respect to upward direction,
+             additional rotation angle (deg), and radius (arcsec) of the mask, (sep, angle,
+             radius). No mask is used when set to None.
 
         :return: None
         """
@@ -772,7 +836,12 @@ class DitheringBackgroundModule(ProcessingModule):
         if "combine" in kwargs:
             self.m_combine = kwargs["combine"]
         else:
-            self.m_combine = True
+            self.m_combine = "pca"
+
+        if "mask_planet" in kwargs:
+            self.m_mask_planet = kwargs["mask_planet"]
+        else:
+            self.m_mask_planet = None
 
         super(DitheringBackgroundModule, self).__init__(name_in)
 
@@ -783,7 +852,7 @@ class DitheringBackgroundModule(ProcessingModule):
         self.m_size = size
         self.m_gaussian = gaussian
         self.m_pca_number = pca_number
-        self.m_mask = mask
+        self.m_mask_star = mask_star
 
         if subframe is None:
             self.m_subframe = subframe
@@ -849,7 +918,7 @@ class DitheringBackgroundModule(ProcessingModule):
                 tags.append("star"+str(count+1))
 
             elif self.m_combine == "pca":
-                tags.append("pca_sub"+str(count+1))
+                tags.append("pcabg_res"+str(count+1))
 
             if self.m_crop or self.m_prepare or self.m_pca_background:
                 print "Processing dither position "+str(count+1)+" out of "+str(n_dither)+"... [DONE]"
@@ -898,12 +967,14 @@ class DitheringBackgroundModule(ProcessingModule):
                 star.run()
 
                 pca = PCABackgroundSubtractionModule(pca_number=self.m_pca_number,
-                                                     mask=self.m_mask,
+                                                     mask_star=self.m_mask_star,
+                                                     mask_planet=self.m_mask_planet,
                                                      name_in="pca_background"+str(i),
                                                      star_in_tag="star"+str(i+1),
                                                      background_in_tag="background"+str(i+1),
-                                                     subtracted_out_tag="pca_sub"+str(i+1),
-                                                     residuals_out_tag=None)
+                                                     residuals_out_tag="pcabg_res"+str(i+1),
+                                                     fit_out_tag="pcabg_fit"+str(i+1),
+                                                     mask_out_tag="pcabg_mask"+str(i+1))
 
                 pca.connect_database(self._m_data_base)
                 pca.run()

--- a/PynPoint/ProcessingModules/BackgroundSubtraction.py
+++ b/PynPoint/ProcessingModules/BackgroundSubtraction.py
@@ -675,7 +675,7 @@ class PCABackgroundSubtractionModule(ProcessingModule):
 
         sys.stdout.write("Creating PCA basis set...")
         sys.stdout.flush()
-        
+
         basis_pca = _create_basis(self.m_background_in_port.get_all(),
                                   self.m_pca_number)
 
@@ -699,8 +699,6 @@ class PCABackgroundSubtractionModule(ProcessingModule):
                 mask_planet = np.ones(im_star.shape)
 
             else:
-                npix = im_star.shape[1]
-
                 cent_x = star[frames[i]:frames[i+1], 1]
                 cent_y = star[frames[i]:frames[i+1], 0]
 
@@ -921,7 +919,8 @@ class DitheringBackgroundModule(ProcessingModule):
                 tags.append("pcabg_res"+str(count+1))
 
             if self.m_crop or self.m_prepare or self.m_pca_background:
-                print "Processing dither position "+str(count+1)+" out of "+str(n_dither)+"... [DONE]"
+                print "Processing dither position "+str(count+1)+ \
+                      " out of "+str(n_dither)+"... [DONE]"
 
         n_dither, star_pos = self._initialize()
 

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -254,10 +254,10 @@ class AngleInterpolationModule(ProcessingModule):
         steps = self.m_data_in_port.get_attribute("NFRAMES")
         ndit = self.m_data_in_port.get_attribute("NDIT")
 
-        if False in ndit == steps:
-            warnings.warn("There is a mismatch between the NDIT and NAXIS3 values. The parallactic"
+        if False in (ndit == steps):
+            warnings.warn("There is a mismatch between the NDIT and NAXIS3 values. The derotation "
                           "angles are calculated with a linear interpolation by using NAXIS3 "
-                          "steps. A frame selection should be applied after the parallactic "
+                          "steps. A frame selection should be applied after the derotation "
                           "angles are calculated.")
 
         new_angles = []
@@ -477,11 +477,10 @@ class AngleCalculationModule(ProcessingModule):
         steps = self.m_data_in_port.get_attribute("NFRAMES")
         ndit = self.m_data_in_port.get_attribute("NDIT")
 
-        if False in ndit == steps:
-            warnings.warn("There is a mismatch between the NDIT and NAXIS3 values. The parallactic"
-                          "angles are calculated with a linear interpolation by using NAXIS3 "
-                          "steps. A frame selection should be applied after the parallactic "
-                          "angles are calculated.")
+        if False in (ndit == steps):
+            warnings.warn("There is a mismatch between the NDIT and NAXIS3 values. A frame "
+                          "selection should be applied after the derotation angle are "
+                          "calculated.")
 
         if self.m_instrument == "SPHERE/IFS":
             warnings.warn("AngleCalculationModule has not been tested for SPHERE/IFS data.")

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -254,7 +254,7 @@ class AngleInterpolationModule(ProcessingModule):
         steps = self.m_data_in_port.get_attribute("NFRAMES")
         ndit = self.m_data_in_port.get_attribute("NDIT")
 
-        if False in (ndit == steps):
+        if not np.all(ndit == steps):
             warnings.warn("There is a mismatch between the NDIT and NAXIS3 values. The derotation "
                           "angles are calculated with a linear interpolation by using NAXIS3 "
                           "steps. A frame selection should be applied after the derotation "
@@ -477,7 +477,7 @@ class AngleCalculationModule(ProcessingModule):
         steps = self.m_data_in_port.get_attribute("NFRAMES")
         ndit = self.m_data_in_port.get_attribute("NDIT")
 
-        if False in (ndit == steps):
+        if not np.all(ndit == steps):
             warnings.warn("There is a mismatch between the NDIT and NAXIS3 values. A frame "
                           "selection should be applied after the derotation angle are "
                           "calculated.")

--- a/PynPoint/Util/TestTools.py
+++ b/PynPoint/Util/TestTools.py
@@ -151,7 +151,7 @@ def create_fits(filename, image, ndit, exp_no, parang, x0, y0):
     header['INSTRUME'] = 'IMAGER'
     header['HIERARCH ESO DET EXP NO'] = 1.
     header['HIERARCH ESO DET NDIT'] = ndit
-    header['HIERARCH ESO DET EXP NO'] = ndit
+    header['HIERARCH ESO DET EXP NO'] = exp_no
     header['HIERARCH ESO ADA POSANG'] = parang[0]
     header['HIERARCH ESO ADA POSANG END'] = parang[1]
     header['HIERARCH ESO SEQ CUMOFFSETX'] = x0

--- a/PynPoint/Util/TestTools.py
+++ b/PynPoint/Util/TestTools.py
@@ -26,8 +26,8 @@ def create_config(filename):
     file_obj.write('NDIT: ESO DET NDIT\n')
     file_obj.write('PARANG_START: ESO ADA POSANG\n')
     file_obj.write('PARANG_END: ESO ADA POSANG END\n')
-    file_obj.write('DITHER_X: None\n')
-    file_obj.write('DITHER_Y: None\n')
+    file_obj.write('DITHER_X: ESO SEQ CUMOFFSETX\n')
+    file_obj.write('DITHER_Y: ESO SEQ CUMOFFSETY\n')
     file_obj.write('DIT: None\n')
     file_obj.write('LATITUDE: None\n')
     file_obj.write('LONGITUDE: None\n')
@@ -59,6 +59,8 @@ def prepare_pca_tests(path):
     header['HIERARCH ESO DET NDIT'] = 1
     header['HIERARCH ESO ADA POSANG'] = 1.
     header['HIERARCH ESO ADA POSANG END'] = 1.
+    header['HIERARCH ESO SEQ CUMOFFSETX'] = 1.
+    header['HIERARCH ESO SEQ CUMOFFSETY'] = 1.
     header['PARANG'] = -17.3261
     header['PARANG'] = -17.3261
     hdu.data = image1
@@ -71,6 +73,8 @@ def prepare_pca_tests(path):
     header['HIERARCH ESO DET NDIT'] = 1
     header['HIERARCH ESO ADA POSANG'] = 1.
     header['HIERARCH ESO ADA POSANG END'] = 1.
+    header['HIERARCH ESO SEQ CUMOFFSETX'] = 1.
+    header['HIERARCH ESO SEQ CUMOFFSETY'] = 1.
     header['PARANG'] = -17.1720
     hdu.data = image2
     hdu.writeto(path+"/test_data/image2.fits")
@@ -82,6 +86,8 @@ def prepare_pca_tests(path):
     header['HIERARCH ESO DET NDIT'] = 1
     header['HIERARCH ESO ADA POSANG'] = 1.
     header['HIERARCH ESO ADA POSANG END'] = 1.
+    header['HIERARCH ESO SEQ CUMOFFSETX'] = 1.
+    header['HIERARCH ESO SEQ CUMOFFSETY'] = 1.
     header['PARANG'] = -17.0143
     hdu.data = image3
     hdu.writeto(path+"/test_data/image3.fits")
@@ -93,17 +99,30 @@ def prepare_pca_tests(path):
     header['HIERARCH ESO DET NDIT'] = 1
     header['HIERARCH ESO ADA POSANG'] = 1.
     header['HIERARCH ESO ADA POSANG END'] = 1.
+    header['HIERARCH ESO SEQ CUMOFFSETX'] = 1.
+    header['HIERARCH ESO SEQ CUMOFFSETY'] = 1.
     header['PARANG'] = -16.6004
     hdu.data = image4
     hdu.writeto(path+"/test_data/image4.fits")
 
     config_file = path+"/test_data/PynPoint_config.ini"
-
     create_config(config_file)
 
     for lines in fileinput.FileInput(config_file, inplace=1):
         lines = lines.replace("PIXSCALE: 0.027\n", "PIXSCALE: 0.01\n")
-        print lines
+        print lines # writes to file
+
+def remove_psf_test_data(path):
+    """
+    Remove FITS files that were created for the test cases of the PSF subtraction.
+    """
+
+    os.remove(os.path.join(path, "test_data/image1.fits"))
+    os.remove(os.path.join(path, "test_data/image2.fits"))
+    os.remove(os.path.join(path, "test_data/image3.fits"))
+    os.remove(os.path.join(path, "test_data/image4.fits"))
+    os.remove(os.path.join(path, "test_data/PynPoint_database.hdf5"))
+    os.remove(os.path.join(path, "test_data/PynPoint_config.ini"))
 
 def create_random(path):
     """
@@ -122,7 +141,7 @@ def create_random(path):
     h5f.create_dataset("header_images/PARANG", data=parang)
     h5f.close()
 
-def create_fits(filename, image, ndit, parang):
+def create_fits(filename, image, ndit, exp_no, parang, x0, y0):
     """
     Create a FITS file with images and header information
     """
@@ -132,59 +151,56 @@ def create_fits(filename, image, ndit, parang):
     header['INSTRUME'] = 'IMAGER'
     header['HIERARCH ESO DET EXP NO'] = 1.
     header['HIERARCH ESO DET NDIT'] = ndit
+    header['HIERARCH ESO DET EXP NO'] = ndit
     header['HIERARCH ESO ADA POSANG'] = parang[0]
     header['HIERARCH ESO ADA POSANG END'] = parang[1]
-    header['HIERARCH ESO SEQ CUMOFFSETX'] = 5.
-    header['HIERARCH ESO SEQ CUMOFFSETY'] = 5.
+    header['HIERARCH ESO SEQ CUMOFFSETX'] = x0
+    header['HIERARCH ESO SEQ CUMOFFSETY'] = y0
     hdu.data = image
     hdu.writeto(filename)
 
-def create_fake(file_start, sep, contrast):
+def create_fake(file_start, ndit, nframes, exp_no, npix, fwhm, x0, y0, angles, sep, contrast):
     """
     Create ADI test data with fake planets.
     """
-
-    ndit = [22, 17, 21, 18]
-    naxis3 = [23, 18, 22, 19]
-    npix = [100, 100, 100, 100]
-    fwhm = [3., 3., 3., 3.]
-    x0 = [25, 75, 75, 25]
-    y0 = [75, 75, 25, 25]
-    angles = [[0., 25.], [25., 50.], [50., 75.], [75., 100.]]
 
     parang = []
     for i, item in enumerate(angles):
         for j in range(ndit[i]):
             parang.append(item[0]+float(j)*(item[1]-item[0])/float(ndit[i]))
 
+    if fwhm is not None or contrast is not None:
+        sigma = fwhm / (2.*math.sqrt(2.*math.log(2.)))
+
+    x = np.arange(0., npix[0], 1.)
+    y = np.arange(0., npix[1], 1.)
+    xx, yy = np.meshgrid(x, y)
+
     np.random.seed(1)
 
-    p_count = 0
-    for j, item in enumerate(fwhm):
-
-        sigma = item / (2.*math.sqrt(2.*math.log(2.)))
-
-        x = np.arange(0., npix[j], 1.)
-        y = np.arange(0., npix[j]+2, 1.)
-        xx, yy = np.meshgrid(x, y)
-
-        image = np.zeros((naxis3[j], npix[j]+2, npix[j]))
+    count = 0
+    for j, item in enumerate(nframes):
+        image = np.zeros((item, npix[1], npix[0]))
 
         for i in range(ndit[j]):
-            star = (1./(2.*np.pi*sigma**2))*np.exp(-((xx-x0[j])**2+(yy-y0[j])**2)/(2.*sigma**2))
-            noise = np.random.normal(loc=0, scale=2e-4, size=(102, 100))
+            noise = np.random.normal(loc=0, scale=2e-4, size=(npix[1], npix[0]))
+            image[i, 0:npix[1], 0:npix[0]] = noise
 
-            planet = contrast*(1./(2.*np.pi*sigma**2))*np.exp(-((xx-x0[j])**2+(yy-y0[j])**2)/(2.*sigma**2))
-            x_shift = sep*math.cos(parang[p_count]*math.pi/180.)
-            y_shift = sep*math.sin(parang[p_count]*math.pi/180.)
-            planet = shift(planet, (x_shift, y_shift), order=5)
+            if fwhm is not None:
+                star = (1./(2.*np.pi*sigma**2))*np.exp(-((xx-x0[j])**2+(yy-y0[j])**2)/(2.*sigma**2))
+                image[i, 0:npix[1], 0:npix[0]] += star
 
-            image[i, 0:npix[j]+2, 0:npix[j]] = star+noise+planet
+            if contrast is not None and sep is not None:
+                planet = contrast*(1./(2.*np.pi*sigma**2))*np.exp(-((xx-x0[j])**2+(yy-y0[j])**2)/(2.*sigma**2))
+                x_shift = sep*math.cos(parang[count]*math.pi/180.)
+                y_shift = sep*math.sin(parang[count]*math.pi/180.)
+                planet = shift(planet, (x_shift, y_shift), order=5)
+                image[i, 0:npix[1], 0:npix[0]] += planet
 
-            p_count += 1
+            count += 1
 
         filename = file_start+str(j+1).zfill(2)+'.fits'
-        create_fits(filename, image, ndit[j], angles[j])
+        create_fits(filename, image, ndit[j], exp_no[j], angles[j], x0[j]-npix[0]/2., y0[j]-npix[1]/2.)
 
 def create_star_data(path, npix_x, npix_y, x0, y0, parang_start, parang_end):
     """
@@ -222,15 +238,3 @@ def create_star_data(path, npix_x, npix_y, x0, y0, parang_start, parang_end):
         header['HIERARCH ESO SEQ CUMOFFSETY'] = "None"
         hdu.data = image
         hdu.writeto(os.path.join(path, 'image'+str(j+1).zfill(2)+'.fits'))
-
-def remove_psf_test_data(path):
-    """
-    Remove FITS files that were created for the test cases of the PSF subtraction.
-    """
-
-    os.remove(os.path.join(path, "test_data/image1.fits"))
-    os.remove(os.path.join(path, "test_data/image2.fits"))
-    os.remove(os.path.join(path, "test_data/image3.fits"))
-    os.remove(os.path.join(path, "test_data/image4.fits"))
-    os.remove(os.path.join(path, "test_data/PynPoint_database.hdf5"))
-    os.remove(os.path.join(path, "test_data/PynPoint_config.ini"))

--- a/tests/test_PSF_subtraction/test_Images.py
+++ b/tests/test_PSF_subtraction/test_Images.py
@@ -1,10 +1,10 @@
-import os
 import warnings
+import os
 
 import numpy as np
 
-import PynPoint.OldVersion
 from PynPoint.Util.TestTools import prepare_pca_tests, remove_psf_test_data
+import PynPoint.OldVersion
 
 warnings.simplefilter("always")
 

--- a/tests/test_PSF_subtraction/test_Residuals.py
+++ b/tests/test_PSF_subtraction/test_Residuals.py
@@ -11,12 +11,10 @@ warnings.simplefilter("always")
 limit = 1e-10
 
 def setup_module():
-    path = os.path.dirname(__file__)
-    prepare_pca_tests(path)
+    prepare_pca_tests(os.path.dirname(__file__))
 
 def teardown_module():
-    path = os.path.dirname(__file__)
-    remove_psf_test_data(path)
+    remove_psf_test_data(os.path.dirname(__file__))
 
 class TestResidual(object):
 

--- a/tests/test_processing/test_BackgroundSubtraction.py
+++ b/tests/test_processing/test_BackgroundSubtraction.py
@@ -215,5 +215,5 @@ class TestBackgroundSubtraction(object):
         assert np.allclose(np.mean(data), 8.937360237872607e-07, rtol=limit, atol=0.)
 
         data = self.pipeline.get_data("nodding")
-        assert np.allclose(data[0, 50, 50], 0.09789197255024433, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 9.711185953895942e-05, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 50, 50], 0.09806026673451182, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 9.942251790089106e-05, rtol=limit, atol=0.)

--- a/tests/test_processing/test_BackgroundSubtraction.py
+++ b/tests/test_processing/test_BackgroundSubtraction.py
@@ -6,48 +6,75 @@ import numpy as np
 
 from PynPoint.Core.Pypeline import Pypeline
 from PynPoint.Core.DataIO import DataStorage
+from PynPoint.IOmodules.FitsReading import FitsReadingModule
 from PynPoint.ProcessingModules.BackgroundSubtraction import MeanBackgroundSubtractionModule, SimpleBackgroundSubtractionModule, \
                                                              PCABackgroundPreparationModule, PCABackgroundSubtractionModule, \
                                                              DitheringBackgroundModule, NoddingBackgroundModule
-from PynPoint.Util.TestTools import create_config
+from PynPoint.Util.TestTools import create_config, create_fake
 
 warnings.simplefilter("always")
 
 limit = 1e-10
 
 def setup_module():
-    file_in = os.path.dirname(__file__) + "/PynPoint_database.hdf5"
+    test_dir = os.path.dirname(__file__)+"/"
 
-    np.random.seed(1)
-    images = np.random.normal(loc=0, scale=2e-4, size=(40, 100, 100))
-    sky = np.random.normal(loc=0, scale=2e-4, size=(40, 100, 100))
+    os.makedirs(test_dir+"dither")
+    os.makedirs(test_dir+"star")
+    os.makedirs(test_dir+"sky")
 
-    h5f = h5py.File(file_in, "w")
-    dset = h5f.create_dataset("images", data=images)
-    dset.attrs['PIXSCALE'] = 0.01
-    h5f.create_dataset("header_images/INDEX", data=np.arange(0, 40, 1))
-    h5f.create_dataset("header_images/NFRAMES", data=[10, 10, 10, 10])
-    h5f.create_dataset("header_images/EXP_NO", data=[1, 3, 5, 7])
-    h5f.create_dataset("header_images/DITHER_X", data=[5, 5, -5, -5])
-    h5f.create_dataset("header_images/DITHER_Y", data=[5, -5, -5, 5])
-    h5f.create_dataset("header_images/STAR_POSITION", data=np.full((10, 2), 40.))
-    h5f.create_dataset("header_images/PARANG", data=np.full(40, 1.))
-    dset = h5f.create_dataset("sky", data=sky)
-    dset.attrs['PIXSCALE'] = 0.01
-    h5f.create_dataset("header_sky/INDEX", data=np.arange(0, 40, 1))
-    h5f.create_dataset("header_sky/NFRAMES", data=[10, 10, 10, 10])
-    h5f.create_dataset("header_sky/EXP_NO", data=[2, 4, 6, 8])
-    h5f.close()
+    create_fake(file_start=test_dir+"dither/dither",
+                ndit=[20, 20, 20, 20],
+                nframes=[20, 20, 20, 20],
+                exp_no=[1, 2, 3, 4],
+                npix=(100, 100),
+                fwhm=3.,
+                x0=[25, 75, 75, 25],
+                y0=[75, 75, 25, 25],
+                angles=[[0., 25.], [25., 50.], [50., 75.], [75., 100.]],
+                sep=None,
+                contrast=None)
 
-    filename = os.path.dirname(__file__) + "/PynPoint_config.ini"
-    create_config(filename)
+    create_fake(file_start=test_dir+"star/star",
+                ndit=[10, 10, 10, 10],
+                nframes=[10, 10, 10, 10],
+                exp_no=[1, 3, 5, 7],
+                npix=(100, 100),
+                fwhm=3.,
+                x0=[50, 50, 50, 50],
+                y0=[50, 50, 50, 50],
+                angles=[[0., 25.], [25., 50.], [50., 75.], [75., 100.]],
+                sep=None,
+                contrast=None)
+
+    create_fake(file_start=test_dir+"sky/sky",
+                ndit=[5, 5, 5, 5],
+                nframes=[5, 5, 5, 5],
+                exp_no=[2, 4, 6, 8],
+                npix=(100, 100),
+                fwhm=None,
+                x0=[50, 50, 50, 50],
+                y0=[50, 50, 50, 50],
+                angles=[[0., 25.], [25., 50.], [50., 75.], [75., 100.]],
+                sep=None,
+                contrast=None)
+
+    create_config(os.path.dirname(__file__)+"/PynPoint_config.ini")
 
 def teardown_module():
-    file_in = os.path.dirname(__file__) + "/PynPoint_database.hdf5"
-    config_file = os.path.dirname(__file__) + "/PynPoint_config.ini"
+    test_dir = os.path.dirname(__file__)+"/"
 
-    os.remove(file_in)
-    os.remove(config_file)
+    for i in range(4):
+        os.remove(test_dir+'dither/dither'+str(i+1).zfill(2)+'.fits')
+        os.remove(test_dir+'star/star'+str(i+1).zfill(2)+'.fits')
+        os.remove(test_dir+'sky/sky'+str(i+1).zfill(2)+'.fits')
+
+    os.rmdir(test_dir+'dither')
+    os.rmdir(test_dir+'star')
+    os.rmdir(test_dir+'sky')
+
+    os.remove(os.path.dirname(__file__)+"/PynPoint_database.hdf5")
+    os.remove(os.path.dirname(__file__)+"/PynPoint_config.ini")
 
 class TestBackgroundSubtraction(object):
 
@@ -57,111 +84,71 @@ class TestBackgroundSubtraction(object):
 
     def test_simple_background_subraction(self):
 
-        simple = SimpleBackgroundSubtractionModule(shift=1,
+        print self.test_dir
+
+        read = FitsReadingModule(name_in="read",
+                                 image_tag="read",
+                                 input_dir=self.test_dir+"dither")
+
+        self.pipeline.add_module(read)
+
+        simple = SimpleBackgroundSubtractionModule(shift=20,
                                                    name_in="simple",
-                                                   image_in_tag="images",
+                                                   image_in_tag="read",
                                                    image_out_tag="simple")
 
         self.pipeline.add_module(simple)
 
         self.pipeline.run()
 
-        storage = DataStorage(self.test_dir+"/PynPoint_database.hdf5")
-        storage.open_connection()
+        data = self.pipeline.get_data("read")
+        assert np.allclose(data[0, 74, 24], 0.05304008435511765, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.00010033896953157959, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["simple"]
-        assert np.allclose(data[0, 10, 10], 0.00016307583939841944, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 1.7347234759768072e-23, rtol=limit, atol=0.)
-
-        storage.close_connection()
+        data = self.pipeline.get_data("simple")
+        assert np.allclose(data[0, 74, 74], -0.05288064325101517, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 2.7755575615628916e-22, rtol=limit, atol=0.)
 
     def test_mean_background_subraction(self):
 
         mean1 = MeanBackgroundSubtractionModule(shift=None,
                                                 cubes=1,
                                                 name_in="mean1",
-                                                image_in_tag="images",
+                                                image_in_tag="read",
                                                 image_out_tag="mean1")
 
         self.pipeline.add_module(mean1)
 
-        mean2 = MeanBackgroundSubtractionModule(shift=10,
+        mean2 = MeanBackgroundSubtractionModule(shift=20,
                                                 cubes=1,
                                                 name_in="mean2",
-                                                image_in_tag="images",
+                                                image_in_tag="read",
                                                 image_out_tag="mean2")
 
         self.pipeline.add_module(mean2)
 
         self.pipeline.run()
 
-        storage = DataStorage(self.test_dir+"/PynPoint_database.hdf5")
-        storage.open_connection()
+        data = self.pipeline.get_data("mean1")
+        assert np.allclose(data[0, 74, 24], 0.0530465391626132, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 1.3970872216676808e-07, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["mean1"]
-        assert np.allclose(data[0, 10, 10], 0.0001881700200690493, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 6.468177714836324e-08, rtol=limit, atol=0.)
-
-        data = storage.m_data_bank["mean2"]
-        assert np.allclose(data[0, 10, 10], 0.0001881700200690493, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 6.468177714836324e-08, rtol=limit, atol=0.)
-
-        storage.close_connection()
-
-    def test_pca_background(self):
-
-        pca_prep = PCABackgroundPreparationModule(dither=(4, 1, 0),
-                                                  name_in="pca_prep",
-                                                  image_in_tag="images",
-                                                  star_out_tag="star",
-                                                  background_out_tag="background")
-
-        self.pipeline.add_module(pca_prep)
-
-        pca_bg = PCABackgroundSubtractionModule(pca_number=5,
-                                                mask=0.3,
-                                                name_in="pca_bg",
-                                                star_in_tag="star",
-                                                background_in_tag="background",
-                                                subtracted_out_tag="subtracted",
-                                                residuals_out_tag="residuals")
-
-        self.pipeline.add_module(pca_bg)
-
-        self.pipeline.run()
-
-        storage = DataStorage(self.test_dir+"/PynPoint_database.hdf5")
-        storage.open_connection()
-
-        data = storage.m_data_bank["star"]
-        assert np.allclose(data[0, 10, 10], 0.0001881700200690493, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 3.137393482985464e-07, rtol=limit, atol=0.)
-
-        data = storage.m_data_bank["background"]
-        assert np.allclose(data[0, 10, 10], 9.38719992395586e-05, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 5.782411586589357e-23, rtol=limit, atol=0.)
-
-        data = storage.m_data_bank["subtracted"]
-        assert np.allclose(data[0, 10, 10], 0.00017730624664203748, rtol=1e-7, atol=0.)
-        assert np.allclose(np.mean(data), 3.102053539454623e-07, rtol=1e-6, atol=0.)
-
-        data = storage.m_data_bank["residuals"]
-        assert np.allclose(data[0, 10, 10], 1.0863759773063205e-05, rtol=1e-5, atol=0.)
-        assert np.allclose(np.mean(data), 3.5339943530839906e-09, rtol=1e-2, atol=0.)
-
-        storage.close_connection()
+        data = self.pipeline.get_data("mean2")
+        assert np.allclose(data[0, 74, 24], 0.0530465391626132, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 1.3970872216676808e-07, rtol=limit, atol=0.)
 
     def test_dithering_background(self):
 
         pca_dither1 = DitheringBackgroundModule(name_in="pca_dither1",
-                                                image_in_tag="images",
+                                                image_in_tag="read",
                                                 image_out_tag="pca_dither1",
                                                 center=None,
                                                 cubes=None,
                                                 size=0.8,
-                                                gaussian=0.15,
+                                                gaussian=0.1,
+                                                subframe=0.1,
                                                 pca_number=5,
-                                                mask=0.3,
+                                                mask_star=0.1,
                                                 crop=True,
                                                 prepare=True,
                                                 pca_background=True,
@@ -170,14 +157,14 @@ class TestBackgroundSubtraction(object):
         self.pipeline.add_module(pca_dither1)
 
         pca_dither2 = DitheringBackgroundModule(name_in="pca_dither2",
-                                                image_in_tag="images",
+                                                image_in_tag="read",
                                                 image_out_tag="pca_dither2",
-                                                center=((55., 55.), (55., 45.), (45., 45.), (45., 55.)),
+                                                center=((25., 75.), (75., 75.), (75., 25.), (25., 25.)),
                                                 cubes=1,
                                                 size=0.8,
-                                                gaussian=0.15,
+                                                gaussian=0.1,
                                                 pca_number=5,
-                                                mask=0.3,
+                                                mask_star=0.1,
                                                 crop=True,
                                                 prepare=True,
                                                 pca_background=True,
@@ -187,24 +174,31 @@ class TestBackgroundSubtraction(object):
 
         self.pipeline.run()
 
-        storage = DataStorage(self.test_dir+"/PynPoint_database.hdf5")
-        storage.open_connection()
+        data = self.pipeline.get_data("pca_dither1")
+        assert np.allclose(data[0, 13, 13], 0.05300595399147854, rtol=1e-6, atol=0.)
+        assert np.allclose(np.mean(data), 0.0012752305968659608, rtol=1e-6, atol=0.)
 
-        data = storage.m_data_bank["pca_dither1"]
-        assert np.allclose(data[0, 10, 10], 4.9091895841309806e-05, rtol=1e-6, atol=0.)
-        assert np.allclose(np.mean(data), 4.1545008537769944e-08, rtol=1e-6, atol=0.)
-
-        data = storage.m_data_bank["pca_dither2"]
-        assert np.allclose(data[0, 10, 10], 4.90918925055851e-05, rtol=1e-6, atol=0.)
-        assert np.allclose(np.mean(data), 4.1544970008885266e-08, rtol=1e-3, atol=0.)
-
-        storage.close_connection()
+        data = self.pipeline.get_data("pca_dither2")
+        assert np.allclose(data[0, 13, 13], 0.05300595400110353, rtol=1e-6, atol=0.)
+        assert np.allclose(np.mean(data), 0.001275230597238928, rtol=1e-3, atol=0.)
 
     def test_nodding_background(self):
 
+        read1 = FitsReadingModule(name_in="read1",
+                                  image_tag="star",
+                                  input_dir=self.test_dir+"star")
+
+        self.pipeline.add_module(read1)
+
+        read2 = FitsReadingModule(name_in="read2",
+                                  image_tag="sky",
+                                  input_dir=self.test_dir+"sky")
+
+        self.pipeline.add_module(read2)
+
         nodding = NoddingBackgroundModule(name_in="nodding",
                                           sky_in_tag="sky",
-                                          science_in_tag="images",
+                                          science_in_tag="star",
                                           image_out_tag="nodding",
                                           mode="both")
 
@@ -212,19 +206,14 @@ class TestBackgroundSubtraction(object):
 
         self.pipeline.run()
 
-        storage = DataStorage(self.test_dir+"/PynPoint_database.hdf5")
-        storage.open_connection()
+        data = self.pipeline.get_data("star")
+        assert np.allclose(data[0, 50, 50], 0.09798413502193704, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.00010029494781738066, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["images"]
-        assert np.allclose(data[0, 10, 10], 0.00012958496246258364, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 2.9494781737579395e-07, rtol=limit, atol=0.)
+        data = self.pipeline.get_data("sky")
+        assert np.allclose(data[0, 50, 50], -7.613171257478652e-05, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 8.937360237872607e-07, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["sky"]
-        assert np.allclose(data[0, 10, 10], -3.7305891376589886e-05, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 3.829912457736603e-07, rtol=limit, atol=0.)
-
-        data = storage.m_data_bank["nodding"]
-        assert np.allclose(data[0, 10, 10], 0.00016689085383917351, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 9.439443523107406e-07, rtol=limit, atol=0.)
-
-        storage.close_connection()
+        data = self.pipeline.get_data("nodding")
+        assert np.allclose(data[0, 50, 50], 0.09789197255024433, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 9.711185953895942e-05, rtol=limit, atol=0.)

--- a/tests/test_processing/test_Documentation.py
+++ b/tests/test_processing/test_Documentation.py
@@ -35,7 +35,17 @@ def setup_module():
 
     # SCIENCE
 
-    create_fake(test_dir + 'adi/adi', 7., 1e-2)
+    create_fake(file_start=test_dir+'adi/adi',
+                ndit=[22, 17, 21, 18],
+                nframes=[23, 18, 22, 19],
+                exp_no=[1, 2, 3, 4],
+                npix=(100, 102),
+                fwhm=3.,
+                x0=[25, 75, 75, 25],
+                y0=[75, 75, 25, 25],
+                angles=[[0., 25.], [25., 50.], [50., 75.], [75., 100.]],
+                sep=7.,
+                contrast=1e-2)
 
     # DARK
 
@@ -48,7 +58,7 @@ def setup_module():
         image = np.random.normal(loc=0, scale=2e-4, size=(n, 100, 100))
 
         filename = test_dir+'dark/dark'+str(j+1).zfill(2)+'.fits'
-        create_fits(filename, image, ndit[j], parang[j])
+        create_fits(filename, image, ndit[j], 0, parang[j], 0., 0.)
 
     # FLAT
 
@@ -61,7 +71,7 @@ def setup_module():
         image = np.random.normal(loc=1, scale=1e-2, size=(n, 100, 100))
 
         filename = test_dir+'flat/flat'+str(j+1).zfill(2)+'.fits'
-        create_fits(filename, image, ndit[j], parang[j])
+        create_fits(filename, image, ndit[j], 0, parang[j], 0., 0.)
 
     filename = os.path.dirname(__file__) + "/PynPoint_config.ini"
     create_config(filename)
@@ -93,7 +103,6 @@ class TestDocumentation(object):
         self.pipeline = Pypeline(self.test_dir, self.test_dir, self.test_dir)
 
     def test_docs(self):
-
         read_science = FitsReadingModule(name_in="read_science",
                                          input_dir=self.test_dir+"adi/",
                                          image_tag="im_arr")
@@ -208,48 +217,43 @@ class TestDocumentation(object):
 
         self.pipeline.run()
 
-        storage = DataStorage(self.test_dir+"/PynPoint_database.hdf5")
-        storage.open_connection()
-
-        data = storage.m_data_bank["im_arr"]
+        data = self.pipeline.get_data("im_arr")
         assert np.allclose(data[0, 61, 39], -0.00022889163546536875, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["dark_arr"]
+        data = self.pipeline.get_data("dark_arr")
         assert np.allclose(data[0, 61, 39], 2.368170995592123e-05, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["flat_arr"]
+        data = self.pipeline.get_data("flat_arr")
         assert np.allclose(data[0, 61, 39], 0.98703416941301647, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["im_arr_last"]
+        data = self.pipeline.get_data("im_arr_last")
         assert np.allclose(data[0, 61, 39], -0.00022889163546536875, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["im_arr_cut"]
+        data = self.pipeline.get_data("im_arr_cut")
         assert np.allclose(data[0, 61, 39], -0.00022889163546536875, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["dark_sub_arr"]
+        data = self.pipeline.get_data("dark_sub_arr")
         assert np.allclose(data[0, 61, 39], -0.00021601281733413911, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["flat_sub_arr"]
+        data = self.pipeline.get_data("flat_sub_arr")
         assert np.allclose(data[0, 61, 39], -0.00021647987125847178, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["bg_cleaned_arr"]
+        data = self.pipeline.get_data("bg_cleaned_arr")
         assert np.allclose(data[0, 61, 39], -0.00013095662386792948, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["bp_cleaned_arr"]
+        data = self.pipeline.get_data("bp_cleaned_arr")
         assert np.allclose(data[0, 61, 39], -0.00013095662386792948, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["im_arr_extract"]
+        data = self.pipeline.get_data("im_arr_extract")
         assert np.allclose(data[0, 10, 10], 0.052958146579313935, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["im_arr_aligned"]
+        data = self.pipeline.get_data("im_arr_aligned")
         assert np.allclose(data[0, 10, 10], 1.1307471842831197e-05, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["im_arr_stacked"]
+        data = self.pipeline.get_data("im_arr_stacked")
         assert np.allclose(data[0, 10, 10], 2.5572805947810986e-05, rtol=limit, atol=0.)
 
-        data = storage.m_data_bank["res_mean"]
+        data = self.pipeline.get_data("res_mean")
         assert np.allclose(data[38, 22], 0.00018312083384477404, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), -1.598348168584834e-07, rtol=limit, atol=0.)
         assert data.shape == (44, 44)
-
-        storage.close_connection()


### PR DESCRIPTION
In some cases it might be helpful to mask the planet when doing the PCA background subtraction to prevent subtraction of the planet signal when fitting the background. There is now a _mask_star_ and _mask_planet_ parameter. Also the mask can be written as output to the database.