### PR TITLE
Image cropping in SDIpreparationModule

### DIFF
--- a/PynPoint/ProcessingModules/PSFSubtractionPCA.py
+++ b/PynPoint/ProcessingModules/PSFSubtractionPCA.py
@@ -622,7 +622,8 @@ class PcaPsfSubtractionModule(ProcessingModule):
         :param reference_in_tag: Tag of the database entry with the reference images that are
                                  read as input.
         :type reference_in_tag: str
-        :param res_mean_tag: Tag of the database entry with the mean collapsed residuals.
+        :param res_mean_tag: Tag of the database entry with the mean collapsed residuals. Not
+                             calculated if set to *None*.
         :type res_mean_tag: str
         :param res_median_tag: Tag of the database entry with the median collapsed residuals. Not
                                calculated if set to *None*.

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -13,7 +13,7 @@ import numpy as np
 from scipy import ndimage
 
 from PynPoint.Core.Processing import ProcessingModule
-from PynPoint.ProcessingModules.ImageResizing import CropImagesModule, ScaleImagesModule
+from PynPoint.ProcessingModules.ImageResizing import RemoveLinesModule, ScaleImagesModule
 from PynPoint.Util.ModuleTools import progress, memory_frames
 
 
@@ -616,10 +616,9 @@ class SDIpreparationModule(ProcessingModule):
 
         self.m_line_wvl = wavelength[0]
         self.m_cnt_wvl = wavelength[1]
+
         self.m_line_width = width[0]
         self.m_cnt_width = width[1]
-        self.m_image_in_tag = image_in_tag
-        self.m_cnt_out_tag = image_out_tag
 
     def run(self):
         """
@@ -633,29 +632,39 @@ class SDIpreparationModule(ProcessingModule):
         self.m_image_out_port.del_all_data()
         self.m_image_out_port.del_all_attributes()
 
-        pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
-
         wvl_factor = self.m_line_wvl/self.m_cnt_wvl
         width_factor = self.m_line_width/self.m_cnt_width
-
-        im_size = self.m_image_in_port.get_shape()[1]
 
         sys.stdout.write("Running SDIpreparationModule...\n")
         sys.stdout.flush()
 
         scaling = ScaleImagesModule(scaling=(wvl_factor, width_factor),
                                     name_in="scaling",
-                                    image_in_tag=self.m_image_in_tag,
+                                    image_in_tag=self.m_image_in_port.tag,
                                     image_out_tag="sdi_scaled")
 
         scaling.connect_database(self._m_data_base)
         scaling.run()
 
-        crop = CropImagesModule(size=im_size*pixscale,
-                                center=None,
-                                name_in="crop",
-                                image_in_tag="sdi_scaled",
-                                image_out_tag=self.m_cnt_out_tag)
+        sdi_port = self.add_input_port("sdi_scaled")
+
+        npix_del = sdi_port.get_shape()[1] - self.m_image_in_port.get_shape()[1]
+
+        if npix_del%2 == 0:
+            npix_del_a = npix_del/2
+            npix_del_b = npix_del/2
+
+        else:
+            warnings.warn("An unequal number of pixels is removed from both sides of the images. "
+                          "Recentering of the images is therefore required.")
+
+            npix_del_a = (npix_del-1)/2
+            npix_del_b = (npix_del+1)/2
+
+        crop = RemoveLinesModule(lines=(npix_del_a, npix_del_b, npix_del_a, npix_del_b),
+                                 name_in="crop",
+                                 image_in_tag="sdi_scaled",
+                                 image_out_tag=self.m_image_out_port.tag)
 
         crop.connect_database(self._m_data_base)
         crop.run()

--- a/tests/test_processing/test_PSFpreparation.py
+++ b/tests/test_processing/test_PSFpreparation.py
@@ -76,6 +76,7 @@ class TestPSFpreparation(object):
         data = self.pipeline.get_data("read")
         assert np.allclose(data[0, 25, 25], 2.0926464668090656e-05, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.00010029494781738066, rtol=limit, atol=0.)
+        assert data.shape == (40, 100, 100)
 
         data = self.pipeline.get_data("prep")
         assert np.allclose(data[0, 25, 25], 0., rtol=limit, atol=0.)
@@ -84,6 +85,6 @@ class TestPSFpreparation(object):
         assert data.shape == (40, 200, 200)
 
         data = self.pipeline.get_data("sdi")
-        assert np.allclose(data[0, 25, 25], 2.8586863287949902e-05, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 1.719735044879641e-05, rtol=limit, atol=0.)
-        assert data.shape == (40, 108, 108)
+        assert np.allclose(data[0, 25, 25], -2.6648118007008814e-05, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 2.0042892634995876e-05, rtol=limit, atol=0.)
+        assert data.shape == (40, 100, 100)


### PR DESCRIPTION
CropImagesModule makes even sized images which is a problem if the input continuum image is odd sized. Replaced it with RemoveLinesModule.