### PR TITLE
Update of the residuals in the new PCA implementation

### DIFF
--- a/PynPoint/ProcessingModules/PSFSubtractionPCA.py
+++ b/PynPoint/ProcessingModules/PSFSubtractionPCA.py
@@ -649,15 +649,15 @@ class PcaPsfSubtractionModule(ProcessingModule):
 
         super(PcaPsfSubtractionModule, self).__init__(name_in)
 
-        if "basis_out_tag" in kwargs:
-            self.m_basis_tag = kwargs["basis_out_tag"]
-        else:
-            self.m_basis_tag = None
-
         if "verbose" in kwargs:
             self.m_verbose = kwargs["verbose"]
         else:
             self.m_verbose = True
+
+        if "basis_out_tag" in kwargs:
+            self.m_basis_out_port = self.add_output_port(basis_out_tag)
+        else:
+            self.m_basis_out_port = None
 
         # look for the maximum number of components
         self.m_max_pacs = np.max(pca_numbers)
@@ -666,44 +666,33 @@ class PcaPsfSubtractionModule(ProcessingModule):
 
         self.m_pca = PCA(n_components=self.m_max_pacs, svd_solver="arpack")
 
-        # add input Ports
+        # add input ports
         self.m_reference_in_port = self.add_input_port(reference_in_tag)
         self.m_star_in_port = self.add_input_port(images_in_tag)
 
-        # create output if none create special not used port
-        self.m_res_mean_out_port = self.add_output_port(str(res_mean_tag))
-
-        # None check
-        if res_median_tag is None:
-            self.m_res_median_out_port = self.add_output_port(str("no median"))
-            self.m_res_median_out_port.deactivate()
+        # add output ports
+        if res_mean_tag is None:
+            self.m_res_mean_out_port = None
         else:
-            self.m_res_median_out_port = self.add_output_port(str(res_median_tag))
+            self.m_res_mean_out_port = self.add_output_port(res_mean_tag)
+
+        if res_median_tag is None:
+            self.m_res_median_out_port = None
+        else:
+            self.m_res_median_out_port = self.add_output_port(res_median_tag)
 
         if res_rot_mean_clip_tag is None:
-            self.m_res_rot_mean_clip_out_port = self.add_output_port(str("no clip"))
-            self.m_res_rot_mean_clip_out_port.deactivate()
+            self.m_res_rot_mean_clip_out_port = None
         else:
-            self.m_res_rot_mean_clip_out_port = self.add_output_port(str(res_rot_mean_clip_tag))
+            self.m_res_rot_mean_clip_out_port = self.add_output_port(res_rot_mean_clip_tag)
 
-        if self.m_basis_tag is not None:
-            self.m_basis_out_port = self.add_output_port(self.m_basis_tag)
-
-        # use a dict to store output ports for the non-stacked residuals
-        self.m_res_arr_out_ports = {}
-        self.m_res_arr_required = True
-
-        for pca_number in self.m_components:
-            # (cast to string for None case)
-            # if res_arr_out_tag is None we still get different Tag names like None02
-            self.m_res_arr_out_ports[pca_number] = self.add_output_port(str(res_arr_out_tag)
-                                                                        + str(pca_number))
-
-        # deactivate not needed array out ports
         if res_arr_out_tag is None:
-            self.m_res_arr_required = False
-            for port in self.m_res_arr_out_ports.itervalues():
-                port.deactivate()
+            self.m_res_arr_out_ports = None
+        else:
+            self.m_res_arr_out_ports = {}
+            for pca_number in self.m_components:
+                self.m_res_arr_out_ports[pca_number] = self.add_output_port(res_arr_out_tag
+                                                                            +str(pca_number))
 
     def _run_multi_processing(self, star_data):
         """
@@ -715,11 +704,16 @@ class PcaPsfSubtractionModule(ProcessingModule):
 
         tmp_output = np.zeros((len(self.m_components), star_data.shape[1], star_data.shape[2]))
 
-        self.m_res_mean_out_port.set_all(tmp_output, keep_attributes=False)
-        self.m_res_median_out_port.set_all(tmp_output, keep_attributes=False)
-        self.m_res_rot_mean_clip_out_port.set_all(tmp_output, keep_attributes=False)
+        if self.m_res_mean_out_port is not None:
+            self.m_res_mean_out_port.set_all(tmp_output, keep_attributes=False)
 
-        cpu_count = self._m_config_port.get_attribute("CPU")
+        if self.m_res_median_out_port is not None:
+            self.m_res_median_out_port.set_all(tmp_output, keep_attributes=False)
+
+        if self.m_res_rot_mean_clip_out_port is not None:
+            self.m_res_rot_mean_clip_out_port.set_all(tmp_output, keep_attributes=False)
+
+        cpu = self._m_config_port.get_attribute("CPU")
 
         rotations = -1.*self.m_star_in_port.get_attribute("PARANG")
         rotations += np.ones(rotations.shape[0]) * self.m_extra_rot
@@ -727,12 +721,12 @@ class PcaPsfSubtractionModule(ProcessingModule):
         pca_capsule = PcaMultiprocessingCapsule(self.m_res_mean_out_port,
                                                 self.m_res_median_out_port,
                                                 self.m_res_rot_mean_clip_out_port,
-                                                cpu_count,
+                                                cpu,
                                                 deepcopy(self.m_components),
                                                 deepcopy(self.m_pca),
                                                 deepcopy(star_data),
-                                                deepcopy(rotations),
-                                                result_requirements=(False, False, False))
+                                                deepcopy(rotations))
+
         pca_capsule.run()
 
     def _run_single_processing(self, star_sklearn, star_data):
@@ -743,11 +737,8 @@ class PcaPsfSubtractionModule(ProcessingModule):
         :return: None
         """
 
-        self.m_res_mean_out_port.del_all_data()
-        self.m_res_median_out_port.del_all_data()
-        self.m_res_rot_mean_clip_out_port.del_all_data()
-
         for i, pca_number in enumerate(self.m_components):
+
             if self.m_verbose:
                 progress(i, len(self.m_components), "Creating residuals...")
 
@@ -776,7 +767,7 @@ class PcaPsfSubtractionModule(ProcessingModule):
 
             # create residuals
             # 1.) The de-rotated result images
-            if self.m_res_arr_required:
+            if self.m_res_arr_out_ports is not None:
                 self.m_res_arr_out_ports[pca_number].set_all(res_array)
                 self.m_res_arr_out_ports[pca_number].copy_attributes_from_input_port(
                     self.m_star_in_port)
@@ -784,22 +775,28 @@ class PcaPsfSubtractionModule(ProcessingModule):
                                                                              "PCA")
 
             # 2.) mean
-            tmp_res_rot_mean = np.mean(res_array, axis=0)
-            self.m_res_mean_out_port.append(tmp_res_rot_mean, data_dim=3)
+            if self.m_res_mean_out_port is not None:
+                tmp_res_rot_mean = np.mean(res_array, axis=0)
+                self.m_res_mean_out_port.append(tmp_res_rot_mean, data_dim=3)
 
             # 3.) median
-            if self.m_res_median_out_port.m_activate:
+            if self.m_res_median_out_port is not None:
                 tmp_res_rot_median = np.median(res_array, axis=0)
                 self.m_res_median_out_port.append(tmp_res_rot_median, data_dim=3)
 
             # 4.) clipped mean
-            if self.m_res_rot_mean_clip_out_port.m_activate:
+            if self.m_res_rot_mean_clip_out_port is not None:
                 res_rot_temp = res_array.copy()
-                for j in range(res_rot_temp.shape[0]):
-                    res_rot_temp[j, ] -= - tmp_res_rot_mean
 
-                res_rot_var = (res_rot_temp ** 2.).sum(axis=0)
+                if self.m_res_mean_out_port is None:
+                    tmp_res_rot_mean = np.mean(res_array, axis=0)
+
+                for j in range(res_rot_temp.shape[0]):
+                    res_rot_temp[j, ] -= -tmp_res_rot_mean
+
+                res_rot_var = (res_rot_temp**2.).sum(axis=0)
                 tmp_res_rot_var = res_rot_var
+
                 self.m_res_rot_mean_clip_out_port.append(tmp_res_rot_var, data_dim=3)
 
         if self.m_verbose:
@@ -815,6 +812,23 @@ class PcaPsfSubtractionModule(ProcessingModule):
 
         :return: None
         """
+
+        if self.m_res_mean_out_port is not None:
+            self.m_res_mean_out_port.del_all_data()
+            self.m_res_mean_out_port.del_all_attributes()
+
+        if self.m_res_median_out_port is not None:
+            self.m_res_median_out_port.del_all_data()
+            self.m_res_median_out_port.del_all_attributes()
+
+        if self.m_res_rot_mean_clip_out_port is not None:
+            self.m_res_rot_mean_clip_out_port.del_all_data()
+            self.m_res_rot_mean_clip_out_port.del_all_attributes()
+
+        if self.m_res_arr_out_ports is not None:
+            for pca_number in self.m_components:
+                self.m_res_arr_out_ports[pca_number].del_all_data()
+                self.m_res_arr_out_ports[pca_number].del_all_attributes()
 
         # get all data and subtract the mean
         star_data = self.m_star_in_port.get_all()
@@ -842,7 +856,7 @@ class PcaPsfSubtractionModule(ProcessingModule):
             stdout.write(" [DONE]\n")
             stdout.flush()
 
-        if self.m_basis_tag is not None:
+        if self.m_basis_out_port is not None:
             basis = self.m_pca.components_.reshape((self.m_pca.components_.shape[0],
                                                     star_data.shape[1], star_data.shape[2]))
             self.m_basis_out_port.set_all(basis)
@@ -851,25 +865,34 @@ class PcaPsfSubtractionModule(ProcessingModule):
         star_sklearn = star_data.reshape((star_data.shape[0],
                                           star_data.shape[1] * star_data.shape[2]))
 
+        cpu = self._m_config_port.get_attribute("CPU")
+
         # multiprocessing crashed on Mac in combination with numpy
-        if platform == "darwin" or self.m_res_arr_required:
+        if platform == "darwin" or self.m_res_arr_out_ports is not None or cpu == 1:
             self._run_single_processing(star_sklearn, star_data)
+
         else:
             if self.m_verbose:
                 stdout.write("Creating residuals...")
                 stdout.flush()
+
             self._run_multi_processing(star_data)
+
             if self.m_verbose:
                 stdout.write(" [DONE]\n")
                 stdout.flush()
 
         # save history for all other ports
-        self.m_res_mean_out_port.copy_attributes_from_input_port(self.m_star_in_port)
-        self.m_res_median_out_port.copy_attributes_from_input_port(self.m_star_in_port)
-        self.m_res_rot_mean_clip_out_port.copy_attributes_from_input_port(self.m_star_in_port)
+        if self.m_res_mean_out_port is not None:
+            self.m_res_mean_out_port.copy_attributes_from_input_port(self.m_star_in_port)
+            self.m_res_mean_out_port.add_history_information("PSF subtraction", "PCA")
 
-        self.m_res_mean_out_port.add_history_information("PSF subtraction", "PCA")
-        self.m_res_median_out_port.add_history_information("PSF subtraction", "PCA")
-        self.m_res_rot_mean_clip_out_port.add_history_information("PSF subtraction", "PCA")
+        if self.m_res_median_out_port is not None:
+            self.m_res_median_out_port.copy_attributes_from_input_port(self.m_star_in_port)
+            self.m_res_median_out_port.add_history_information("PSF subtraction", "PCA")
 
-        self.m_res_mean_out_port.close_port()
+        if self.m_res_rot_mean_clip_out_port is not None:
+            self.m_res_rot_mean_clip_out_port.copy_attributes_from_input_port(self.m_star_in_port)
+            self.m_res_rot_mean_clip_out_port.add_history_information("PSF subtraction", "PCA")
+
+        self.m_star_in_port.close_port()

--- a/PynPoint/ProcessingModules/PSFSubtractionPCA.py
+++ b/PynPoint/ProcessingModules/PSFSubtractionPCA.py
@@ -594,7 +594,7 @@ class PcaPsfSubtractionModule(ProcessingModule):
     Module for fast (compared to PSFSubtractionModule) PCA subtraction. The multiprocessing
     implementation is only supported for Linux and Windows. Mac only runs in single processing
     due to a bug in the numpy package. Note that the calculation of the residuals with multi-
-    processing may required a large amount of memory in case the stack of input images is very
+    processing may require a large amount of memory in case the stack of input images is very
     large. In that case, CPU could be set to a smaller number (or even 1) in the configuration
     file.
     """
@@ -807,7 +807,7 @@ class PcaPsfSubtractionModule(ProcessingModule):
             stdout.write("Creating residuals... [DONE]\n")
             stdout.flush()
 
-    def _clear_output_port(self):
+    def _clear_output_ports(self):
         if self.m_res_mean_out_port is not None:
             self.m_res_mean_out_port.del_all_data()
             self.m_res_mean_out_port.del_all_attributes()
@@ -835,7 +835,7 @@ class PcaPsfSubtractionModule(ProcessingModule):
         :return: None
         """
 
-        self._clear_output_port()
+        self._clear_output_ports()
 
         # get all data and subtract the mean
         star_data = self.m_star_in_port.get_all()

--- a/PynPoint/Util/MultiprocessingPCA.py
+++ b/PynPoint/Util/MultiprocessingPCA.py
@@ -74,7 +74,7 @@ class PcaTaskProcessor(TaskProcessor):
                  star_arr,
                  angles,
                  pca_model,
-                 result_requirements=(False, False, False, False)):
+                 result_requirements=(False, False, False)):
         """
         Constructor of PcaTaskProcessor.
 

--- a/PynPoint/Util/MultiprocessingPCA.py
+++ b/PynPoint/Util/MultiprocessingPCA.py
@@ -74,7 +74,7 @@ class PcaTaskProcessor(TaskProcessor):
                  star_arr,
                  angles,
                  pca_model,
-                 result_requirements=(False, False, False)):
+                 result_requirements=(False, False, False, False)):
         """
         Constructor of PcaTaskProcessor.
 
@@ -89,7 +89,7 @@ class PcaTaskProcessor(TaskProcessor):
         :param pca_model:
         :type pca_model: PCA
         :param result_requirements:
-        :type result_requirements:
+        :type result_queue_innts:
 
         :return: None
         """
@@ -133,23 +133,23 @@ class PcaTaskProcessor(TaskProcessor):
         # create residuals
         res_length = 3
 
-        if self.m_result_requirements[2]:
-            res_length += res_array.shape[0]
+        # if self.m_result_requirements[3]:
+        #     res_length += res_array.shape[0]
 
         residual_output = np.zeros((res_length, res_array.shape[1], res_array.shape[2]))
 
         # 1.) mean
-        tmp_res_rot_mean = np.mean(res_array, axis=0)
-
-        residual_output[0, :, :] = tmp_res_rot_mean
+        if self.m_result_requirements[0]:
+            tmp_res_rot_mean = np.mean(res_array, axis=0)
+            residual_output[0, :, :] = tmp_res_rot_mean
 
         # 2.) median
-        if self.m_result_requirements[0]:
+        if self.m_result_requirements[1]:
             tmp_res_rot_median = np.median(res_array, axis=0)
             residual_output[1, :, :] = tmp_res_rot_median
 
         # 3.) clipped mean
-        if self.m_result_requirements[1]:
+        if self.m_result_requirements[2]:
             res_rot_mean_clip = np.zeros(self.m_star_arr[0, ].shape)
 
             for i in range(res_rot_mean_clip.shape[0]):
@@ -167,8 +167,8 @@ class PcaTaskProcessor(TaskProcessor):
             residual_output[2, :, :] = res_rot_mean_clip
 
         # 4.) The de-rotated result images
-        if self.m_result_requirements[2]:
-            residual_output[3:, :, :] = res_array
+        # if self.m_result_requirements[3]:
+        #     residual_output[3:, :, :] = res_array
 
         # print "Created Residual with " + str(pca_number) + " components"
 
@@ -227,19 +227,20 @@ class PcaTaskWriter(TaskWriter):
                 continue
 
             with self.m_data_mutex:
-                self.m_data_out_port[to_slice(next_result.m_position)] = \
-                    next_result.m_data_array[0, :, :]
-
                 if self.m_result_requirements[0]:
+                    self.m_data_out_port[to_slice(next_result.m_position)] = \
+                        next_result.m_data_array[0, :, :]
+
+                if self.m_result_requirements[1]:
                     self.m_median_out_port_in[to_slice(next_result.m_position)] = \
                         next_result.m_data_array[1, :, :]
 
-                if self.m_result_requirements[1]:
+                if self.m_result_requirements[2]:
                     self.m_clip_out_port_in[to_slice(next_result.m_position)] = \
                         next_result.m_data_array[2, :, :]
 
-                if self.m_result_requirements[2]:
-                    raise NotImplementedError("Not yet supported.")
+                # if self.m_result_requirements[2]:
+                #     raise NotImplementedError("Not yet supported.")
 
             self.m_result_queue.task_done()
 
@@ -257,8 +258,7 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
                  pca_numbers,
                  pca_model,
                  star_arr,
-                 rotations,
-                 result_requirements=(False, False, False)):
+                 rotations):
         """
         Constructor of PcaMultiprocessingCapsule.
 
@@ -276,8 +276,6 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
         :type star_arr:
         :param rotations:
         :type rotations:
-        :param result_requirements:
-        :type result_requirements:
 
         :return: None
         """
@@ -285,11 +283,21 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
         self.m_mean_out_port = mean_out_port
         self.m_median_out_port = median_out_port
         self.m_clip_out_port = clip_out_port
-        self.m_result_requirements = result_requirements
         self.m_pca_numbers = pca_numbers
         self.m_pca_model = pca_model
         self.m_star_arr = star_arr
         self.m_rotations = rotations
+
+        self.m_result_requirements = [False, False, False]
+
+        if self.m_mean_out_port is not None:
+            self.m_result_requirements[0] = True
+
+        if self.m_median_out_port is not None:
+            self.m_result_requirements[1] = True
+
+        if self.m_clip_out_port is not None:
+            self.m_result_requirements[2] = True
 
         super(PcaMultiprocessingCapsule, self).__init__(None, None, num_processors)
 


### PR DESCRIPTION
It was not possible to create any other residuals then the mean residuals when the multiprocessing was used with the PSF subtraction so I made some changes related to the output ports and the residuals that are written. All output tags are now working and can also be set to None (also the 'mean' tag). Tested with CPU=1 and CPU=8.