### PR TITLE
several small updates

### DIFF
--- a/PynPoint/Core/Processing.py
+++ b/PynPoint/Core/Processing.py
@@ -23,7 +23,7 @@ class PypelineModule:
         * Writing Module (:class:`PynPoint.core.Processing.WritingModule`)
         * Processing Module (:class:`PynPoint.core.Processing.ProcessingModule`)
 
-    Each PypelinModule has a name as a unique identifier in the Pypeline and has to implement the
+    Each PypelineModule has a name as a unique identifier in the Pypeline and has to implement the
     functions *connect_database* and *run* which are used in the Pypeline methods.
     """
 

--- a/PynPoint/ProcessingModules/BackgroundSubtraction.py
+++ b/PynPoint/ProcessingModules/BackgroundSubtraction.py
@@ -421,7 +421,6 @@ class PCABackgroundPreparationModule(ProcessingModule):
             if bg_frames[i]:
                 background = cube_mean[i, ]
                 self.m_background_out_port.append(im_tmp)
-                self.m_background_out_port.append(im_tmp)
 
                 background_nframes = np.append(background_nframes, nframes[i])
                 background_index = np.append(background_index, index[count:count+item])

--- a/PynPoint/ProcessingModules/BackgroundSubtraction.py
+++ b/PynPoint/ProcessingModules/BackgroundSubtraction.py
@@ -270,7 +270,6 @@ class PCABackgroundPreparationModule(ProcessingModule):
 
     def __init__(self,
                  dither,
-                 mean=False,
                  name_in="separate_star",
                  image_in_tag="im_arr",
                  star_out_tag="im_arr_star",
@@ -319,7 +318,6 @@ class PCABackgroundPreparationModule(ProcessingModule):
             raise ValueError("The 'dither' tuple should contain three integer values.")
 
         self.m_dither = dither
-        self.m_mean = mean
 
     def _prepare(self):
         nframes = self.m_image_in_port.get_attribute("NFRAMES")
@@ -419,15 +417,11 @@ class PCABackgroundPreparationModule(ProcessingModule):
 
             im_tmp = self.m_image_in_port[count:count+item, ]
 
-            if self.m_mean:
-                for j in enumerate(item):
-                    im_tmp[j, ] -= np.mean(im_tmp[j, ])
-
             # Background frames
             if bg_frames[i]:
                 background = cube_mean[i, ]
                 self.m_background_out_port.append(im_tmp)
-                # self.m_background_out_port.append(im_tmp-background)
+                self.m_background_out_port.append(im_tmp)
 
                 background_nframes = np.append(background_nframes, nframes[i])
                 background_index = np.append(background_index, index[count:count+item])
@@ -535,6 +529,7 @@ class PCABackgroundSubtractionModule(ProcessingModule):
                  pca_number=60,
                  mask_star=0.7,
                  mask_planet=None,
+                 subtract_mean=False,
                  name_in="pca_background",
                  star_in_tag="im_star",
                  background_in_tag="im_background",
@@ -553,6 +548,9 @@ class PCABackgroundSubtractionModule(ProcessingModule):
                             (deg), and radius (arcsec) of the mask, (sep, angle, extra_rot,
                             radius). No mask is used when set to None.
         :type mask_planet: tuple(float, float, float, float)
+        :param subtract_mean: The mean of the background images is subtracted from both the star
+                              and background images before the PCA basis is constructed.
+        :type subtract_mean: bool
         :param name_in: Unique name of the module instance.
         :type name_in: str
         :param star_in_tag: Tag of the database entry with the star images.
@@ -591,6 +589,7 @@ class PCABackgroundSubtractionModule(ProcessingModule):
         self.m_pca_number = pca_number
         self.m_mask_star = mask_star
         self.m_mask_planet = mask_planet
+        self.m_subtract_mean = subtract_mean
 
     def run(self):
         """
@@ -625,10 +624,13 @@ class PCABackgroundSubtractionModule(ProcessingModule):
 
             return mask
 
-        def _create_basis(images, pca_number):
+        def _create_basis(images, bg_mean, pca_number):
             """
             Method for creating a set of principle components for a stack of images.
             """
+
+            if self.m_subtract_mean:
+                images -= bg_mean
 
             _, _, v_svd = svds(images.reshape(images.shape[0],
                                               images.shape[1]*images.shape[2]),
@@ -701,7 +703,13 @@ class PCABackgroundSubtractionModule(ProcessingModule):
         sys.stdout.write("Creating PCA basis set...")
         sys.stdout.flush()
 
+        if self.m_subtract_mean:
+            bg_mean = np.mean(self.m_background_in_port.get_all(), axis=0)
+        else:
+            bg_mean = None
+
         basis_pca = _create_basis(self.m_background_in_port.get_all(),
+                                  bg_mean,
                                   self.m_pca_number)
 
         sys.stdout.write(" [DONE]\n")
@@ -715,6 +723,9 @@ class PCABackgroundSubtractionModule(ProcessingModule):
             progress(i, len(frames[:-1]), "Calculating background model...")
 
             im_star = self.m_star_in_port[frames[i]:frames[i+1], ]
+
+            if self.m_subtract_mean:
+                im_star -= bg_mean
 
             mask_star = _create_mask(self.m_mask_star,
                                      star[frames[i]:frames[i+1], ],
@@ -785,6 +796,7 @@ class DitheringBackgroundModule(ProcessingModule):
                  subframe=None,
                  pca_number=60,
                  mask_star=0.7,
+                 subtract_mean=False,
                  **kwargs):
         """
         Constructor of DitheringBackgroundModule.
@@ -821,6 +833,9 @@ class DitheringBackgroundModule(ProcessingModule):
         :type pca_number: int
         :param mask_star: Radius of the central mask (arcsec).
         :type mask_star: float
+        :param subtract_mean: The mean of the background images is subtracted from both the star
+                              and background images before the PCA basis is constructed.
+        :type subtract_mean: bool
         :param \**kwargs:
             See below.
 
@@ -884,6 +899,7 @@ class DitheringBackgroundModule(ProcessingModule):
         self.m_gaussian = gaussian
         self.m_pca_number = pca_number
         self.m_mask_star = mask_star
+        self.m_subtract_mean = subtract_mean
 
         if subframe is None:
             self.m_subframe = subframe
@@ -976,7 +992,6 @@ class DitheringBackgroundModule(ProcessingModule):
                 prepare = PCABackgroundPreparationModule(dither=(n_dither,
                                                                  self.m_cubes,
                                                                  star_pos[i]),
-                                                         mean=False,
                                                          name_in="prepare"+str(i),
                                                          image_in_tag="dither_crop"+str(i+1),
                                                          star_out_tag="dither_star"+str(i+1),
@@ -1020,6 +1035,7 @@ class DitheringBackgroundModule(ProcessingModule):
                 pca = PCABackgroundSubtractionModule(pca_number=self.m_pca_number,
                                                      mask_star=self.m_mask_star,
                                                      mask_planet=self.m_mask_planet,
+                                                     subtract_mean=self.m_subtract_mean,
                                                      name_in="pca_background"+str(i),
                                                      star_in_tag="dither_star"+str(i+1),
                                                      background_in_tag="dither_background"+str(i+1),
@@ -1035,6 +1051,7 @@ class DitheringBackgroundModule(ProcessingModule):
         if self.m_combine is not None:
             combine = CombineTagsModule(name_in="combine",
                                         check_attr=True,
+                                        index_init=False,
                                         image_in_tags=tags,
                                         image_out_tag="dither_combine")
 

--- a/PynPoint/ProcessingModules/BasicOperations.py
+++ b/PynPoint/ProcessingModules/BasicOperations.py
@@ -7,7 +7,7 @@ import sys
 from scipy.ndimage import rotate
 
 from PynPoint.Core.Processing import ProcessingModule
-from PynPoint.Util.ModuleTools import progress, memory_frames, number_images
+from PynPoint.Util.ModuleTools import progress, memory_frames, number_images_port
 
 
 class SubtractImagesModule(ProcessingModule):
@@ -195,7 +195,7 @@ class RotateImagesModule(ProcessingModule):
             raise ValueError("Input and output port should have a different tag.")
 
         memory = self._m_config_port.get_attribute("MEMORY")
-        nimages = number_images(self.m_image_in_port)
+        nimages = number_images_port(self.m_image_in_port)
         frames = memory_frames(memory, nimages)
 
         for i, _ in enumerate(frames[:-1]):

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -482,6 +482,7 @@ class SimplexMinimizationModule(ProcessingModule):
         sys.stdout.flush()
 
         pos_init = _rotate(center, self.m_position, self.m_extra_rot)
+        pos_init = (int(pos_init[0]), int(pos_init[1]))
 
         minimize(fun=_objective,
                  x0=[pos_init[0], pos_init[1], self.m_magnitude],

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -14,7 +14,7 @@ from scipy import ndimage
 
 from PynPoint.Core.Processing import ProcessingModule
 from PynPoint.ProcessingModules.ImageResizing import RemoveLinesModule, ScaleImagesModule
-from PynPoint.Util.ModuleTools import progress, memory_frames
+from PynPoint.Util.ModuleTools import progress, memory_frames, image_size, create_mask
 
 
 class PSFpreparationModule(ProcessingModule):
@@ -127,28 +127,9 @@ class PSFpreparationModule(ProcessingModule):
         Internal method which masks the central and outer parts of the images.
         """
 
-        im_shape = (im_data.shape[1], im_data.shape[2])
+        im_shape = image_size(im_data)
 
-        mask = np.ones(im_shape)
-
-        if self.m_cent_size is not None or self.m_edge_size is not None:
-            npix = im_shape[0]
-
-            if npix%2 == 0:
-                x_grid = y_grid = np.linspace(-npix/2+0.5, npix/2-0.5, npix)
-            elif npix%2 == 1:
-                x_grid = y_grid = np.linspace(-(npix-1)/2, (npix-1)/2, npix)
-
-            xx_grid, yy_grid = np.meshgrid(x_grid, y_grid)
-            rr_grid = np.sqrt(xx_grid**2+yy_grid**2)
-
-        if self.m_cent_size is not None:
-            mask[rr_grid < self.m_cent_size] = 0.
-
-        if self.m_edge_size is not None:
-            if self.m_edge_size > npix/2.:
-                self.m_edge_size = npix/2.
-            mask[rr_grid > self.m_edge_size] = 0.
+        mask = create_mask(im_shape, [self.m_cent_size, self.m_edge_size])
 
         if self.m_mask_out_port is not None:
             self.m_mask_out_port.set_all(mask)

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -66,6 +66,11 @@ We would like to thank several people who provided contributions and helped test
 Changelog
 ---------
 
+0.5.0 (2018-06-19)
+++++++++++++++++++
+
+* Release on the PyPI server
+
 0.4.0 (2018-03-15)
 ++++++++++++++++++
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -8,9 +8,9 @@ Quickstart
 Installation
 ------------
 
-Installation of PynPoint is achieved from the command line with the |pip| (**not possible yet**): ::
+PynPoint is available in the |pypi| and can be installed from the command line with the |pip|: ::
 
-    $ pip install --user PynPoint
+    $ pip install --user pynpoint
 
 Alternatively, the PynPoint repository can be cloned from Github, which will contain the most recent implementations: ::
 
@@ -19,6 +19,10 @@ Alternatively, the PynPoint repository can be cloned from Github, which will con
 Or the repository can be downloaded from the |Github| as a zip file. If needed, the required Python packages can be installed from the PynPoint folder with: ::
 
     $ pip install -r requirements.txt
+
+.. |pypi| raw:: html
+
+   <a href="https://pypi.org/project/pynpoint/" target="_blank">PyPI repository</a>
 
 .. |pip| raw:: html
 

--- a/tests/test_processing/test_FluxAndPosition.py
+++ b/tests/test_processing/test_FluxAndPosition.py
@@ -142,10 +142,10 @@ class TestFluxAndPosition(object):
 
         data = storage.m_data_bank["flux_position"]
         assert np.allclose(data[46, 0], 32.31651815143485, rtol=limit, atol=0.)
-        assert np.allclose(data[46, 1], 50.10345749706295, rtol=limit, atol=0.)
-        assert np.allclose(data[46, 2], 0.5055288651354779, rtol=limit, atol=0.)
-        assert np.allclose(data[46, 3], 89.6834045889695, rtol=limit, atol=0.)
-        assert np.allclose(data[46, 4], 4.997674024675655, rtol=limit, atol=0.)
+        assert np.allclose(data[46, 1], 54.29654740209472, rtol=limit, atol=0.)
+        assert np.allclose(data[46, 2], 0.49134499544925503, rtol=limit, atol=0.)
+        assert np.allclose(data[46, 3], 76.34349996, rtol=limit, atol=0.)
+        assert np.allclose(data[46, 4], 4.24884874724, rtol=limit, atol=0.)
 
         data = storage.m_data_bank["res_mean"]
         assert np.allclose(data[0, 49, 31], 9.258255068620805e-05, rtol=limit, atol=0.)

--- a/tests/test_processing/test_FluxAndPosition.py
+++ b/tests/test_processing/test_FluxAndPosition.py
@@ -80,12 +80,12 @@ class TestFluxAndPosition(object):
                                             psf_in_tag="read",
                                             res_out_tag="simplex_res",
                                             flux_position_tag="flux_position",
-                                            merit="sum",
-                                            aperture=0.05,
-                                            sigma=0.027,
+                                            merit="hessian",
+                                            aperture=0.1,
+                                            sigma=0.,
                                             tolerance=0.1,
-                                            pca_number=2,
-                                            cent_size=None,
+                                            pca_number=1,
+                                            cent_size=0.1,
                                             edge_size=None,
                                             extra_rot=0.)
 
@@ -137,15 +137,15 @@ class TestFluxAndPosition(object):
         assert np.allclose(np.mean(data), 0.0001012983225928772, rtol=limit, atol=0.)
 
         data = storage.m_data_bank["simplex_res"]
-        assert np.allclose(data[46, 49, 31], 6.02309675294837e-06, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), -2.408916491902155e-08, rtol=limit, atol=0.)
+        assert np.allclose(data[39, 49, 31], 3.867262068300381e-05, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), -3.2370214672746846e-08, rtol=limit, atol=0.)
 
         data = storage.m_data_bank["flux_position"]
-        assert np.allclose(data[46, 0], 32.31651815143485, rtol=limit, atol=0.)
-        assert np.allclose(data[46, 1], 54.29654740209472, rtol=limit, atol=0.)
-        assert np.allclose(data[46, 2], 0.49134499544925503, rtol=limit, atol=0.)
-        assert np.allclose(data[46, 3], 76.34349996, rtol=limit, atol=0.)
-        assert np.allclose(data[46, 4], 4.24884874724, rtol=limit, atol=0.)
+        assert np.allclose(data[39, 0], 31.488455510806045, rtol=limit, atol=0.)
+        assert np.allclose(data[39, 1], 50.06387100494, rtol=limit, atol=0.)
+        assert np.allclose(data[39, 2], 0.49981467627913445, rtol=limit, atol=0.)
+        assert np.allclose(data[39, 3], 89.80231122816105, rtol=limit, atol=0.)
+        assert np.allclose(data[39, 4], 5.024025489733977, rtol=limit, atol=0.)
 
         data = storage.m_data_bank["res_mean"]
         assert np.allclose(data[0, 49, 31], 9.258255068620805e-05, rtol=limit, atol=0.)

--- a/tests/test_processing/test_FluxAndPosition.py
+++ b/tests/test_processing/test_FluxAndPosition.py
@@ -137,11 +137,11 @@ class TestFluxAndPosition(object):
         assert np.allclose(np.mean(data), 0.0001012983225928772, rtol=limit, atol=0.)
 
         data = storage.m_data_bank["simplex_res"]
-        assert np.allclose(data[46, 49, 31], 3.718481593648487e-05, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), -2.8892749617545238e-08, rtol=limit, atol=0.)
+        assert np.allclose(data[46, 49, 31], 6.02309675294837e-06, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), -2.408916491902155e-08, rtol=limit, atol=0.)
 
         data = storage.m_data_bank["flux_position"]
-        assert np.allclose(data[46, 0], 31.276994533457994, rtol=limit, atol=0.)
+        assert np.allclose(data[46, 0], 32.31651815143485, rtol=limit, atol=0.)
         assert np.allclose(data[46, 1], 50.10345749706295, rtol=limit, atol=0.)
         assert np.allclose(data[46, 2], 0.5055288651354779, rtol=limit, atol=0.)
         assert np.allclose(data[46, 3], 89.6834045889695, rtol=limit, atol=0.)

--- a/tests/test_processing/test_StarAlignment.py
+++ b/tests/test_processing/test_StarAlignment.py
@@ -113,6 +113,6 @@ class TestStarAlignment(object):
 
         data = storage.m_data_bank["center"]
         assert np.allclose(data[0, 10, 10], 4.128859892625027e-05, rtol=1e-4, atol=0.)
-        assert np.allclose(np.mean(data), 0.0005163806188663894, rtol=1e-7, atol=0.)
+        assert np.allclose(np.mean(data), 0.0005163806188663894, rtol=1e-4, atol=0.)
 
         storage.close_connection()


### PR DESCRIPTION
- _subtract_mean_ parameter for the PCA background subtraction. If set to True, the mean of the stack with background images is subtracted from both the background images and the star images before the PCA basis is calculated.
- _index_init_ in CombineTagsModule. If set to True, new index stamps are created, simply starting counting from zero in the order by which database tags are combined. If set to False, the _INDEX_ attribute is copied from the input tags.
- Several small functions in Util.ModuleTools which are often needed by processing modules.
- Both inner and outer mask possible with the MCMC sampling.