### PR TITLE
dither parameter in WaffleCenteringModule

### DIFF
--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -720,26 +720,31 @@ class WaffleCenteringModule(ProcessingModule):
         :return: None
         """
 
+        def _get_center(ndim, center):
+            if ndim == 2:
+                center_frame = self.m_center_in_port.get_all()
+
+            elif ndim == 3:
+                center_frame = self.m_center_in_port.get_all()[0, ]
+
+                if center_shape[0] > 1:
+                    warnings.warn("Multiple center images found. Using the first image of "
+                                  "the stack.")
+
+            if center is None:
+                center = image_center(center_frame)
+            else:
+                center = (np.floor(center[0]), np.floor(center[1]))
+
+            return center_frame, center
+
         self.m_image_out_port.del_all_data()
         self.m_image_out_port.del_all_attributes()
 
         center_ndim = self.m_center_in_port.get_ndim()
         center_shape = self.m_center_in_port.get_shape()
         im_shape = self.m_image_in_port.get_shape()
-
-        if center_ndim == 2:
-            center_frame = self.m_center_in_port.get_all()
-
-        elif center_ndim == 3:
-            center_frame = self.m_center_in_port.get_all()[0, ]
-
-            if center_shape[0] > 1:
-                warnings.warn("Multiple center images found. Using the first image of the stack.")
-
-        if self.m_center is None:
-            self.m_center = image_center(center_frame)
-        else:
-            self.m_center = (np.floor(self.m_center[0]), np.floor(self.m_center[1]))
+        center_frame, self.m_center = _get_center(center_ndim, self.m_center)
 
         if im_shape[-2:] != center_shape[-2:]:
             raise ValueError("Science and center images should have the same shape.")

--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -861,7 +861,7 @@ class WaffleCenteringModule(ProcessingModule):
                         (float(im_shape[-1])-1.)/2. - x_center]
 
             if self.m_dither:
-                index = np.digitize(i, nframes, right==False) - 1
+                index = np.digitize(i, nframes, right=False) - 1
 
                 shift_yx[0] -= dither_y[index]
                 shift_yx[1] -= dither_x[index]

--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -757,7 +757,8 @@ class WaffleCenteringModule(ProcessingModule):
             dither_y = self.m_image_in_port.get_attribute("DITHER_Y")
 
             nframes = self.m_image_in_port.get_attribute("NFRAMES")
-            nframes = np.cumsum(nframes) - 1
+            nframes = np.cumsum(nframes)
+            nframes = np.insert(nframes, 0, 0)
 
         center_frame_unsharp = center_frame - gaussian_filter(input=center_frame,
                                                               sigma=self.m_sigma)

--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -745,6 +745,9 @@ class WaffleCenteringModule(ProcessingModule):
             dither_x = self.m_image_in_port.get_attribute("DITHER_X")
             dither_y = self.m_image_in_port.get_attribute("DITHER_Y")
 
+            nframes = self.m_image_in_port.get_attribute("NFRAMES")
+            nframes = np.cumsum(nframes) - 1
+
         center_frame_unsharp = center_frame - gaussian_filter(input=center_frame,
                                                               sigma=self.m_sigma)
 
@@ -858,8 +861,10 @@ class WaffleCenteringModule(ProcessingModule):
                         (float(im_shape[-1])-1.)/2. - x_center]
 
             if self.m_dither:
-                shift_yx[0] -= dither_y[i]
-                shift_yx[1] -= dither_x[i]
+                index = np.digitize(i, nframes, right==False) - 1
+
+                shift_yx[0] -= dither_y[index]
+                shift_yx[1] -= dither_x[index]
 
             if npix%2 == 0:
                 im_tmp = np.zeros((image.shape[0]+1, image.shape[1]+1))

--- a/PynPoint/Util/ModuleTools.py
+++ b/PynPoint/Util/ModuleTools.py
@@ -130,7 +130,7 @@ def image_size(images):
 
 def image_center(image):
     """
-    Function to get the pixel position of the center of a square image. Note that this position
+    Function to get the pixel position of the center of an image. Note that this position
     can not be unambiguously defined for an even-sized image.
 
     :param image: Input image (2D or 3D).
@@ -140,11 +140,14 @@ def image_center(image):
     :rtype: (int, int)
     """
 
-    if image.shape[-2] != image.shape[-1]:
-        warnings.warn("PynPoint only supports processing of square images.")
+    if image.shape[-2]%2 == 0 and image.shape[-1]%2 == 0:
+        center = (image.shape[-2]/2-1, image.shape[-1]/2-1)
 
-    if image.shape[-1]%2 == 0:
-        center = (image.shape[-1]/2-1, image.shape[-1]/2-1)
+    elif image.shape[-2]%2 == 0 and image.shape[-1]%2 == 1:
+        center = (image.shape[-2]/2-1, (image.shape[-1]-1)/2)
+
+    elif image.shape[-2]%2 == 1 and image.shape[-1]%2 == 0:
+        center = ((image.shape[-2]-1)/2, image.shape[-1]/2-1)
 
     elif image.shape[-1]%2 == 1:
         center = ((image.shape[-1]-1)/2, (image.shape[-1]-1)/2)

--- a/PynPoint/Util/ModuleTools.py
+++ b/PynPoint/Util/ModuleTools.py
@@ -149,8 +149,8 @@ def image_center(image):
     elif image.shape[-2]%2 == 1 and image.shape[-1]%2 == 0:
         center = ((image.shape[-2]-1)/2, image.shape[-1]/2-1)
 
-    elif image.shape[-1]%2 == 1:
-        center = ((image.shape[-1]-1)/2, (image.shape[-1]-1)/2)
+    elif image.shape[-2]%2 == 1 and image.shape[-1]%2 == 1:
+        center = ((image.shape[-2]-1)/2, (image.shape[-1]-1)/2)
 
     return center
 

--- a/PynPoint/Util/ModuleTools.py
+++ b/PynPoint/Util/ModuleTools.py
@@ -4,6 +4,7 @@ Functions for Pypeline modules.
 
 import sys
 import math
+import warnings
 
 import cv2
 import numpy as np
@@ -138,6 +139,9 @@ def image_center(image):
     :return: Pixel position of the image center.
     :rtype: (int, int)
     """
+
+    if image.shape[-2] != image.shape[-1]:
+        warnings.warn("PynPoint only supports processing of square images.")
 
     if image.shape[-1]%2 == 0:
         center = (image.shape[-1]/2-1, image.shape[-1]/2-1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ configparser
 h5py==2.6.0
 numpy
 numba==0.37.0
-scipy
+scipy==1.1.0
 astropy<3.0.0
 photutils
-scikit-image
+scikit-image==0.14.0
 scikit-learn
 opencv-python
 statsmodels==0.8.0


### PR DESCRIPTION
- Added a _dither_ parameter (default is False) in the WaffleCenteringModule. If set to True then the DITHER_X and DITHER_Y attributes will be used to apply an additional correction for a dithering offset. In the config file DITHER_X should be set to ESO INS1 DITH POSX and DITHER_Y to ESO INS1 DITH POSY for SPHERE/IRDIS data. Tested on an IRDIS pupil-stabilized DPI data set.

- Updated the requirements.txt file