### PR TITLE
Two new modules for bad pixel cleaning

### DIFF
--- a/PynPoint/Core/Processing.py
+++ b/PynPoint/Core/Processing.py
@@ -433,7 +433,7 @@ class ProcessingModule(PypelineModule):
                     for k in range(images.shape[0]):
                         result.append(func(images[k], * func_args))
 
-            return result
+            return np.asarray(result)
 
         ndim, frames = _initialize()
 
@@ -451,10 +451,10 @@ class ProcessingModule(PypelineModule):
                 if image_out_port.tag == image_in_port.tag:
                     try:
                         if np.size(frames) == 2:
-                            image_out_port.set_all(np.asarray(result), keep_attributes=True)
+                            image_out_port.set_all(result, keep_attributes=True)
 
                         else:
-                            image_out_port[frames[i]:frames[i+1]] = np.asarray(result)
+                            image_out_port[frames[i]:frames[i+1]] = result
 
                     except TypeError:
                         raise ValueError("Input and output port have the same tag while %s is "
@@ -462,7 +462,10 @@ class ProcessingModule(PypelineModule):
                                          "MEMORY=None." % func)
 
                 else:
-                    image_out_port.append(np.asarray(result))
+                    if ndim == 2:
+                        result = np.squeeze(result, axis=0)
+
+                    image_out_port.append(result)
 
         sys.stdout.write(message+" [DONE]\n")
         sys.stdout.flush()

--- a/PynPoint/ProcessingModules/TimeDenoising.py
+++ b/PynPoint/ProcessingModules/TimeDenoising.py
@@ -172,9 +172,9 @@ class WaveletTimeDenoisingModule(ProcessingModule):
         else:
             return
 
-        self.apply_function_to_line_in_time_multi_processing(denoise_line_in_time,
-                                                             self.m_image_in_port,
-                                                             self.m_image_out_port)
+        self.apply_function_in_time(denoise_line_in_time,
+                                    self.m_image_in_port,
+                                    self.m_image_out_port)
 
         self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
         self.m_image_out_port.add_history_information("Wavelet time de-noising",

--- a/PynPoint/ProcessingModules/__init__.py
+++ b/PynPoint/ProcessingModules/__init__.py
@@ -7,7 +7,8 @@ from PynPoint.ProcessingModules.BackgroundSubtraction import SimpleBackgroundSub
 
 from PynPoint.ProcessingModules.BadPixelCleaning import BadPixelSigmaFilterModule, \
                                                         BadPixelInterpolationModule, \
-                                                        BadPixelMapModule
+                                                        BadPixelMapModule, \
+                                                        BadPixelTimeFilterModule
 
 from PynPoint.ProcessingModules.DarkAndFlatCalibration import DarkCalibrationModule, \
                                                               FlatCalibrationModule                                                              

--- a/PynPoint/ProcessingModules/__init__.py
+++ b/PynPoint/ProcessingModules/__init__.py
@@ -8,7 +8,8 @@ from PynPoint.ProcessingModules.BackgroundSubtraction import SimpleBackgroundSub
 from PynPoint.ProcessingModules.BadPixelCleaning import BadPixelSigmaFilterModule, \
                                                         BadPixelInterpolationModule, \
                                                         BadPixelMapModule, \
-                                                        BadPixelTimeFilterModule
+                                                        BadPixelTimeFilterModule, \
+                                                        ReplaceBadPixelsModule
 
 from PynPoint.ProcessingModules.DarkAndFlatCalibration import DarkCalibrationModule, \
                                                               FlatCalibrationModule                                                              

--- a/PynPoint/Util/ModuleTools.py
+++ b/PynPoint/Util/ModuleTools.py
@@ -83,7 +83,7 @@ def crop_image(image, center, size):
     if image.ndim == 2:
         im_crop = np.copy(image[y_start:y_end, x_start:x_end])
 
-    elif image.ndim == 2:
+    elif image.ndim == 3:
         im_crop = np.copy(image[:, y_start:y_end, x_start:x_end])
 
     return im_crop

--- a/tests/test_processing/test_BadPixelCleaning.py
+++ b/tests/test_processing/test_BadPixelCleaning.py
@@ -7,7 +7,8 @@ import numpy as np
 from PynPoint.Core.Pypeline import Pypeline
 from PynPoint.ProcessingModules.BadPixelCleaning import BadPixelSigmaFilterModule, \
                                                         BadPixelMapModule, \
-                                                        BadPixelInterpolationModule
+                                                        BadPixelInterpolationModule, \
+                                                        BadPixelTimeFilterModule
 from PynPoint.Util.TestTools import create_config, remove_test_data
 
 warnings.simplefilter("always")
@@ -112,4 +113,21 @@ class TestBadPixelCleaning(object):
         assert np.allclose(data[0, 10, 10], 1.0139222106683477e-05, rtol=limit, atol=0.)
         assert np.allclose(data[0, 20, 20], -4.686852973820094e-05, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 3.0499629451215465e-07, rtol=limit, atol=0.)
+        assert data.shape == (40, 100, 100)
+
+    def test_bad_pixel_time(self):
+
+        time = BadPixelTimeFilterModule(name_in="time",
+                                        image_in_tag="images",
+                                        image_out_tag="time",
+                                        sigma=(5., 5.))
+
+        self.pipeline.add_module(time)
+        self.pipeline.run_module("time")
+
+        data = self.pipeline.get_data("time")
+        assert np.allclose(data[0, 0, 0], 0.00032486907273264834, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 10, 10], 8.32053029919322e-06, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 20, 20], -2.3565404332481378e-05, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 2.9727173024489924e-07, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)

--- a/tests/test_processing/test_BadPixelCleaning.py
+++ b/tests/test_processing/test_BadPixelCleaning.py
@@ -8,7 +8,8 @@ from PynPoint.Core.Pypeline import Pypeline
 from PynPoint.ProcessingModules.BadPixelCleaning import BadPixelSigmaFilterModule, \
                                                         BadPixelMapModule, \
                                                         BadPixelInterpolationModule, \
-                                                        BadPixelTimeFilterModule
+                                                        BadPixelTimeFilterModule, \
+                                                        ReplaceBadPixelsModule
 from PynPoint.Util.TestTools import create_config, remove_test_data
 
 warnings.simplefilter("always")
@@ -130,4 +131,23 @@ class TestBadPixelCleaning(object):
         assert np.allclose(data[0, 10, 10], 8.32053029919322e-06, rtol=limit, atol=0.)
         assert np.allclose(data[0, 20, 20], -2.3565404332481378e-05, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 2.9727173024489924e-07, rtol=limit, atol=0.)
+        assert data.shape == (40, 100, 100)
+
+    def test_replace_bad_pixels(self):
+
+        replace = ReplaceBadPixelsModule(name_in="replace",
+                                         image_in_tag="images",
+                                         map_in_tag="bp_map",
+                                         image_out_tag="replace",
+                                         size=2,
+                                         replace="mean")
+
+        self.pipeline.add_module(replace)
+        self.pipeline.run_module("replace")
+
+        data = self.pipeline.get_data("replace")
+        assert np.allclose(data[0, 0, 0], 0.00032486907273264834, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 10, 10], 5.493280938051695e-05, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 20, 20], -5.51613113375153e-05, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 3.019578931588861e-07, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)


### PR DESCRIPTION
- BadPixelTimeFilterModule applies sigma clipping along pixel lines in time. This can be helpful if a large enough dither pattern was used, as for example is possible with SPHERE/IRDIS. The bad pixels are replaced with the mean value (ignoring the bad pixels) along the pixel line. The sigma threshold can be set separately for the upper and lower limit which can be useful if there is a bright companion rotating through the field. Pixel lines are processed in parallel if CPU>1 in the config file. Tested on SPHERE/IRDIS data.

- ReplaceBadPixelsModule takes as input a stack of images and a bad pixel map (which can be created from the darks and flats with BadPixelMapModule). The bad pixels are then replaced by the mean or median value of the surrounding pixels (excluding the bad pixels) for a specified window size. Tested on SPHERE/IRDIS data for which I got much better results than with the BadPixelSigmaFilterModule.

- Test cases for both modules.