### PR TITLE
Few small updates

### DIFF
--- a/PynPoint/Core/DataIO.py
+++ b/PynPoint/Core/DataIO.py
@@ -903,9 +903,9 @@ class OutputPort(Port):
                       value,
                       static=True):
         """
-        Adds a attribute to the dataset of the Port with the attribute name = `name` and the value =
-        `value`. If the attribute already exists it will be overwritten. Two different types of
-        attributes are supported:
+        Adds an attribute to the dataset of the Port with the attribute name = `name` and the
+        value = `value`. If the attribute already exists it will be overwritten. Two different
+        types of attributes are supported:
 
             1. **static attributes**:
                Contain a single value or name (e.g. The name of the used Instrument).
@@ -919,10 +919,10 @@ class OutputPort(Port):
         Static attributes will be direct attributes while non-static attributes are stored in a
         group with the name *header_* + name of the dataset.
 
-        :param name: The name of the attribute
+        :param name: Name of the attribute.
         :type name: str
-        :param value: The value of the attribute
-        :param static: If True the attribute will be static (default)
+        :param value: Value of the attribute
+        :param static: Indicate if the attribute is static (True) or non-static (False).
         :type static: bool
 
         :return: None

--- a/PynPoint/ProcessingModules/BadPixelCleaning.py
+++ b/PynPoint/ProcessingModules/BadPixelCleaning.py
@@ -489,7 +489,7 @@ class BadPixelTimeFilterModule(ProcessingModule):
                  name_in="bp_time",
                  image_in_tag="im_arr",
                  image_out_tag="im_arr_bp_time",
-                 sigma=5):
+                 sigma=(5., 5.)):
         """
         Constructor of BadPixelTimeFilterModule.
 
@@ -589,7 +589,8 @@ class ReplaceBadPixelsModule(ProcessingModule):
                      mean or median replacement value. For example, a 5x5 window is used if
                      _size_=2.
         :type size: int
-        :param replace: Replace the bad pixel with the mean ('mean') or median ('media') value.
+        :param replace: Replace the bad pixel with the mean ('mean'), median ('media'), or
+                        NaN ('nan').
         :type replace: str
 
         :return: None
@@ -637,6 +638,8 @@ class ReplaceBadPixelsModule(ProcessingModule):
                         im_mask[item[0], item[1]] = np.nanmean(im_tmp)
                     elif self.m_replace == "median":
                         im_mask[item[0], item[1]] = np.nanmedian(im_tmp)
+                    elif self.m_replace == "nan":
+                        im_mask[item[0], item[1]] = np.nan
 
             return im_mask
 

--- a/tests/test_processing/test_BackgroundSubtraction.py
+++ b/tests/test_processing/test_BackgroundSubtraction.py
@@ -160,11 +160,10 @@ class TestBackgroundSubtraction(object):
                                                cubes=None,
                                                size=0.8,
                                                gaussian=0.1,
-                                               subframe=0.1,
+                                               subframe=0.5,
                                                pca_number=5,
                                                mask_star=0.1,
                                                mask_planet=None,
-                                               bad_pixel=None,
                                                crop=True,
                                                prepare=True,
                                                pca_background=True,
@@ -194,13 +193,13 @@ class TestBackgroundSubtraction(object):
         assert data.shape == (60, 31, 31)
 
         data = self.pipeline.get_data("dither_pca_fit1")
-        assert np.allclose(data[0, 14, 14], 1.519641183676098e-05, rtol=1e-6, atol=0.)
-        assert np.allclose(np.mean(data), 1.977958667148767e-07, rtol=1e-4, atol=0.)
+        assert np.allclose(data[0, 14, 14], 1.5196412298279846e-05, rtol=1e-6, atol=0.)
+        assert np.allclose(np.mean(data), 1.9779802529804516e-07, rtol=1e-4, atol=0.)
         assert data.shape == (20, 31, 31)
 
         data = self.pipeline.get_data("dither_pca_res1")
-        assert np.allclose(data[0, 14, 14], 0.05302488794328089, rtol=1e-6, atol=0.)
-        assert np.allclose(np.mean(data), 0.0010412324307166826, rtol=1e-6, atol=0.)
+        assert np.allclose(data[0, 14, 14], 0.05302488794281937, rtol=1e-6, atol=0.)
+        assert np.allclose(np.mean(data), 0.0010412324285580998, rtol=1e-6, atol=0.)
         assert data.shape == (20, 31, 31)
 
         data = self.pipeline.get_data("dither_pca_mask1")
@@ -213,10 +212,10 @@ class TestBackgroundSubtraction(object):
         assert np.allclose(np.mean(data), 0.001040627977720779, rtol=1e-6, atol=0.)
         assert data.shape == (80, 31, 31)
 
-        data = self.pipeline.get_attribute("pca_dither1", "STAR_POSITION", static=False)
+        data = self.pipeline.get_attribute("dither_pca_res1", "STAR_POSITION", static=False)
         assert np.allclose(data[0, 0], [15., 15.], rtol=1e-6, atol=0.)
         assert np.allclose(np.mean(data), 15., rtol=1e-6, atol=0.)
-        assert data.shape == (80, 2)
+        assert data.shape == (20, 2)
 
     def test_dithering_center(self):
 

--- a/tests/test_processing/test_StarAlignment.py
+++ b/tests/test_processing/test_StarAlignment.py
@@ -276,7 +276,7 @@ class TestStarAlignment(object):
                                        image_out_tag="center_odd",
                                        radius=42.5,
                                        pattern="x",
-                                       sigma=5.)
+                                       sigma=0.135)
 
         self.pipeline.add_module(waffle)
         self.pipeline.run_module("waffle_odd")
@@ -302,7 +302,7 @@ class TestStarAlignment(object):
                                        image_out_tag="center_even",
                                        radius=42.5,
                                        pattern="x",
-                                       sigma=5.)
+                                       sigma=0.135)
 
         self.pipeline.add_module(waffle)
         self.pipeline.run_module("waffle_even")


### PR DESCRIPTION
- Fix of the default value of sigma in BadPixelTimeFilterModule.
- The replace parameter in BadPixelTimeFilterModule can be set to 'nan' (in addition to mean and median).
- The sigma parameter in WaffleCenteringModule is given in arcsec instead of pixels.
- The size parameter in WaffleCenteringModule can be set to None in which case images are not cropped but returned in their original shape.
- Few simplifications in the PCABackgroundSubtractionModule.