### PR TITLE
ImageResizing test cases, scale_image function, update in SDIpreparationModule

### DIFF
--- a/PynPoint/ProcessingModules/FrameSelection.py
+++ b/PynPoint/ProcessingModules/FrameSelection.py
@@ -479,7 +479,7 @@ class RemoveLastFrameModule(ProcessingModule):
             progress(i, len(ndit), "Running RemoveLastFrameModule...")
 
             if nframes[i] != item+1:
-                warnings.warn("Number of frames (%s) is smaller than NDIT+1." % nframes[i])
+                warnings.warn("Number of frames (%s) is not equal to NDIT+1." % nframes[i])
 
             frame_start = np.sum(nframes[0:i])
             frame_end = np.sum(nframes[0:i+1]) - 1

--- a/PynPoint/ProcessingModules/ImageResizing.py
+++ b/PynPoint/ProcessingModules/ImageResizing.py
@@ -163,7 +163,7 @@ class ScaleImagesModule(ProcessingModule):
                            scaling_y,
                            scaling_flux):
 
-            tmp_image = scale_image(image_in, scaling_size)
+            tmp_image = scale_image(image_in, scaling_x, scaling_y)
 
             return scaling_flux * tmp_image
 

--- a/PynPoint/ProcessingModules/ImageResizing.py
+++ b/PynPoint/ProcessingModules/ImageResizing.py
@@ -7,10 +7,8 @@ import warnings
 
 import numpy as np
 
-from skimage.transform import rescale
-
 from PynPoint.Core.Processing import ProcessingModule
-from PynPoint.Util.ImageTools import crop_image
+from PynPoint.Util.ImageTools import crop_image, scale_image
 
 
 class CropImagesModule(ProcessingModule):
@@ -143,18 +141,9 @@ class ScaleImagesModule(ProcessingModule):
                            scaling_size,
                            scaling_flux):
 
-            sum_before = np.sum(image_in)
+            tmp_image = scale_image(image_in, scaling_size)
 
-            tmp_image = rescale(image=np.asarray(image_in, dtype=np.float64),
-                                scale=(scaling_size, scaling_size),
-                                order=5,
-                                mode="reflect",
-                                anti_aliasing=True,
-                                multichannel=False)
-
-            sum_after = np.sum(tmp_image)
-
-            return tmp_image * (sum_before / sum_after) * scaling_flux
+            return scaling_flux * tmp_image
 
         self.apply_function_to_images(_image_scaling,
                                       self.m_image_in_port,

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -643,7 +643,7 @@ class SDIpreparationModule(ProcessingModule):
             im_crop = im_scale[npix_del_a:-npix_del_b, npix_del_a:-npix_del_b]
 
             if npix_del%2 == 1:
-                im_crop = shift_image(im_crop, (0.5, 0.5), interpolation="spline")
+                im_crop = shift_image(im_crop, (-0.5, -0.5), interpolation="spline")
 
             if nimages == 1:
                 self.m_image_out_port.set_all(im_crop)
@@ -657,11 +657,9 @@ class SDIpreparationModule(ProcessingModule):
         self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
 
         history = "(line, continuum) = ("+str(self.m_line_wvl)+", "+str(self.m_cnt_wvl)+")"
-        print history
         self.m_image_out_port.add_history_information("Wavelength center", history)
 
         history = "(line, continuum) = ("+str(self.m_line_width)+", "+str(self.m_cnt_width)+")"
-        print history
         self.m_image_out_port.add_history_information("Wavelength width", history)
 
         self.m_image_in_port.close_port()

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -627,7 +627,7 @@ class SDIpreparationModule(ProcessingModule):
             else:
                 image = self.m_image_in_port[i, ]
 
-            im_scale = width_factor * scale_image(image, wvl_factor)
+            im_scale = width_factor * scale_image(image, wvl_factor, wvl_factor)
 
             if i == 0:
                 npix_del = im_scale.shape[-1] - image.shape[-1]

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -637,9 +637,6 @@ class SDIpreparationModule(ProcessingModule):
                     npix_del_b = int(npix_del/2)
 
                 else:
-                    warnings.warn("An unequal number of pixels is removed from both sides of the "
-                                  "images. Recentering of the images is therefore required.")
-
                     npix_del_a = int((npix_del-1)/2)
                     npix_del_b = int((npix_del+1)/2)
 
@@ -659,10 +656,12 @@ class SDIpreparationModule(ProcessingModule):
 
         self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
 
-        self.m_image_out_port.add_history_information("Wavelength center (line, continuum)",
-                                                      (self.m_line_wvl, self.m_cnt_wvl))
+        history = "(line, continuum) = ("+str(self.m_line_wvl)+", "+str(self.m_cnt_wvl)+")"
+        print history
+        self.m_image_out_port.add_history_information("Wavelength center", history)
 
-        self.m_image_out_port.add_history_information("Wavelength width (line, continuum)",
-                                                      (self.m_line_width, self.m_cnt_width))
+        history = "(line, continuum) = ("+str(self.m_line_width)+", "+str(self.m_cnt_width)+")"
+        print history
+        self.m_image_out_port.add_history_information("Wavelength width", history)
 
         self.m_image_in_port.close_port()

--- a/PynPoint/ProcessingModules/StarAlignment.py
+++ b/PynPoint/ProcessingModules/StarAlignment.py
@@ -800,8 +800,6 @@ class WaffleCenteringModule(ProcessingModule):
                 y_0 = np.floor(self.m_center[1] + self.m_radius * np.sin(np.pi / 4. * (2 * i + 1)))
 
             elif self.m_pattern == "+":
-                warnings.warn("The '+' pattern has not been tested yet.")
-
                 x_0 = np.floor(self.m_center[0] + self.m_radius * np.cos(np.pi / 4. * (2 * i)))
                 y_0 = np.floor(self.m_center[1] + self.m_radius * np.sin(np.pi / 4. * (2 * i)))
 

--- a/PynPoint/Util/ImageTools.py
+++ b/PynPoint/Util/ImageTools.py
@@ -2,14 +2,12 @@
 Functions for image processing.
 """
 
-import math
-
-import cv2
 import numpy as np
 
 from scipy.ndimage import fourier_shift
 from scipy.ndimage import shift
 from scipy.ndimage import rotate
+from skimage.transform import rescale
 
 
 def image_center(image):
@@ -161,3 +159,29 @@ def shift_image(image, shift_yx, interpolation, mode='constant'):
         im_center = np.fft.ifftn(fft_shift).real
 
     return im_center
+
+def scale_image(image, scaling):
+    """
+    Function to spatially scale an image.
+
+    :param images: Input image.
+    :type images: ndarray
+    :param scaling: Scaling factor.
+    :type scaling: float
+
+    :return: Shifted image.
+    :rtype: ndarray
+    """
+
+    sum_before = np.sum(image)
+
+    im_scale = rescale(image=np.asarray(image, dtype=np.float64),
+                       scale=(scaling, scaling),
+                       order=5,
+                       mode="reflect",
+                       anti_aliasing=True,
+                       multichannel=False)
+
+    sum_after = np.sum(im_scale)
+
+    return im_scale * (sum_before / sum_after)

--- a/PynPoint/Util/ImageTools.py
+++ b/PynPoint/Util/ImageTools.py
@@ -160,14 +160,16 @@ def shift_image(image, shift_yx, interpolation, mode='constant'):
 
     return im_center
 
-def scale_image(image, scaling):
+def scale_image(image, scaling_x, scaling_y):
     """
     Function to spatially scale an image.
 
     :param images: Input image.
     :type images: ndarray
-    :param scaling: Scaling factor.
-    :type scaling: float
+    :param scaling_x: Scaling factor x.
+    :type scaling_x: float
+    :param scaling_y: Scaling factor y.
+    :type scaling_y: float
 
     :return: Shifted image.
     :rtype: ndarray
@@ -176,7 +178,7 @@ def scale_image(image, scaling):
     sum_before = np.sum(image)
 
     im_scale = rescale(image=np.asarray(image, dtype=np.float64),
-                       scale=(scaling, scaling),
+                       scale=(scaling_y, scaling_x),
                        order=5,
                        mode="reflect",
                        anti_aliasing=True,

--- a/tests/test_processing/test_ImageResizing.py
+++ b/tests/test_processing/test_ImageResizing.py
@@ -1,0 +1,146 @@
+import os
+import warnings
+
+import numpy as np
+
+from PynPoint.Core.Pypeline import Pypeline
+from PynPoint.IOmodules.FitsReading import FitsReadingModule
+from PynPoint.ProcessingModules.ImageResizing import CropImagesModule, \
+                                                     ScaleImagesModule, \
+                                                     AddLinesModule, \
+                                                     RemoveLinesModule
+from PynPoint.Util.TestTools import create_config, create_star_data, remove_test_data
+
+warnings.simplefilter("always")
+
+limit = 1e-10
+
+class TestImageResizing(object):
+
+    def setup_class(self):
+
+        self.test_dir = os.path.dirname(__file__) + "/"
+
+        create_star_data(path=self.test_dir+"images",
+                         npix_x=20,
+                         npix_y=20,
+                         x0=[10, 10, 10, 10],
+                         y0=[10, 10, 10, 10],
+                         parang_start=[0., 25., 50., 75.],
+                         parang_end=[25., 50., 75., 100.],
+                         exp_no=[1, 2, 3, 4])
+
+        create_config(self.test_dir+"PynPoint_config.ini")
+
+        self.pipeline = Pypeline(self.test_dir, self.test_dir, self.test_dir)
+
+    def teardown_class(self):
+
+        remove_test_data(self.test_dir, folders=["images"])
+
+    def test_read_data(self):
+
+        read = FitsReadingModule(name_in="read",
+                                 image_tag="images",
+                                 input_dir=self.test_dir+"images",
+                                 overwrite=True,
+                                 check=True)
+
+        self.pipeline.add_module(read)
+
+        self.pipeline.run_module("read")
+
+        data = self.pipeline.get_data("images")
+        assert np.allclose(data[0, 10, 10], 0.09799496683489618, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.0025020285041348557, rtol=limit, atol=0.)
+        assert data.shape == (40, 20, 20)
+
+    def test_crop_images(self):
+
+        crop = CropImagesModule(size=0.3,
+                                center=None,
+                                name_in="crop1",
+                                image_in_tag="images",
+                                image_out_tag="crop1")
+
+        self.pipeline.add_module(crop)
+
+        crop = CropImagesModule(size=0.3,
+                                center=(6, 6),
+                                name_in="crop2",
+                                image_in_tag="images",
+                                image_out_tag="crop2")
+
+        self.pipeline.add_module(crop)
+
+        self.pipeline.run_module("crop1")
+        self.pipeline.run_module("crop2")
+
+        data = self.pipeline.get_data("crop1")
+        assert np.allclose(data[0, 7, 7], 0.09799496683489618, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.005921620406208569, rtol=limit, atol=0.)
+        assert data.shape == (40, 13, 13)
+
+        data = self.pipeline.get_data("crop2")
+        assert np.allclose(data[0, 7, 7], 0.0005067239693313918, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.005664905759498735, rtol=limit, atol=0.)
+        assert data.shape == (40, 13, 13)
+
+    def test_scale_images(self):
+
+        scale = ScaleImagesModule(scaling=(2., None),
+                                  name_in="scale1",
+                                  image_in_tag="images",
+                                  image_out_tag="scale1")
+
+        self.pipeline.add_module(scale)
+
+        scale = ScaleImagesModule(scaling=(None, 2.),
+                                  name_in="scale2",
+                                  image_in_tag="images",
+                                  image_out_tag="scale2")
+
+        self.pipeline.add_module(scale)
+
+        self.pipeline.run_module("scale1")
+        self.pipeline.run_module("scale2")
+
+        data = self.pipeline.get_data("scale1")
+        assert np.allclose(data[0, 20, 20], 0.02362264611391428, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.000625507126033714, rtol=limit, atol=0.)
+        assert data.shape == (40, 40, 40)
+
+        data = self.pipeline.get_data("scale2")
+        assert np.allclose(data[0, 10, 10], 0.19598993366979467, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.005004057008269711, rtol=limit, atol=0.)
+        assert data.shape == (40, 20, 20)
+
+    def test_add_lines(self):
+
+        add = AddLinesModule(lines=(2, 5, 0, 9),
+                             name_in="add",
+                             image_in_tag="images",
+                             image_out_tag="add")
+
+        self.pipeline.add_module(add)
+        self.pipeline.run_module("add")
+
+        data = self.pipeline.get_data("add")
+        assert np.allclose(data[0, 12, 12], 0.028528539751565975, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.0012781754810395176, rtol=limit, atol=0.)
+        assert data.shape == (40, 29, 27)
+
+    def test_remove_lines(self):
+
+        remove = RemoveLinesModule(lines=(2, 5, 0, 9),
+                                   name_in="remove",
+                                   image_in_tag="images",
+                                   image_out_tag="remove")
+
+        self.pipeline.add_module(remove)
+        self.pipeline.run_module("remove")
+
+        data = self.pipeline.get_data("remove")
+        assert np.allclose(data[0, 10, 10], 0.02882041378895293, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.004595775333521642, rtol=limit, atol=0.)
+        assert data.shape == (40, 11, 13)

--- a/tests/test_processing/test_ImageResizing.py
+++ b/tests/test_processing/test_ImageResizing.py
@@ -21,15 +21,7 @@ class TestImageResizing(object):
 
         self.test_dir = os.path.dirname(__file__) + "/"
 
-        create_star_data(path=self.test_dir+"resize",
-                         npix_x=20,
-                         npix_y=20,
-                         x0=[10, 10, 10, 10],
-                         y0=[10, 10, 10, 10],
-                         parang_start=[0., 25., 50., 75.],
-                         parang_end=[25., 50., 75., 100.],
-                         exp_no=[1, 2, 3, 4])
-
+        create_star_data(path=self.test_dir+"resize")
         create_config(self.test_dir+"PynPoint_config.ini")
 
         self.pipeline = Pypeline(self.test_dir, self.test_dir, self.test_dir)
@@ -51,9 +43,9 @@ class TestImageResizing(object):
         self.pipeline.run_module("read")
 
         data = self.pipeline.get_data("read")
-        assert np.allclose(data[0, 10, 10], 0.09799496683489618, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 0.0025020285041348557, rtol=limit, atol=0.)
-        assert data.shape == (40, 20, 20)
+        assert np.allclose(data[0, 50, 50], 0.09798413502193704, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.00010029494781738066, rtol=limit, atol=0.)
+        assert data.shape == (40, 100, 100)
 
     def test_crop_images(self):
 
@@ -66,7 +58,7 @@ class TestImageResizing(object):
         self.pipeline.add_module(crop)
 
         crop = CropImagesModule(size=0.3,
-                                center=(6, 6),
+                                center=(10, 10),
                                 name_in="crop2",
                                 image_in_tag="read",
                                 image_out_tag="crop2")
@@ -77,13 +69,13 @@ class TestImageResizing(object):
         self.pipeline.run_module("crop2")
 
         data = self.pipeline.get_data("crop1")
-        assert np.allclose(data[0, 7, 7], 0.09799496683489618, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 0.005921620406208569, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 7, 7], 0.09798413502193704, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.005917829617688413, rtol=limit, atol=0.)
         assert data.shape == (40, 13, 13)
 
         data = self.pipeline.get_data("crop2")
-        assert np.allclose(data[0, 7, 7], 0.0005067239693313918, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 0.005664905759498735, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 7, 7], 0.00021012292977345447, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), -2.9375442509680414e-06, rtol=limit, atol=0.)
         assert data.shape == (40, 13, 13)
 
     def test_scale_images(self):
@@ -106,14 +98,14 @@ class TestImageResizing(object):
         self.pipeline.run_module("scale2")
 
         data = self.pipeline.get_data("scale1")
-        assert np.allclose(data[0, 20, 20], 0.02362264611391428, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 0.000625507126033714, rtol=limit, atol=0.)
-        assert data.shape == (40, 40, 40)
+        assert np.allclose(data[0, 100, 100], 0.02356955774929094, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 2.507373695434516e-05, rtol=limit, atol=0.)
+        assert data.shape == (40, 200, 200)
 
         data = self.pipeline.get_data("scale2")
-        assert np.allclose(data[0, 10, 10], 0.19598993366979467, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 0.005004057008269711, rtol=limit, atol=0.)
-        assert data.shape == (40, 20, 20)
+        assert np.allclose(data[0, 50, 50], 0.19596827004387415, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.00020058989563476127, rtol=limit, atol=0.)
+        assert data.shape == (40, 100, 100)
 
     def test_add_lines(self):
 
@@ -126,9 +118,9 @@ class TestImageResizing(object):
         self.pipeline.run_module("add")
 
         data = self.pipeline.get_data("add")
-        assert np.allclose(data[0, 12, 12], 0.028528539751565975, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 0.0012781754810395176, rtol=limit, atol=0.)
-        assert data.shape == (40, 29, 27)
+        assert np.allclose(data[0, 50, 50], 0.02851872141873229, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 8.599412485413757e-05, rtol=limit, atol=0.)
+        assert data.shape == (40, 109, 107)
 
     def test_remove_lines(self):
 
@@ -141,6 +133,6 @@ class TestImageResizing(object):
         self.pipeline.run_module("remove")
 
         data = self.pipeline.get_data("remove")
-        assert np.allclose(data[0, 10, 10], 0.02882041378895293, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 0.004595775333521642, rtol=limit, atol=0.)
-        assert data.shape == (40, 11, 13)
+        assert np.allclose(data[0, 50, 50], 0.028455980719223083, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.00011848528804183087, rtol=limit, atol=0.)
+        assert data.shape == (40, 91, 93)

--- a/tests/test_processing/test_ImageResizing.py
+++ b/tests/test_processing/test_ImageResizing.py
@@ -21,7 +21,7 @@ class TestImageResizing(object):
 
         self.test_dir = os.path.dirname(__file__) + "/"
 
-        create_star_data(path=self.test_dir+"images",
+        create_star_data(path=self.test_dir+"resize",
                          npix_x=20,
                          npix_y=20,
                          x0=[10, 10, 10, 10],
@@ -36,13 +36,13 @@ class TestImageResizing(object):
 
     def teardown_class(self):
 
-        remove_test_data(self.test_dir, folders=["images"])
+        remove_test_data(self.test_dir, folders=["resize"])
 
     def test_read_data(self):
 
         read = FitsReadingModule(name_in="read",
-                                 image_tag="images",
-                                 input_dir=self.test_dir+"images",
+                                 image_tag="read",
+                                 input_dir=self.test_dir+"resize",
                                  overwrite=True,
                                  check=True)
 
@@ -50,7 +50,7 @@ class TestImageResizing(object):
 
         self.pipeline.run_module("read")
 
-        data = self.pipeline.get_data("images")
+        data = self.pipeline.get_data("read")
         assert np.allclose(data[0, 10, 10], 0.09799496683489618, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.0025020285041348557, rtol=limit, atol=0.)
         assert data.shape == (40, 20, 20)
@@ -60,7 +60,7 @@ class TestImageResizing(object):
         crop = CropImagesModule(size=0.3,
                                 center=None,
                                 name_in="crop1",
-                                image_in_tag="images",
+                                image_in_tag="read",
                                 image_out_tag="crop1")
 
         self.pipeline.add_module(crop)
@@ -68,7 +68,7 @@ class TestImageResizing(object):
         crop = CropImagesModule(size=0.3,
                                 center=(6, 6),
                                 name_in="crop2",
-                                image_in_tag="images",
+                                image_in_tag="read",
                                 image_out_tag="crop2")
 
         self.pipeline.add_module(crop)
@@ -90,14 +90,14 @@ class TestImageResizing(object):
 
         scale = ScaleImagesModule(scaling=(2., None),
                                   name_in="scale1",
-                                  image_in_tag="images",
+                                  image_in_tag="read",
                                   image_out_tag="scale1")
 
         self.pipeline.add_module(scale)
 
         scale = ScaleImagesModule(scaling=(None, 2.),
                                   name_in="scale2",
-                                  image_in_tag="images",
+                                  image_in_tag="read",
                                   image_out_tag="scale2")
 
         self.pipeline.add_module(scale)
@@ -119,7 +119,7 @@ class TestImageResizing(object):
 
         add = AddLinesModule(lines=(2, 5, 0, 9),
                              name_in="add",
-                             image_in_tag="images",
+                             image_in_tag="read",
                              image_out_tag="add")
 
         self.pipeline.add_module(add)
@@ -134,7 +134,7 @@ class TestImageResizing(object):
 
         remove = RemoveLinesModule(lines=(2, 5, 0, 9),
                                    name_in="remove",
-                                   image_in_tag="images",
+                                   image_in_tag="read",
                                    image_out_tag="remove")
 
         self.pipeline.add_module(remove)

--- a/tests/test_processing/test_PSFpreparation.py
+++ b/tests/test_processing/test_PSFpreparation.py
@@ -93,3 +93,9 @@ class TestPSFpreparation(object):
         assert np.allclose(data[0, 25, 25], -2.6648118007008814e-05, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 2.0042892634995876e-05, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)
+
+        attribute = self.pipeline.get_attribute("sdi", "History: Wavelength center (line, continuum)")
+        assert np.allclose(attribute, (0.65, 0.6), rtol=limit, atol=0.)
+
+        attribute = self.pipeline.get_attribute("sdi", "History: Wavelength width (line, continuum)")
+        assert np.allclose(attribute, (0.1, 0.5), rtol=limit, atol=0.)

--- a/tests/test_processing/test_PSFpreparation.py
+++ b/tests/test_processing/test_PSFpreparation.py
@@ -94,8 +94,8 @@ class TestPSFpreparation(object):
         assert np.allclose(np.mean(data), 2.0042892634995876e-05, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)
 
-        attribute = self.pipeline.get_attribute("sdi", "History: Wavelength center (line, continuum)")
-        assert np.allclose(attribute, (0.65, 0.6), rtol=limit, atol=0.)
+        attribute = self.pipeline.get_attribute("sdi", "History: Wavelength center")
+        assert attribute == "(line, continuum) = (0.65, 0.6)"
 
-        attribute = self.pipeline.get_attribute("sdi", "History: Wavelength width (line, continuum)")
-        assert np.allclose(attribute, (0.1, 0.5), rtol=limit, atol=0.)
+        attribute = self.pipeline.get_attribute("sdi", "History: Wavelength width")
+        assert attribute == "(line, continuum) = (0.1, 0.5)"


### PR DESCRIPTION
- Added test cases for all pipeline modules in ImageResizing.

- Added Util.ImageTools.scale_image which is used by ScaleImagesModule and SDIpreparationModule.

- SDIpreparationModule is no longer calling other pipeline modules but uses the Util functionalities. Test cases OK.

A general comment: to limit the amount of data that is stored in the database I am trying to move functionalities that are used by various modules to Util instead of calling a pipeline module from within another module. This would in particular be useful for modules that require PCA (e.g. ContrastCurveModule and SimplexMinimizationModule), let's discuss how to do that @majobodo.

- Depending on the spatial scaling factor in SDIpreparationModule, it may occur that image sizes change from odd to even or vice versa. Therefore, cropping the images to the initial size with leaving the star in the center is not possible (which is required for the SDI part). In that case an additional 0.5 shift in both directions is now applied.