### PR TITLE
Util functions

### DIFF
--- a/PynPoint/ProcessingModules/DetectionLimits.py
+++ b/PynPoint/ProcessingModules/DetectionLimits.py
@@ -160,8 +160,6 @@ class ContrastCurveModule(ProcessingModule):
         parang = self.m_image_in_port.get_attribute("PARANG")
         pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
 
-        print parang
-
         self.m_aperture /= pixscale
 
         if psf.ndim == 3 and psf.shape[0] != images.shape[0]:

--- a/PynPoint/ProcessingModules/DetectionLimits.py
+++ b/PynPoint/ProcessingModules/DetectionLimits.py
@@ -9,13 +9,11 @@ import warnings
 import numpy as np
 
 from scipy.interpolate import interp1d
-from scipy.stats import t
 
 from PynPoint.Core.Processing import ProcessingModule
-from PynPoint.ProcessingModules.PSFpreparation import PSFpreparationModule
-from PynPoint.ProcessingModules.PSFSubtractionPCA import PcaPsfSubtractionModule
-from PynPoint.ProcessingModules.FluxAndPosition import FakePlanetModule
-from PynPoint.Util.AnalysisTools import false_alarm, student_fpf
+from PynPoint.Util.AnalysisTools import false_alarm, student_fpf, fake_planet
+from PynPoint.Util.ImageTools import create_mask
+from PynPoint.Util.PSFSubtractionTools import pca_psf_subtraction
 
 
 class ContrastCurveModule(ProcessingModule):
@@ -109,14 +107,17 @@ class ContrastCurveModule(ProcessingModule):
         super(ContrastCurveModule, self).__init__(name_in)
 
         self.m_image_in_port = self.add_input_port(image_in_tag)
+
         if psf_in_tag == image_in_tag:
             self.m_psf_in_port = self.m_image_in_port
         else:
             self.m_psf_in_port = self.add_input_port(psf_in_tag)
+
         if pca_out_tag is None:
             self.m_pca_out_port = None
         else:
             self.m_pca_out_port = self.add_output_port(pca_out_tag)
+
         self.m_contrast_out_port = self.add_output_port(contrast_out_tag)
 
         self.m_image_in_tag = image_in_tag
@@ -156,7 +157,10 @@ class ContrastCurveModule(ProcessingModule):
         images = self.m_image_in_port.get_all()
         psf = self.m_psf_in_port.get_all()
 
+        parang = self.m_image_in_port.get_attribute("PARANG")
         pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
+
+        print parang
 
         self.m_aperture /= pixscale
 
@@ -177,14 +181,16 @@ class ContrastCurveModule(ProcessingModule):
         if self.m_cent_size is None:
             index_del = np.argwhere(pos_r-self.m_aperture <= 0.)
         else:
-            index_del = np.argwhere(pos_r-self.m_aperture <= self.m_cent_size/pixscale)
+            self.m_cent_size /= pixscale
+            index_del = np.argwhere(pos_r-self.m_aperture <= self.m_cent_size)
 
         pos_r = np.delete(pos_r, index_del)
 
         if self.m_edge_size is None or self.m_edge_size/pixscale > images.shape[1]/2.:
             index_del = np.argwhere(pos_r+self.m_aperture >= images.shape[1]/2.)
         else:
-            index_del = np.argwhere(pos_r+self.m_aperture >= self.m_edge_size/pixscale)
+            self.m_edge_size /= pixscale
+            index_del = np.argwhere(pos_r+self.m_aperture >= self.m_edge_size)
 
         pos_r = np.delete(pos_r, index_del)
 
@@ -228,50 +234,21 @@ class ContrastCurveModule(ProcessingModule):
                     sys.stdout.flush()
 
                     mag = list_mag[-1]
+                    flux_ratio = 10.**(-mag/2.5)
 
-                    fake_planet = FakePlanetModule(position=(sep*pixscale, ang),
-                                                   magnitude=mag,
-                                                   psf_scaling=self.m_psf_scaling,
-                                                   interpolation="spline",
-                                                   name_in="fake_planet",
-                                                   image_in_tag=self.m_image_in_tag,
-                                                   psf_in_tag=self.m_psf_in_tag,
-                                                   image_out_tag="contrast_fake",
-                                                   verbose=False)
+                    fake = fake_planet(self.m_image_in_port.get_all(),
+                                       self.m_psf_scaling*flux_ratio*psf,
+                                       parang,
+                                       (sep, ang),
+                                       interpolation="spline")
 
-                    fake_planet.connect_database(self._m_data_base)
-                    fake_planet.run()
+                    im_shape = (fake.shape[-2], fake.shape[-1])
+                    mask = create_mask(im_shape, [self.m_cent_size, self.m_edge_size])
 
-                    prep = PSFpreparationModule(name_in="prep",
-                                                image_in_tag="contrast_fake",
-                                                image_out_tag="contrast_prep",
-                                                image_mask_out_tag=None,
-                                                mask_out_tag=None,
-                                                norm=self.m_norm,
-                                                resize=None,
-                                                cent_size=self.m_cent_size,
-                                                edge_size=self.m_edge_size,
-                                                verbose=False)
-
-                    prep.connect_database(self._m_data_base)
-                    prep.run()
-
-                    psf_sub = PcaPsfSubtractionModule(name_in="pca_contrast",
-                                                      pca_numbers=self.m_pca_number,
-                                                      images_in_tag="contrast_prep",
-                                                      reference_in_tag="contrast_prep",
-                                                      res_mean_tag="contrast_res_mean",
-                                                      res_median_tag=None,
-                                                      res_arr_out_tag=None,
-                                                      res_rot_mean_clip_tag=None,
-                                                      extra_rot=self.m_extra_rot,
-                                                      verbose=False)
-
-                    psf_sub.connect_database(self._m_data_base)
-                    psf_sub.run()
-
-                    res_input_port = self.add_input_port("contrast_res_mean")
-                    im_res = res_input_port.get_all()
+                    im_res = pca_psf_subtraction(fake*mask,
+                                                 parang,
+                                                 self.m_pca_number,
+                                                 self.m_extra_rot)
 
                     if len(im_res.shape) == 3:
                         if im_res.shape[0] == 1:

--- a/PynPoint/ProcessingModules/DetectionLimits.py
+++ b/PynPoint/ProcessingModules/DetectionLimits.py
@@ -248,12 +248,6 @@ class ContrastCurveModule(ProcessingModule):
                                                  self.m_pca_number,
                                                  self.m_extra_rot)
 
-                    if len(im_res.shape) == 3:
-                        if im_res.shape[0] == 1:
-                            im_res = np.squeeze(im_res, axis=0)
-                        else:
-                            raise ValueError("Multiple residual images found, expecting only one.")
-
                     if self.m_pca_out_port is not None:
                         if count == 1 and iteration == 1:
                             self.m_pca_out_port.set_all(im_res, data_dim=3)

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -16,12 +16,12 @@ from skimage.feature import hessian_matrix
 from photutils import aperture_photometry, CircularAperture
 
 from PynPoint.Core.Processing import ProcessingModule
-from PynPoint.ProcessingModules.PSFpreparation import PSFpreparationModule
-from PynPoint.ProcessingModules.PSFSubtractionPCA import PcaPsfSubtractionModule
-from PynPoint.Util.ModuleTools import progress, memory_frames, image_size, image_size_port, \
-                                      number_images_port, rotate_coordinates
+from PynPoint.Util.AnalysisTools import fake_planet
 from PynPoint.Util.ImageTools import create_mask, crop_image, shift_image, image_center
 from PynPoint.Util.MCMCtools import lnprob
+from PynPoint.Util.ModuleTools import progress, memory_frames, image_size_port, \
+                                      number_images_port, rotate_coordinates
+from PynPoint.Util.PSFSubtractionTools import pca_psf_subtraction
 
 
 class FakePlanetModule(ProcessingModule):
@@ -37,8 +37,7 @@ class FakePlanetModule(ProcessingModule):
                  name_in="fake_planet",
                  image_in_tag="im_arr",
                  psf_in_tag="im_psf",
-                 image_out_tag="im_fake",
-                 **kwargs):
+                 image_out_tag="im_fake"):
         """
         Constructor of FakePlanetModule.
 
@@ -65,27 +64,19 @@ class FakePlanetModule(ProcessingModule):
         :type psf_in_tag: str
         :param image_out_tag: Tag of the database entry with images that are written as output.
         :type image_out_tag: str
-        :param \**kwargs:
-            See below.
-
-        :Keyword arguments:
-            **verbose** (*bool*) -- Print progress.
 
         :return: None
         """
 
-        if "verbose" in kwargs:
-            self.m_verbose = kwargs["verbose"]
-        else:
-            self.m_verbose = True
-
         super(FakePlanetModule, self).__init__(name_in)
 
         self.m_image_in_port = self.add_input_port(image_in_tag)
+
         if psf_in_tag == image_in_tag:
             self.m_psf_in_port = self.m_image_in_port
         else:
             self.m_psf_in_port = self.add_input_port(psf_in_tag)
+
         self.m_image_out_port = self.add_output_port(image_out_tag)
 
         self.m_position = position
@@ -169,8 +160,7 @@ class FakePlanetModule(ProcessingModule):
         frames, psf, ndim_psf = self._images_init()
 
         for j, _ in enumerate(frames[:-1]):
-            if self.m_verbose:
-                progress(j, len(frames[:-1]), "Running FakePlanetModule...")
+            progress(j, len(frames[:-1]), "Running FakePlanetModule...")
 
             image = np.copy(self.m_image_in_port[frames[j]:frames[j+1]])
 
@@ -186,9 +176,8 @@ class FakePlanetModule(ProcessingModule):
 
             self.m_image_out_port.append(image)
 
-        if self.m_verbose:
-            sys.stdout.write("Running FakePlanetModule... [DONE]\n")
-            sys.stdout.flush()
+        sys.stdout.write("Running FakePlanetModule... [DONE]\n")
+        sys.stdout.flush()
 
         self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
 
@@ -325,6 +314,27 @@ class SimplexMinimizationModule(ProcessingModule):
         :return: None
         """
 
+        self.m_res_out_port.del_all_data()
+        self.m_res_out_port.del_all_attributes()
+
+        self.m_flux_position_port.del_all_data()
+        self.m_flux_position_port.del_all_attributes()
+
+        parang = self.m_image_in_port.get_attribute("PARANG")
+        pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
+
+        self.m_aperture /= pixscale
+        self.m_sigma /= pixscale
+
+        if self.m_cent_size is not None:
+            self.m_cent_size /= pixscale
+
+        if self.m_edge_size is not None:
+            self.m_edge_size /= pixscale
+
+        psf = self.m_psf_in_port.get_all()
+        center = (psf.shape[-2]/2., psf.shape[-1]/2.)
+
         def _objective(arg):
             sys.stdout.write('.')
             sys.stdout.flush()
@@ -333,51 +343,23 @@ class SimplexMinimizationModule(ProcessingModule):
             pos_x = arg[1]
             mag = arg[2]
 
-            sep = math.sqrt((pos_y-center[0])**2+(pos_x-center[1])**2)*pixscale
+            sep = math.sqrt((pos_y-center[0])**2+(pos_x-center[1])**2)
             ang = math.atan2(pos_y-center[0], pos_x-center[1])*180./math.pi - 90.
+            flux_ratio = 10.**(-mag/2.5)
 
-            fake_planet = FakePlanetModule(position=(sep, ang),
-                                           magnitude=mag,
-                                           psf_scaling=self.m_psf_scaling,
-                                           interpolation="spline",
-                                           name_in="fake_planet",
-                                           image_in_tag=self.m_image_in_tag,
-                                           psf_in_tag=self.m_psf_in_tag,
-                                           image_out_tag="simplex_fake",
-                                           verbose=False)
+            fake = fake_planet(self.m_image_in_port.get_all(),
+                               self.m_psf_scaling*flux_ratio*psf,
+                               parang,
+                               (sep, ang),
+                               interpolation="spline")
 
-            fake_planet.connect_database(self._m_data_base)
-            fake_planet.run()
+            im_shape = (fake.shape[-2], fake.shape[-1])
+            mask = create_mask(im_shape, [self.m_cent_size, self.m_edge_size])
 
-            prep = PSFpreparationModule(name_in="prep",
-                                        image_in_tag="simplex_fake",
-                                        image_out_tag="simplex_prep",
-                                        image_mask_out_tag=None,
-                                        mask_out_tag=None,
-                                        norm=False,
-                                        cent_size=self.m_cent_size,
-                                        edge_size=self.m_edge_size,
-                                        verbose=False)
-
-            prep.connect_database(self._m_data_base)
-            prep.run()
-
-            psf_sub = PcaPsfSubtractionModule(name_in="pca_simplex",
-                                              pca_numbers=self.m_pca_number,
-                                              images_in_tag="simplex_prep",
-                                              reference_in_tag="simplex_prep",
-                                              res_mean_tag="simplex_res_mean",
-                                              res_median_tag=None,
-                                              res_arr_out_tag=None,
-                                              res_rot_mean_clip_tag=None,
-                                              extra_rot=self.m_extra_rot,
-                                              verbose=False)
-
-            psf_sub.connect_database(self._m_data_base)
-            psf_sub.run()
-
-            res_input_port = self.add_input_port("simplex_res_mean")
-            im_res = res_input_port.get_all()
+            im_res = pca_psf_subtraction(fake*mask,
+                                         parang,
+                                         self.m_pca_number,
+                                         self.m_extra_rot)
 
             if len(im_res.shape) == 3:
                 if im_res.shape[0] == 1:
@@ -391,7 +373,7 @@ class SimplexMinimizationModule(ProcessingModule):
                                  center=self.m_position,
                                  size=2*int(math.ceil(self.m_aperture)))
 
-            npix = image_size(im_crop)[0]
+            npix = im_crop.shape[-1]
 
             if self.m_merit == "hessian":
 
@@ -425,7 +407,7 @@ class SimplexMinimizationModule(ProcessingModule):
 
             res = np.asarray((position[1],
                               position[0],
-                              sep,
+                              sep*pixscale,
                               (ang-self.m_extra_rot)%360.,
                               mag,
                               merit))
@@ -433,20 +415,6 @@ class SimplexMinimizationModule(ProcessingModule):
             self.m_flux_position_port.append(res, data_dim=2)
 
             return merit
-
-        self.m_res_out_port.del_all_data()
-        self.m_res_out_port.del_all_attributes()
-
-        self.m_flux_position_port.del_all_data()
-        self.m_flux_position_port.del_all_attributes()
-
-        pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
-
-        self.m_aperture /= pixscale
-        self.m_sigma /= pixscale
-
-        psf_size = image_size_port(self.m_psf_in_port)
-        center = (psf_size[0]/2., psf_size[1]/2.)
 
         sys.stdout.write("Running SimplexMinimizationModule")
         sys.stdout.flush()

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -342,10 +342,10 @@ class SimplexMinimizationModule(ProcessingModule):
 
             sep = math.sqrt((pos_y-center[0])**2+(pos_x-center[1])**2)
             ang = math.atan2(pos_y-center[0], pos_x-center[1])*180./math.pi - 90.
-            flux_ratio = 10.**(-mag/2.5)
+            contrast = 10.**(-mag/2.5)
 
             fake = fake_planet(self.m_image_in_port.get_all(),
-                               self.m_psf_scaling*flux_ratio*psf,
+                               self.m_psf_scaling*contrast*psf,
                                parang,
                                (sep, ang),
                                interpolation="spline")
@@ -357,12 +357,6 @@ class SimplexMinimizationModule(ProcessingModule):
                                          parang,
                                          self.m_pca_number,
                                          self.m_extra_rot)
-
-            if len(im_res.shape) == 3:
-                if im_res.shape[0] == 1:
-                    im_res = np.squeeze(im_res, axis=0)
-                else:
-                    raise ValueError("Multiple residual images found, expecting only one.")
 
             self.m_res_out_port.append(im_res, data_dim=3)
 

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -14,7 +14,7 @@ from scipy import ndimage
 
 from PynPoint.Core.Processing import ProcessingModule
 from PynPoint.ProcessingModules.ImageResizing import RemoveLinesModule, ScaleImagesModule
-from PynPoint.Util.ModuleTools import progress, memory_frames, image_size
+from PynPoint.Util.ModuleTools import progress, memory_frames
 from PynPoint.Util.ImageTools import create_mask
 
 
@@ -128,9 +128,8 @@ class PSFpreparationModule(ProcessingModule):
         Internal method which masks the central and outer parts of the images.
         """
 
-        im_shape = image_size(im_data)
-
-        mask = create_mask(im_shape, [self.m_cent_size, self.m_edge_size])
+        mask = create_mask((im_data.shape[-2], im_data.shape[-1]),
+                           [self.m_cent_size, self.m_edge_size])
 
         if self.m_mask_out_port is not None:
             self.m_mask_out_port.set_all(mask)
@@ -148,6 +147,7 @@ class PSFpreparationModule(ProcessingModule):
 
         if self.m_cent_size is not None:
             self.m_cent_size /= pixscale
+
         if self.m_edge_size is not None:
             self.m_edge_size /= pixscale
 
@@ -166,6 +166,7 @@ class PSFpreparationModule(ProcessingModule):
         self.m_image_out_port.set_all(im_data, keep_attributes=True)
         self.m_image_out_port.add_attribute("norm", im_norm, static=False)
         self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
+
         if self.m_resize is not None:
             self.m_image_out_port.add_attribute("PIXSCALE", pixscale/self.m_resize)
 

--- a/PynPoint/Util/ModuleTools.py
+++ b/PynPoint/Util/ModuleTools.py
@@ -68,19 +68,6 @@ def image_size_port(port):
 
     return size
 
-def image_size(images):
-    """
-    Function to get the image size of an array.
-    """
-
-    if images.ndim == 2:
-        size = images.shape
-
-    elif images.ndim == 3:
-        size = (images.shape[1], images.shape[2])
-
-    return size
-
 def locate_star(image, center, width, fwhm):
     """
     Function to locate the star by finding the brightest pixel.

--- a/PynPoint/Util/PSFSubtractionTools.py
+++ b/PynPoint/Util/PSFSubtractionTools.py
@@ -1,0 +1,49 @@
+"""
+Functions for PSF subtraction.
+"""
+
+import numpy as np
+
+from scipy.ndimage import rotate
+from sklearn.decomposition import PCA
+
+
+def pca_psf_subtraction(images,
+                        parang,
+                        pca_number,
+                        extra_rot):
+    """
+    Function for PSF subtraction with PCA.
+
+    :param images: Stack of images, also used as reference images.
+    :type images: ndarray
+    :param parang: Angles (deg) for derotation of the images.
+    :type parang: ndarray
+    :param pca_number: Number of PCA components used for the PSF model.
+    :type pca_number: int
+    :param extra_rot: Additional rotation angle of the images (deg).
+    :type extra_rot: float
+
+    :return: Mean residuals of the PSF subtraction.
+    :rtype: ndarray
+    """
+
+    pca = PCA(n_components=pca_number, svd_solver="arpack")
+
+    images -= np.mean(images, axis=0)
+    images_reshape = images.reshape((images.shape[0], images.shape[1]*images.shape[2]))
+
+    pca.fit(images_reshape)
+
+    pca_rep = np.matmul(pca.components_[:pca_number], images_reshape.T)
+    pca_rep = np.vstack((pca_rep, np.zeros((0, images.shape[0])))).T
+
+    model = pca.inverse_transform(pca_rep)
+    model = model.reshape(images.shape)
+
+    residuals = images - model
+
+    for j, item in enumerate(-1.*parang):
+        residuals[j, ] = rotate(residuals[j, ], item+extra_rot, reshape=False)
+
+    return np.mean(residuals, axis=0)

--- a/tests/test_processing/test_FluxAndPosition.py
+++ b/tests/test_processing/test_FluxAndPosition.py
@@ -85,8 +85,7 @@ class TestFluxAndPosition(object):
                                 name_in="fake",
                                 image_in_tag="read",
                                 psf_in_tag="read",
-                                image_out_tag="fake",
-                                verbose=True)
+                                image_out_tag="fake")
 
         self.pipeline.add_module(fake)
         self.pipeline.run_module("fake")


### PR DESCRIPTION
Changed the implementation of SimplexMinimizationModule and ContrastCurveModule a bit such that there a no longer other pipeline modules called from within these modules. Instead, they use the fake_planet, create_mask, and pca_psf_subtraction functions from the Util folder. The latter was already being used by the MCMCsamplingModule. FakePlanetModule also uses the fake_planet function.

Hopefully this will limit a bit the file size of the database in case for example limits are calculated at many positions or if the minimization is repeated to test the precision with fake companions.

Also, since the database is no longer accessed while the limits are calculated, we can probably run the double for loop (separations and angles) with the multiprocessing functionalities from @majobodo . Something to consider for the future since this module can be quite slow if many images have to be processed...

All test cases OK.

Let me know if you have any comments or questions.