### PR TITLE
scaling in x and y direction with ScaleImagesModule

### DIFF
--- a/PynPoint/ProcessingModules/ImageResizing.py
+++ b/PynPoint/ProcessingModules/ImageResizing.py
@@ -92,17 +92,21 @@ class ScaleImagesModule(ProcessingModule):
     """
 
     def __init__(self,
-                 scaling=(None, None),
+                 scaling=(None, None, None),
+                 pixscale=False,
                  name_in="scaling",
                  image_in_tag="im_arr",
                  image_out_tag="im_arr_scaled"):
         """
         Constructor of ScaleImagesModule.
 
-        :param scaling: Tuple with the scaling factors for the image shape and pixel values,
-                        (scaling_size, scaling_flux). Upsampling and downsampling of the image
-                        corresponds to *scaling_size* > 1 and 0 < *scaling_size* < 1, respectively.
-        :type scaling: (float, float)
+        :param scaling: Tuple with the scaling factors for the image size and flux,
+                        (scaling_x, scaling_y, scaling_flux). Upsampling and downsampling of the
+                        image corresponds to *scaling_x/y* > 1 and 0 < *scaling_x/y* < 1,
+                        respectively.
+        :type scaling: (float, float, float)
+        :param pixscale: Adjust the pixel scale by the average scaling in x and y direction.
+        :type pixscale: bool
         :param name_in: Unique name of the module instance.
         :type name_in: str
         :param image_in_tag: Tag of the database entry that is read as input.
@@ -119,15 +123,32 @@ class ScaleImagesModule(ProcessingModule):
         self.m_image_in_port = self.add_input_port(image_in_tag)
         self.m_image_out_port = self.add_output_port(image_out_tag)
 
+        if len(scaling) == 2:
+            warnings.warn("The 'scaling' parameter requires three values: (scaling_x, scaling_y, "
+                          "scaling_flux). Using the same scaling in x and y direction...")
+
+            scaling = (scaling[0], scaling[0], scaling[1])
+
+        elif len(scaling) < 2 or len(scaling) > 3:
+            raise ValueError("The 'scaling' parameter requires three values: (scaling_x, "
+                             "scaling_y, scaling_flux).")
+
         if scaling[0] is None:
-            self.m_scaling_size = 1.
+            self.m_scaling_x = 1.
         else:
-            self.m_scaling_size = scaling[0]
+            self.m_scaling_x = scaling[0]
 
         if scaling[1] is None:
+            self.m_scaling_y = 1.
+        else:
+            self.m_scaling_y = scaling[1]
+
+        if scaling[2] is None:
             self.m_scaling_flux = 1.
         else:
-            self.m_scaling_flux = scaling[1]
+            self.m_scaling_flux = scaling[2]
+
+        self.m_pixscale = pixscale
 
     def run(self):
         """
@@ -140,13 +161,14 @@ class ScaleImagesModule(ProcessingModule):
         pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
 
         def _image_scaling(image_in,
-                           scaling_size,
+                           scaling_x,
+                           scaling_y,
                            scaling_flux):
 
             sum_before = np.sum(image_in)
 
             tmp_image = rescale(image=np.asarray(image_in, dtype=np.float64),
-                                scale=(scaling_size, scaling_size),
+                                scale=(scaling_y, scaling_x),
                                 order=5,
                                 mode="reflect",
                                 anti_aliasing=True,
@@ -160,12 +182,21 @@ class ScaleImagesModule(ProcessingModule):
                                       self.m_image_in_port,
                                       self.m_image_out_port,
                                       "Running ScaleImagesModule...",
-                                      func_args=(self.m_scaling_size, self.m_scaling_flux,))
+                                      func_args=(self.m_scaling_x,
+                                                 self.m_scaling_y,
+                                                 self.m_scaling_flux,))
 
-        history = "size  = "+str(self.m_scaling_size)+", flux = "+str(self.m_scaling_flux)
-        self.m_image_out_port.add_history_information("Images scaled", history)
+        history = "size =("+str(self.m_scaling_x)+", "+str(self.m_scaling_y)+ "), flux=" + \
+                  str(self.m_scaling_flux)
+
+        self.m_image_out_port.add_history_information("ScaleImagesModule", history)
+
         self.m_image_out_port.copy_attributes_from_input_port(self.m_image_in_port)
-        self.m_image_out_port.add_attribute("PIXSCALE", pixscale/self.m_scaling_size)
+
+        if self.m_pixscale:
+            mean_scaling = (self.m_scaling_x+self.m_scaling_y)/2.
+            self.m_image_out_port.add_attribute("PIXSCALE", pixscale/mean_scaling)
+
         self.m_image_out_port.close_port()
 
 

--- a/tests/test_processing/test_ImageResizing.py
+++ b/tests/test_processing/test_ImageResizing.py
@@ -1,0 +1,138 @@
+import os
+import warnings
+
+import numpy as np
+
+from PynPoint.Core.Pypeline import Pypeline
+from PynPoint.IOmodules.FitsReading import FitsReadingModule
+from PynPoint.ProcessingModules.ImageResizing import CropImagesModule, \
+                                                     ScaleImagesModule, \
+                                                     AddLinesModule, \
+                                                     RemoveLinesModule
+from PynPoint.Util.TestTools import create_config, create_star_data, remove_test_data
+
+warnings.simplefilter("always")
+
+limit = 1e-10
+
+class TestImageResizing(object):
+
+    def setup_class(self):
+
+        self.test_dir = os.path.dirname(__file__) + "/"
+
+        create_star_data(path=self.test_dir+"resize")
+        create_config(self.test_dir+"PynPoint_config.ini")
+
+        self.pipeline = Pypeline(self.test_dir, self.test_dir, self.test_dir)
+
+    def teardown_class(self):
+
+        remove_test_data(self.test_dir, folders=["resize"])
+
+    def test_read_data(self):
+
+        read = FitsReadingModule(name_in="read",
+                                 image_tag="read",
+                                 input_dir=self.test_dir+"resize",
+                                 overwrite=True,
+                                 check=True)
+
+        self.pipeline.add_module(read)
+
+        self.pipeline.run_module("read")
+
+        data = self.pipeline.get_data("read")
+        assert np.allclose(data[0, 50, 50], 0.09798413502193704, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.00010029494781738066, rtol=limit, atol=0.)
+        assert data.shape == (40, 100, 100)
+
+    def test_crop_images(self):
+
+        crop = CropImagesModule(size=0.3,
+                                center=None,
+                                name_in="crop1",
+                                image_in_tag="read",
+                                image_out_tag="crop1")
+
+        self.pipeline.add_module(crop)
+
+        crop = CropImagesModule(size=0.3,
+                                center=(10, 10),
+                                name_in="crop2",
+                                image_in_tag="read",
+                                image_out_tag="crop2")
+
+        self.pipeline.add_module(crop)
+
+        self.pipeline.run_module("crop1")
+        self.pipeline.run_module("crop2")
+
+        data = self.pipeline.get_data("crop1")
+        assert np.allclose(data[0, 7, 7], 0.09798413502193704, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.005917829617688413, rtol=limit, atol=0.)
+        assert data.shape == (40, 13, 13)
+
+        data = self.pipeline.get_data("crop2")
+        assert np.allclose(data[0, 7, 7], 0.00021012292977345447, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), -2.9375442509680414e-06, rtol=limit, atol=0.)
+        assert data.shape == (40, 13, 13)
+
+    def test_scale_images(self):
+
+        scale = ScaleImagesModule(scaling=(2., 2., None),
+                                  name_in="scale1",
+                                  image_in_tag="read",
+                                  image_out_tag="scale1")
+
+        self.pipeline.add_module(scale)
+
+        scale = ScaleImagesModule(scaling=(None, None, 2.),
+                                  name_in="scale2",
+                                  image_in_tag="read",
+                                  image_out_tag="scale2")
+
+        self.pipeline.add_module(scale)
+
+        self.pipeline.run_module("scale1")
+        self.pipeline.run_module("scale2")
+
+        data = self.pipeline.get_data("scale1")
+        assert np.allclose(data[0, 100, 100], 0.02356955774929094, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 2.507373695434516e-05, rtol=limit, atol=0.)
+        assert data.shape == (40, 200, 200)
+
+        data = self.pipeline.get_data("scale2")
+        assert np.allclose(data[0, 50, 50], 0.19596827004387415, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.00020058989563476127, rtol=limit, atol=0.)
+        assert data.shape == (40, 100, 100)
+
+    def test_add_lines(self):
+
+        add = AddLinesModule(lines=(2, 5, 0, 9),
+                             name_in="add",
+                             image_in_tag="read",
+                             image_out_tag="add")
+
+        self.pipeline.add_module(add)
+        self.pipeline.run_module("add")
+
+        data = self.pipeline.get_data("add")
+        assert np.allclose(data[0, 50, 50], 0.02851872141873229, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 8.599412485413757e-05, rtol=limit, atol=0.)
+        assert data.shape == (40, 109, 107)
+
+    def test_remove_lines(self):
+
+        remove = RemoveLinesModule(lines=(2, 5, 0, 9),
+                                   name_in="remove",
+                                   image_in_tag="read",
+                                   image_out_tag="remove")
+
+        self.pipeline.add_module(remove)
+        self.pipeline.run_module("remove")
+
+        data = self.pipeline.get_data("remove")
+        assert np.allclose(data[0, 50, 50], 0.028455980719223083, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.00011848528804183087, rtol=limit, atol=0.)
+        assert data.shape == (40, 91, 93)


### PR DESCRIPTION
The scaling parameter in ScaleImagesModule takes three values, (scaling_x, scaling_y, scaling_flux), instead of previously (scaling_size, scaling_flux). The same scaling in x and y direction is used if the tuple contains two values.

In this way, one can apply a first order distortion correction by linearly scaling in x and y direction. There is also an additional parameter called pixscale which can be set to False (default) if the PIXSCALE attribute should not be adjusted.