### PR TITLE
removed .codecov.yml, added PyPI badge, SortParangModule fix

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,0 @@
-comment: off

--- a/PynPoint/ProcessingModules/PSFpreparation.py
+++ b/PynPoint/ProcessingModules/PSFpreparation.py
@@ -326,10 +326,9 @@ class SortParangModule(ProcessingModule):
         if star_new is not None:
             self.m_image_out_port.add_attribute("STAR_POSITION", star_new, static=False)
 
-        if "NFRAMES" in self.m_image_in_port.get_all_non_static_attributes():
-            self.m_image_out_port.del_attribute("NFRAMES")
+        self.m_image_out_port.add_history_information("SortParangModule",
+                                                      "images sorted by INDEX")
 
-        self.m_image_out_port.add_history_information("Images sorted", "parang")
         self.m_image_out_port.close_port()
 
 

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,11 @@ PynPoint
 
 **Python package for processing and analysis of high-contrast imaging data**
 
-.. image:: https://img.shields.io/badge/GitHub-PynPoint-blue.svg?style=flat
-    :target: https://github.com/PynPoint/PynPoint
+.. image:: https://badge.fury.io/py/pynpoint.svg
+    :target: https://badge.fury.io/py/pynpoint
+
+.. .. image:: https://img.shields.io/badge/GitHub-PynPoint-blue.svg?style=flat
+..     :target: https://github.com/PynPoint/PynPoint
 
 .. image:: https://travis-ci.org/PynPoint/PynPoint.svg?branch=master
     :target: https://travis-ci.org/PynPoint/PynPoint

--- a/README.rst
+++ b/README.rst
@@ -6,26 +6,20 @@ PynPoint
 .. image:: https://badge.fury.io/py/pynpoint.svg
     :target: https://badge.fury.io/py/pynpoint
 
-.. .. image:: https://img.shields.io/badge/GitHub-PynPoint-blue.svg?style=flat
-..     :target: https://github.com/PynPoint/PynPoint
+.. image:: https://img.shields.io/badge/Python-2.7-yellow.svg?style=flat
+    :target: https://pypi.python.org/pypi/pynpoint
 
 .. image:: https://travis-ci.org/PynPoint/PynPoint.svg?branch=master
     :target: https://travis-ci.org/PynPoint/PynPoint
 
-.. .. image:: https://codecov.io/gh/PynPoint/PynPoint/branch/master/graph/badge.svg
-..     :target: https://codecov.io/gh/PynPoint/PynPoint
+.. image:: https://readthedocs.org/projects/pynpoint/badge/?version=latest
+    :target: http://pynpoint.readthedocs.io/en/latest/?badge=latest
 
 .. image:: https://coveralls.io/repos/github/PynPoint/PynPoint/badge.svg?branch=master
     :target: https://coveralls.io/github/PynPoint/PynPoint?branch=master
 
 .. image:: https://www.codefactor.io/repository/github/pynpoint/pynpoint/badge
     :target: https://www.codefactor.io/repository/github/pynpoint/pynpoint
-
-.. image:: https://readthedocs.org/projects/pynpoint/badge/?version=latest
-    :target: http://pynpoint.readthedocs.io/en/latest/?badge=latest
-
-.. image:: https://img.shields.io/badge/Python-2.7-yellow.svg?style=flat
-    :target: https://pypi.python.org/pypi/pynpoint
 
 .. image:: https://img.shields.io/badge/License-GPLv3-blue.svg
     :target: https://github.com/PynPoint/PynPoint/blob/master/LICENSE


### PR DESCRIPTION
- Removed .codecov.yml

- Added PyPI badge to README.

- SortParangModule was removing the NFRAMES attributes but this is not needed. After sorting the images by INDEX, the NFRAMES attributes are still valid.