### PR TITLE
Improved masking PcaPsfSubtractionModule

### DIFF
--- a/PynPoint/ProcessingModules/DetectionLimits.py
+++ b/PynPoint/ProcessingModules/DetectionLimits.py
@@ -247,10 +247,9 @@ class ContrastCurveModule(ProcessingModule):
                     im_shape = (fake.shape[-2], fake.shape[-1])
                     mask = create_mask(im_shape, [self.m_cent_size, self.m_edge_size])
 
-                    im_res = pca_psf_subtraction(fake*mask,
-                                                 parang,
-                                                 self.m_pca_number,
-                                                 self.m_extra_rot)
+                    im_res = pca_psf_subtraction(images=fake*mask,
+                                                 angles=-1.*parang+self.m_extra_rot,
+                                                 pca_number=self.m_pca_number)
 
                     if self.m_pca_out_port is not None:
                         if count == 1 and iteration == 1:

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -353,12 +353,12 @@ class SimplexMinimizationModule(ProcessingModule):
                                interpolation="spline")
 
             im_shape = (fake.shape[-2], fake.shape[-1])
+
             mask = create_mask(im_shape, [self.m_cent_size, self.m_edge_size])
 
-            im_res = pca_psf_subtraction(fake*mask,
-                                         parang,
-                                         self.m_pca_number,
-                                         self.m_extra_rot)
+            im_res = pca_psf_subtraction(images=fake*mask,
+                                         angles=-1.*parang+self.m_extra_rot,
+                                         pca_number=self.m_pca_number)
 
             self.m_res_out_port.append(im_res, data_dim=3)
 

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -19,6 +19,7 @@ from PynPoint.Util.MCMCtools import lnprob
 from PynPoint.Util.ModuleTools import progress, memory_frames, image_size_port, \
                                       number_images_port, rotate_coordinates
 from PynPoint.Util.PSFSubtractionTools import pca_psf_subtraction
+from PynPoint.Util.Residuals import combine_residuals
 
 
 class FakePlanetModule(ProcessingModule):
@@ -356,13 +357,15 @@ class SimplexMinimizationModule(ProcessingModule):
 
             mask = create_mask(im_shape, [self.m_cent_size, self.m_edge_size])
 
-            im_res = pca_psf_subtraction(images=fake*mask,
-                                         angles=-1.*parang+self.m_extra_rot,
-                                         pca_number=self.m_pca_number)
+            _, im_res = pca_psf_subtraction(images=fake*mask,
+                                            angles=-1.*parang+self.m_extra_rot,
+                                            pca_number=self.m_pca_number)
 
-            self.m_res_out_port.append(im_res, data_dim=3)
+            stack = combine_residuals(method="mean", res_rot=im_res)
 
-            merit = merit_function(residuals=im_res,
+            self.m_res_out_port.append(stack, data_dim=3)
+
+            merit = merit_function(residuals=stack,
                                    function=self.m_merit,
                                    position=self.m_position,
                                    aperture=self.m_aperture,

--- a/PynPoint/ProcessingModules/PSFSubtractionPCA.py
+++ b/PynPoint/ProcessingModules/PSFSubtractionPCA.py
@@ -136,7 +136,7 @@ class PcaPsfSubtractionModule(ProcessingModule):
         :return: None
         """
 
-        tmp_output = np.zeros((len(self.m_components), star_data.shape[1], star_data.shape[2]))
+        tmp_output = np.zeros((len(self.m_components), im_shape[1], im_shape[2]))
 
         if self.m_res_mean_out_port is not None:
             self.m_res_mean_out_port.set_all(tmp_output, keep_attributes=False)
@@ -152,8 +152,7 @@ class PcaPsfSubtractionModule(ProcessingModule):
 
         cpu = self._m_config_port.get_attribute("CPU")
 
-        rotations = -1.*self.m_star_in_port.get_attribute("PARANG")
-        rotations += np.ones(rotations.shape[0])*self.m_extra_rot
+        rotations = -1.*self.m_star_in_port.get_attribute("PARANG") + self.m_extra_rot
 
         pca_capsule = PcaMultiprocessingCapsule(self.m_res_mean_out_port,
                                                 self.m_res_median_out_port,
@@ -162,8 +161,10 @@ class PcaPsfSubtractionModule(ProcessingModule):
                                                 cpu,
                                                 deepcopy(self.m_components),
                                                 deepcopy(self.m_pca),
-                                                deepcopy(star_data),
-                                                deepcopy(rotations))
+                                                deepcopy(star_reshape),
+                                                deepcopy(rotations),
+                                                deepcopy(im_shape),
+                                                deepcopy(indices))
 
         pca_capsule.run()
 
@@ -197,7 +198,7 @@ class PcaPsfSubtractionModule(ProcessingModule):
             # inverse rotation
             parang = -1.*self.m_star_in_port.get_attribute("PARANG")
 
-            res_array = np.zeros(shape=residuals.shape)
+            res_array = np.zeros(residuals.shape)
             for j, angle in enumerate(parang):
                 # ndimage.rotate rotates in clockwise direction for positive angles
                 res_array[j, ] = ndimage.rotate(input=residuals[j, ],

--- a/PynPoint/ProcessingModules/PSFSubtractionPCA.py
+++ b/PynPoint/ProcessingModules/PSFSubtractionPCA.py
@@ -150,15 +150,13 @@ class PcaPsfSubtractionModule(ProcessingModule):
         if self.m_res_rot_mean_clip_out_port is not None:
             self.m_res_rot_mean_clip_out_port.set_all(tmp_output, keep_attributes=False)
 
-        cpu = self._m_config_port.get_attribute("CPU")
-
         angles = -1.*self.m_star_in_port.get_attribute("PARANG") + self.m_extra_rot
 
         pca_capsule = PcaMultiprocessingCapsule(self.m_res_mean_out_port,
                                                 self.m_res_median_out_port,
                                                 self.m_res_weighted_out_port,
                                                 self.m_res_rot_mean_clip_out_port,
-                                                cpu,
+                                                self._m_config_port.get_attribute("CPU"),
                                                 deepcopy(self.m_components),
                                                 deepcopy(self.m_pca),
                                                 deepcopy(star_reshape),

--- a/PynPoint/ProcessingModules/PSFSubtractionPCA.py
+++ b/PynPoint/ProcessingModules/PSFSubtractionPCA.py
@@ -85,12 +85,12 @@ class PcaPsfSubtractionModule(ProcessingModule):
 
         super(PcaPsfSubtractionModule, self).__init__(name_in)
 
-        self.m_max_pacs = np.max(pca_numbers)
+        self.m_max_pc = np.max(pca_numbers)
         self.m_components = np.sort(np.atleast_1d(pca_numbers))
         self.m_extra_rot = extra_rot
         self.m_subtract_mean = subtract_mean
 
-        self.m_pca = PCA(n_components=self.m_max_pacs, svd_solver="arpack")
+        self.m_pca = PCA(n_components=self.m_max_pc, svd_solver="arpack")
 
         self.m_reference_in_port = self.add_input_port(reference_in_tag)
         self.m_star_in_port = self.add_input_port(images_in_tag)
@@ -128,7 +128,7 @@ class PcaPsfSubtractionModule(ProcessingModule):
         else:
             self.m_basis_out_port = self.add_output_port(basis_out_tag)
 
-    def _run_multi_processing(self, star_data):
+    def _run_multi_processing(self, star_reshape, im_shape, indices):
         """
         Internal function to create the residuals, derotate the images, and write the output
         using multiprocessing.
@@ -167,7 +167,7 @@ class PcaPsfSubtractionModule(ProcessingModule):
 
         pca_capsule.run()
 
-    def _run_single_processing(self, star_sklearn, star_data):
+    def _run_single_processing(self, star_reshape, im_shape, indices):
         """
         Internal function to create the residuals, derotate the images, and write the output
         using a single process.
@@ -175,43 +175,45 @@ class PcaPsfSubtractionModule(ProcessingModule):
         :return: None
         """
 
-        for i, pca_number in enumerate(self.m_components):
+        for i, pc_number in enumerate(self.m_components):
             progress(i, len(self.m_components), "Creating residuals...")
 
-            tmp_pca_representation = np.matmul(self.m_pca.components_[:pca_number],
-                                               star_sklearn.T)
+            # create pca representation
+            pca_rep = np.matmul(self.m_pca.components_[:pc_number], star_reshape.T)
+            pca_rep = np.vstack((pca_rep, np.zeros((self.m_max_pc - pc_number, im_shape[0])))).T
 
-            tmp_pca_representation = np.vstack((tmp_pca_representation,
-                                                np.zeros((self.m_max_pacs - pca_number,
-                                                          star_data.shape[0])))).T
+            # create PSF model
+            psf_model = self.m_pca.inverse_transform(pca_rep)
 
-            tmp_psf_images = self.m_pca.inverse_transform(tmp_pca_representation)
+            # create original array size
+            residuals = np.zeros((im_shape[0], im_shape[1]*im_shape[2]))
 
-            tmp_psf_images = tmp_psf_images.reshape((star_data.shape[0],
-                                                     star_data.shape[1],
-                                                     star_data.shape[2]))
+            # subtract the psf model
+            residuals[:, indices] = star_reshape - psf_model
 
-            # subtract the psf model of the star
-            tmp_without_psf = star_data - tmp_psf_images
+            # reshape to the original image size
+            residuals = residuals.reshape(im_shape)
 
             # inverse rotation
-            delta_para = -1.*self.m_star_in_port.get_attribute("PARANG")
-            res_array = np.zeros(shape=tmp_without_psf.shape)
-            for j, angle in enumerate(delta_para):
-                res_temp = tmp_without_psf[j, ]
+            parang = -1.*self.m_star_in_port.get_attribute("PARANG")
+
+            res_array = np.zeros(shape=residuals.shape)
+            for j, angle in enumerate(parang):
                 # ndimage.rotate rotates in clockwise direction for positive angles
-                res_array[j, ] = ndimage.rotate(input=res_temp,
+                res_array[j, ] = ndimage.rotate(input=residuals[j, ],
                                                 angle=angle+self.m_extra_rot,
                                                 reshape=False)
+
+            history = "max PC number = "+str(self.m_max_pc)
 
             # create residuals
             # 1.) derotated residuals
             if self.m_res_arr_out_ports is not None:
-                self.m_res_arr_out_ports[pca_number].set_all(res_array)
-                self.m_res_arr_out_ports[pca_number].copy_attributes_from_input_port(
+                self.m_res_arr_out_ports[pc_number].set_all(res_array)
+                self.m_res_arr_out_ports[pc_number].copy_attributes_from_input_port(
                     self.m_star_in_port)
-                self.m_res_arr_out_ports[pca_number].add_history_information("PSF subtraction",
-                                                                             "PCA")
+                self.m_res_arr_out_ports[pc_number].add_history_information( \
+                    "PcaPsfSubtractionModule", history)
 
             # 2.) mean
             if self.m_res_mean_out_port is not None:
@@ -225,14 +227,14 @@ class PcaPsfSubtractionModule(ProcessingModule):
 
             # 4.) noise weighted
             if self.m_res_weighted_out_port is not None:
-                tmp_res_var = np.var(tmp_without_psf, axis=0)
+                tmp_res_var = np.var(residuals, axis=0)
 
                 res_repeat = np.repeat(tmp_res_var[np.newaxis, :, :],
-                                       repeats=tmp_without_psf.shape[0],
+                                       repeats=residuals.shape[0],
                                        axis=0)
 
                 res_var = np.zeros(res_repeat.shape)
-                for j, angle in enumerate(delta_para):
+                for j, angle in enumerate(parang):
                     # ndimage.rotate rotates in clockwise direction for positive angles
                     res_var[j, ] = ndimage.rotate(input=res_repeat[j, ],
                                                   angle=angle+self.m_extra_rot,
@@ -291,9 +293,9 @@ class PcaPsfSubtractionModule(ProcessingModule):
             self.m_res_rot_mean_clip_out_port.del_all_attributes()
 
         if self.m_res_arr_out_ports is not None:
-            for pca_number in self.m_components:
-                self.m_res_arr_out_ports[pca_number].del_all_data()
-                self.m_res_arr_out_ports[pca_number].del_all_attributes()
+            for pc_number in self.m_components:
+                self.m_res_arr_out_ports[pc_number].del_all_data()
+                self.m_res_arr_out_ports[pc_number].del_all_attributes()
 
     def run(self):
         """
@@ -309,37 +311,52 @@ class PcaPsfSubtractionModule(ProcessingModule):
 
         # get all data
         star_data = self.m_star_in_port.get_all()
+        im_shape = star_data.shape
+
+        # select the first image and get the unmasked image indices
+        im_star = star_data[0, ].reshape(-1)
+        indices = np.where(im_star != 0.)[0]
+
+        # reshape the star data and select the unmasked pixels
+        star_reshape = star_data.reshape(im_shape[0], im_shape[1]*im_shape[2])
+        star_reshape = star_reshape[:, indices]
 
         if self.m_reference_in_port.tag == self.m_star_in_port.tag:
-            ref_star_data = deepcopy(star_data)
+            ref_reshape = deepcopy(star_reshape)
 
         else:
-            ref_star_data = self.m_reference_in_port.get_all()
+            ref_data = self.m_reference_in_port.get_all()
+            ref_shape = ref_data.shape
+
+            if ref_shape[-2:] != im_shape[-2:]:
+                raise ValueError("The image size of the science data and the reference data "
+                                 "should be identical.")
+
+            # reshape reference data and select the unmasked pixels
+            ref_reshape = ref_data.reshape(ref_shape[0], ref_shape[1]*ref_shape[2])
+            ref_reshape = ref_reshape[:, indices]
 
         # subtract mean from science data, if required
         if self.m_subtract_mean:
-            mean_star = np.mean(star_data, axis=0)
-            star_data -= mean_star
+            mean_star = np.mean(star_reshape, axis=0)
+            star_reshape -= mean_star
 
         # subtract mean from reference data
-        mean_ref_star = np.mean(ref_star_data, axis=0)
-        ref_star_data -= mean_ref_star
+        mean_ref = np.mean(ref_reshape, axis=0)
+        ref_reshape -= mean_ref
 
-        # Fit the PCA model
+        # create the PCA basis
         sys.stdout.write("Constructing PSF model...")
         sys.stdout.flush()
 
-        ref_star_sklearn = ref_star_data.reshape((ref_star_data.shape[0],
-                                                  ref_star_data.shape[1]*ref_star_data.shape[2]))
-        self.m_pca.fit(ref_star_sklearn)
+        self.m_pca.fit(ref_reshape)
 
         # add mean of reference array as 1st PC and orthogonalize it with respect to the PCA basis
         if not self.m_subtract_mean:
-            mean_ref_star_sklearn = mean_ref_star.reshape((1, ref_star_data.shape[1]* \
-                                                              ref_star_data.shape[2]))
+            mean_ref_reshape = mean_ref.reshape((1, mean_ref.shape[0]))
 
-            q_ortho, _ = np.linalg.qr(np.vstack((mean_ref_star_sklearn,
-                                                 self.m_pca.components_[:-1,])).T)
+            q_ortho, _ = np.linalg.qr(np.vstack((mean_ref_reshape,
+                                                 self.m_pca.components_[:-1, ])).T)
 
             self.m_pca.components_ = q_ortho.T
 
@@ -347,44 +364,48 @@ class PcaPsfSubtractionModule(ProcessingModule):
         sys.stdout.flush()
 
         if self.m_basis_out_port is not None:
-            basis = self.m_pca.components_.reshape((self.m_pca.components_.shape[0],
-                                                    star_data.shape[1], star_data.shape[2]))
-            self.m_basis_out_port.set_all(basis)
+            pc_size = self.m_pca.components_.shape[0]
 
-        # prepare the data for sklearns PCA
-        star_sklearn = star_data.reshape((star_data.shape[0],
-                                          star_data.shape[1]*star_data.shape[2]))
+            basis = np.zeros((pc_size, im_shape[1]*im_shape[2]))
+            basis[:, indices] = self.m_pca.components_
+            basis = basis.reshape((pc_size, im_shape[1], im_shape[2]))
+
+            self.m_basis_out_port.set_all(basis)
 
         cpu = self._m_config_port.get_attribute("CPU")
 
-        # multiprocessing crashed on Mac in combination with numpy
+        # multiprocessing crashes on osx due to a bug in numpy
         if sys.platform == "darwin" or self.m_res_arr_out_ports is not None or cpu == 1:
-            self._run_single_processing(star_sklearn, star_data)
+            self._run_single_processing(star_reshape, im_shape, indices)
 
         else:
             sys.stdout.write("Creating residuals")
             sys.stdout.flush()
 
-            self._run_multi_processing(star_data)
+            self._run_multi_processing(star_reshape, im_shape, indices)
 
             sys.stdout.write(" [DONE]\n")
             sys.stdout.flush()
 
+        history = "max PC number = "+str(self.m_max_pc)
+
         # save history for all other ports
         if self.m_res_mean_out_port is not None:
             self.m_res_mean_out_port.copy_attributes_from_input_port(self.m_star_in_port)
-            self.m_res_mean_out_port.add_history_information("PSF subtraction", "PCA")
+            self.m_res_mean_out_port.add_history_information("PcaPsfSubtractionModule", history)
 
         if self.m_res_median_out_port is not None:
             self.m_res_median_out_port.copy_attributes_from_input_port(self.m_star_in_port)
-            self.m_res_median_out_port.add_history_information("PSF subtraction", "PCA")
+            self.m_res_median_out_port.add_history_information("PcaPsfSubtractionModule", history)
 
         if self.m_res_weighted_out_port is not None:
             self.m_res_weighted_out_port.copy_attributes_from_input_port(self.m_star_in_port)
-            self.m_res_weighted_out_port.add_history_information("PSF subtraction", "PCA")
+            self.m_res_weighted_out_port.add_history_information("PcaPsfSubtractionModule",
+                                                                 history)
 
         if self.m_res_rot_mean_clip_out_port is not None:
             self.m_res_rot_mean_clip_out_port.copy_attributes_from_input_port(self.m_star_in_port)
-            self.m_res_rot_mean_clip_out_port.add_history_information("PSF subtraction", "PCA")
+            self.m_res_rot_mean_clip_out_port.add_history_information("PcaPsfSubtractionModule",
+                                                                      history)
 
         self.m_star_in_port.close_port()

--- a/PynPoint/Util/MCMCtools.py
+++ b/PynPoint/Util/MCMCtools.py
@@ -89,19 +89,18 @@ def lnprob(param,
 
         sep, ang, mag = param
 
-        fake = fake_planet(images,
-                           psf,
-                           parang-extra_rot,
-                           (sep/pixscale, ang),
-                           mag,
-                           psf_scaling)
+        fake = fake_planet(images=images,
+                           psf=psf,
+                           parang=parang-extra_rot,
+                           position=(sep/pixscale, ang),
+                           magnitude=mag,
+                           psf_scaling=psf_scaling)
 
         fake *= mask
 
-        im_res = pca_psf_subtraction(fake,
-                                     parang,
-                                     pca_number,
-                                     extra_rot)
+        im_res = pca_psf_subtraction(images=fake,
+                                     angles=-1.*parang+extra_rot,
+                                     pca_number=pca_number)
 
         merit = merit_function(residuals=im_res,
                                function="sum",

--- a/PynPoint/Util/MCMCtools.py
+++ b/PynPoint/Util/MCMCtools.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from PynPoint.Util.AnalysisTools import fake_planet, merit_function
 from PynPoint.Util.PSFSubtractionTools import pca_psf_subtraction
+from PynPoint.Util.Residuals import combine_residuals
 
 def lnprob(param,
            bounds,
@@ -98,11 +99,13 @@ def lnprob(param,
 
         fake *= mask
 
-        im_res = pca_psf_subtraction(images=fake,
-                                     angles=-1.*parang+extra_rot,
-                                     pca_number=pca_number)
+        _, im_res = pca_psf_subtraction(images=fake,
+                                        angles=-1.*parang+extra_rot,
+                                        pca_number=pca_number)
 
-        merit = merit_function(residuals=im_res,
+        stack = combine_residuals(method="mean", res_rot=im_res)
+
+        merit = merit_function(residuals=stack,
                                function="sum",
                                position=aperture[0:2],
                                aperture=aperture[2],

--- a/PynPoint/Util/Multiprocessing.py
+++ b/PynPoint/Util/Multiprocessing.py
@@ -104,7 +104,7 @@ class TaskCreator(multiprocessing.Process):
         :return: None
         """
 
-        pass
+        # pass
 
     def create_poison_pills(self):
         """

--- a/PynPoint/Util/Multiprocessing.py
+++ b/PynPoint/Util/Multiprocessing.py
@@ -4,6 +4,7 @@ implementation needed to process lines in time as used in the wavelet time denoi
 """
 
 import multiprocessing
+
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
@@ -213,7 +214,7 @@ class TaskProcessor(multiprocessing.Process):
         :rtype:
         """
 
-        pass
+        # pass
 
 
 class TaskWriter(multiprocessing.Process):

--- a/PynPoint/Util/MultiprocessingPCA.py
+++ b/PynPoint/Util/MultiprocessingPCA.py
@@ -125,7 +125,7 @@ class PcaTaskProcessor(TaskProcessor):
         psf_model = self.m_pca_model.inverse_transform(pca_rep)
 
         # create original array size
-        residuals = np.zeros((im_shape[0], im_shape[1]*im_shape[2]))
+        residuals = np.zeros((self.m_im_shape[0], self.m_im_shape[1]*self.m_im_shape[2]))
 
         # subtract the psf model
         residuals[:, self.m_indices] = self.m_star_reshape - psf_model
@@ -187,7 +187,7 @@ class PcaTaskProcessor(TaskProcessor):
 
         # 4.) clipped mean
         if self.m_result_requirements[3]:
-            res_rot_mean_clip = np.zeros(self.m_star_arr[0, ].shape)
+            res_rot_mean_clip = np.zeros(self.m_im_shape[1:3].shape)
 
             for i in range(res_rot_mean_clip.shape[0]):
                 for j in range(res_rot_mean_clip.shape[1]):
@@ -304,7 +304,7 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
                  num_processors,
                  pca_numbers,
                  pca_model,
-                 star_arr,
+                 star_reshape,
                  rotations,
                  im_shape,
                  indices):
@@ -323,8 +323,8 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
         :type num_processors:
         :param pca_numbers:
         :type pca_numbers:
-        :param star_arr:
-        :type star_arr:
+        :param star_reshape:
+        :type star_reshape:
         :param rotations:
         :type rotations:
         :param im_shape:
@@ -341,7 +341,7 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
         self.m_clip_out_port = clip_out_port
         self.m_pca_numbers = pca_numbers
         self.m_pca_model = pca_model
-        self.m_star_arr = star_arr
+        self.m_star_reshape = star_reshape
         self.m_rotations = rotations
         self.m_im_shape = im_shape
         self.m_indices = indices
@@ -386,7 +386,7 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
 
         tmp_processors = [PcaTaskProcessor(self.m_tasks_queue,
                                            self.m_result_queue,
-                                           self.m_star_arr,
+                                           self.m_star_reshape,
                                            self.m_rotations,
                                            self.m_pca_model,
                                            self.m_im_shape,

--- a/PynPoint/Util/Residuals.py
+++ b/PynPoint/Util/Residuals.py
@@ -1,0 +1,83 @@
+"""
+Functions for combining the residuals of the PSF subtraction.
+"""
+
+import numpy as np
+
+from scipy.ndimage import rotate
+
+
+def combine_residuals(method, res_rot, residuals=None, angles=None):
+    """
+    Function for combining the derotated residuals of the PSF subtraction.
+
+    :param method: Method used for combining the residuals ("mean", "median", "weighted", or
+                   "clipped").
+    :type method: str
+    :param res_rot: Derotated residuals of the PSF subtraction (3D).
+    :type res_rot: numpy.ndimage
+    :param residuals: Non-derotated residuals of the PSF subtraction (3D). Only required for the
+                      noise-weighted residuals.
+    :type residuals: numpy.ndimage
+    :param angles: Derotation angles (deg). Only required for the noise-weighted residuals.
+    :type angles: numpy.ndimage
+
+    :return: Combined residuals (2D).
+    :rtype: numpy.ndimage
+    """
+
+    if method == "mean":
+        stack = np.mean(res_rot, axis=0)
+
+    elif method == "median":
+        stack = np.median(res_rot, axis=0)
+
+    elif method == "weighted":
+        tmp_res_var = np.var(residuals, axis=0)
+
+        res_repeat = np.repeat(tmp_res_var[np.newaxis, :, :],
+                               repeats=residuals.shape[0],
+                               axis=0)
+
+        res_var = np.zeros(res_repeat.shape)
+        for j, angle in enumerate(angles):
+            # scipy.ndimage.rotate rotates in clockwise direction for positive angles
+            res_var[j, ] = rotate(input=res_repeat[j, ],
+                                  angle=angle,
+                                  reshape=False)
+
+        weight1 = np.divide(res_rot,
+                            res_var,
+                            out=np.zeros_like(res_var),
+                            where=(np.abs(res_var) > 1e-100) & (res_var != np.nan))
+
+        weight2 = np.divide(1.,
+                            res_var,
+                            out=np.zeros_like(res_var),
+                            where=(np.abs(res_var) > 1e-100) & (res_var != np.nan))
+
+        sum1 = np.sum(weight1, axis=0)
+        sum2 = np.sum(weight2, axis=0)
+
+        stack = np.divide(sum1,
+                          sum2,
+                          out=np.zeros_like(sum2),
+                          where=(np.abs(sum2) > 1e-100) & (sum2 != np.nan))
+
+    elif method == "clipped":
+        stack = np.zeros(res_rot.shape[-2:])
+
+        for i in range(stack.shape[0]):
+            for j in range(stack.shape[1]):
+                temp = res_rot[:, i, j]
+
+                if temp.var() > 0.0:
+                    no_mean = temp - temp.mean()
+
+                    part1 = no_mean.compress((no_mean < 3.0*np.sqrt(no_mean.var())).flat)
+                    part2 = part1.compress((part1 > (-1.0)*3.0*np.sqrt(no_mean.var())).flat)
+
+                    stack[i, j] = temp.mean() + part2.mean()
+
+
+    return stack

--- a/docs/PynPoint.Util.rst
+++ b/docs/PynPoint.Util.rst
@@ -76,6 +76,14 @@ PynPoint.Util.RemoveTools module
     :undoc-members:
     :show-inheritance:
 
+PynPoint.Util.Residuals module
+------------------------------
+
+.. automodule:: PynPoint.Util.Residuals
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 PynPoint.Util.TestTools module
 ------------------------------
 

--- a/tests/test_processing/test_PSFSubtractionPCA.py
+++ b/tests/test_processing/test_PSFSubtractionPCA.py
@@ -97,7 +97,7 @@ class TestPSFSubtractionPCA(object):
 
         prep = PSFpreparationModule(name_in="prep1",
                                     image_in_tag="science",
-                                    image_out_tag="science_mask",
+                                    image_out_tag="science_prep",
                                     mask_out_tag=None,
                                     norm=False,
                                     resize=None,
@@ -107,7 +107,7 @@ class TestPSFSubtractionPCA(object):
         self.pipeline.add_module(prep)
         self.pipeline.run_module("prep1")
 
-        data = self.pipeline.get_data("science_mask")
+        data = self.pipeline.get_data("science_prep")
         assert np.allclose(data[0, 0, 0], 0.0, rtol=limit, atol=0.)
         assert np.allclose(data[0, 25, 25], 2.0926464668090656e-05, rtol=limit, atol=0.)
         assert np.allclose(data[0, 99, 99], 0.0, rtol=limit, atol=0.)
@@ -116,7 +116,7 @@ class TestPSFSubtractionPCA(object):
 
         prep = PSFpreparationModule(name_in="prep2",
                                     image_in_tag="reference",
-                                    image_out_tag="reference_mask",
+                                    image_out_tag="reference_prep",
                                     mask_out_tag=None,
                                     norm=False,
                                     resize=None,
@@ -126,7 +126,7 @@ class TestPSFSubtractionPCA(object):
         self.pipeline.add_module(prep)
         self.pipeline.run_module("prep2")
 
-        data = self.pipeline.get_data("reference_mask")
+        data = self.pipeline.get_data("reference_prep")
         assert np.allclose(data[0, 0, 0], 0.0, rtol=limit, atol=0.)
         assert np.allclose(data[0, 25, 25], 2.0926464668090656e-05, rtol=limit, atol=0.)
         assert np.allclose(data[0, 99, 99], 0.0, rtol=limit, atol=0.)
@@ -253,54 +253,12 @@ class TestPSFSubtractionPCA(object):
         assert np.allclose(np.mean(data), 2.3755682312090375e-05, rtol=limit, atol=0.)
         assert data.shape == (20, 100, 100)
 
-    # def test_psf_subtraction_pca_multi(self):
-    #
-    #     database = h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a')
-    #     database['config'].attrs['CPU'] = 4
-    #     database.close()
-    #
-    #     pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
-    #                                   name_in="pca_multi",
-    #                                   images_in_tag="science",
-    #                                   reference_in_tag="science",
-    #                                   res_mean_tag="res_mean_multi",
-    #                                   res_median_tag="res_median_multi",
-    #                                   res_weighted_tag="res_weighted_multi",
-    #                                   res_rot_mean_clip_tag="res_clip_multi",
-    #                                   res_arr_out_tag=None,
-    #                                   basis_out_tag="basis_multi",
-    #                                   extra_rot=-15.,
-    #                                   subtract_mean=True)
-    #
-    #     self.pipeline.add_module(pca)
-    #     self.pipeline.run_module("pca_multi")
-    #
-    #     data_single = self.pipeline.get_data("res_mean_single")
-    #     data_multi = self.pipeline.get_data("res_mean_multi")
-    #     assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
-    #     assert data_single.shape == data_multi.shape
-    #
-    #     data_single = self.pipeline.get_data("res_median_single")
-    #     data_multi = self.pipeline.get_data("res_median_multi")
-    #     assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
-    #     assert data_single.shape == data_multi.shape
-    #
-    #     data_single = self.pipeline.get_data("res_weighted_single")
-    #     data_multi = self.pipeline.get_data("res_weighted_multi")
-    #     assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
-    #     assert data_single.shape == data_multi.shape
-    #
-    #     data_single = self.pipeline.get_data("basis_single")
-    #     data_multi = self.pipeline.get_data("basis_multi")
-    #     assert np.allclose(data_single, data_multi, rtol=1e-5, atol=0.)
-    #     assert data_single.shape == data_multi.shape
-
     def test_psf_subtraction_pca_single_mask(self):
 
         pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
                                       name_in="pca_single_mask",
-                                      images_in_tag="science_mask",
-                                      reference_in_tag="science_mask",
+                                      images_in_tag="science_prep",
+                                      reference_in_tag="science_prep",
                                       res_mean_tag="res_mean_single_mask",
                                       res_median_tag="res_median_single_mask",
                                       res_weighted_tag="res_weighted_single_mask",
@@ -337,54 +295,12 @@ class TestPSFSubtractionPCA(object):
         assert np.allclose(np.mean(data), 5.584100479595007e-06, rtol=limit, atol=0.)
         assert data.shape == (20, 100, 100)
 
-    # def test_psf_subtraction_pca_multi_mask(self):
-    #
-    #     database = h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a')
-    #     database['config'].attrs['CPU'] = 4
-    #     database.close()
-    #
-    #     pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
-    #                                   name_in="pca_multi_mask",
-    #                                   images_in_tag="science_mask",
-    #                                   reference_in_tag="ref_mask",
-    #                                   res_mean_tag="res_mean_multi_mask",
-    #                                   res_median_tag="res_median_multi_mask",
-    #                                   res_weighted_tag="res_weighted_multi_mask",
-    #                                   res_rot_mean_clip_tag="res_clip_multi_mask",
-    #                                   res_arr_out_tag=None,
-    #                                   basis_out_tag="basis_multi_mask",
-    #                                   extra_rot=-15.,
-    #                                   subtract_mean=True)
-    #
-    #     self.pipeline.add_module(pca)
-    #     self.pipeline.run_module("pca_multi_mask")
-    #
-    #     data_single = self.pipeline.get_data("res_mean_single_mask")
-    #     data_multi = self.pipeline.get_data("res_mean_multi_mask")
-    #     assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
-    #     assert data_single.shape == data_multi.shape
-    #
-    #     data_single = self.pipeline.get_data("res_median_single_mask")
-    #     data_multi = self.pipeline.get_data("res_median_multi_mask")
-    #     assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
-    #     assert data_single.shape == data_multi.shape
-    #
-    #     data_single = self.pipeline.get_data("res_weighted_single_mask")
-    #     data_multi = self.pipeline.get_data("res_weighted_multi_mask")
-    #     assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
-    #     assert data_single.shape == data_multi.shape
-    #
-    #     data_single = self.pipeline.get_data("basis_single_mask")
-    #     data_multi = self.pipeline.get_data("basis_multi_mask")
-    #     assert np.allclose(data_single, data_multi, rtol=1e-5, atol=0.)
-    #     assert data_single.shape == data_multi.shape
-
     def test_psf_subtraction_no_mean_mask(self):
 
         pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
                                       name_in="pca_no_mean_mask",
-                                      images_in_tag="science_mask",
-                                      reference_in_tag="science_mask",
+                                      images_in_tag="science_prep",
+                                      reference_in_tag="science_prep",
                                       res_mean_tag="res_mean_no_mean_mask",
                                       res_median_tag=None,
                                       res_weighted_tag=None,
@@ -409,8 +325,8 @@ class TestPSFSubtractionPCA(object):
 
         pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
                                       name_in="pca_ref_mask",
-                                      images_in_tag="science_mask",
-                                      reference_in_tag="reference_mask",
+                                      images_in_tag="science_prep",
+                                      reference_in_tag="reference_prep",
                                       res_mean_tag="res_mean_ref_mask",
                                       res_median_tag=None,
                                       res_weighted_tag=None,
@@ -435,8 +351,8 @@ class TestPSFSubtractionPCA(object):
 
         pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
                                       name_in="pca_ref_no_mean_mask",
-                                      images_in_tag="science_mask",
-                                      reference_in_tag="reference_mask",
+                                      images_in_tag="science_prep",
+                                      reference_in_tag="reference_prep",
                                       res_mean_tag="res_mean_ref_no_mean_mask",
                                       res_median_tag=None,
                                       res_weighted_tag=None,
@@ -456,3 +372,87 @@ class TestPSFSubtractionPCA(object):
         data = self.pipeline.get_data("basis_ref_no_mean_mask")
         assert np.allclose(np.sum(np.abs(data)), 1026.3329224435665, rtol=limit, atol=0.)
         assert data.shape == (20, 100, 100)
+
+    def test_psf_subtraction_pca_multi(self):
+
+        database = h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a')
+        database['config'].attrs['CPU'] = 4
+        database.close()
+
+        pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
+                                      name_in="pca_multi",
+                                      images_in_tag="science",
+                                      reference_in_tag="science",
+                                      res_mean_tag="res_mean_multi",
+                                      res_median_tag="res_median_multi",
+                                      res_weighted_tag="res_weighted_multi",
+                                      res_rot_mean_clip_tag="res_clip_multi",
+                                      res_arr_out_tag=None,
+                                      basis_out_tag="basis_multi",
+                                      extra_rot=-15.,
+                                      subtract_mean=True)
+
+        self.pipeline.add_module(pca)
+        self.pipeline.run_module("pca_multi")
+
+        data_single = self.pipeline.get_data("res_mean_single")
+        data_multi = self.pipeline.get_data("res_mean_multi")
+        assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
+        assert data_single.shape == data_multi.shape
+
+        data_single = self.pipeline.get_data("res_median_single")
+        data_multi = self.pipeline.get_data("res_median_multi")
+        assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
+        assert data_single.shape == data_multi.shape
+
+        data_single = self.pipeline.get_data("res_weighted_single")
+        data_multi = self.pipeline.get_data("res_weighted_multi")
+        assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
+        assert data_single.shape == data_multi.shape
+
+        data_single = self.pipeline.get_data("basis_single")
+        data_multi = self.pipeline.get_data("basis_multi")
+        assert np.allclose(data_single, data_multi, rtol=1e-5, atol=0.)
+        assert data_single.shape == data_multi.shape
+
+    def test_psf_subtraction_pca_multi_mask(self):
+
+        database = h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a')
+        database['config'].attrs['CPU'] = 4
+        database.close()
+
+        pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
+                                      name_in="pca_multi_mask",
+                                      images_in_tag="science_prep",
+                                      reference_in_tag="science_prep",
+                                      res_mean_tag="res_mean_multi_mask",
+                                      res_median_tag="res_median_multi_mask",
+                                      res_weighted_tag="res_weighted_multi_mask",
+                                      res_rot_mean_clip_tag="res_clip_multi_mask",
+                                      res_arr_out_tag=None,
+                                      basis_out_tag="basis_multi_mask",
+                                      extra_rot=-15.,
+                                      subtract_mean=True)
+
+        self.pipeline.add_module(pca)
+        self.pipeline.run_module("pca_multi_mask")
+
+        data_single = self.pipeline.get_data("res_mean_single_mask")
+        data_multi = self.pipeline.get_data("res_mean_multi_mask")
+        assert np.allclose(data_single[data_single > 1e-12], data_multi[data_multi > 1e-12], rtol=1e-6, atol=0.)
+        assert data_single.shape == data_multi.shape
+
+        data_single = self.pipeline.get_data("res_median_single_mask")
+        data_multi = self.pipeline.get_data("res_median_multi_mask")
+        assert np.allclose(data_single[data_single > 1e-12], data_multi[data_multi > 1e-12], rtol=1e-6, atol=0.)
+        assert data_single.shape == data_multi.shape
+
+        data_single = self.pipeline.get_data("res_weighted_single_mask")
+        data_multi = self.pipeline.get_data("res_weighted_multi_mask")
+        assert np.allclose(data_single[data_single > 1e-12], data_multi[data_multi > 1e-12], rtol=1e-6, atol=0.)
+        assert data_single.shape == data_multi.shape
+
+        data_single = self.pipeline.get_data("basis_single_mask")
+        data_multi = self.pipeline.get_data("basis_multi_mask")
+        assert np.allclose(data_single, data_multi, rtol=1e-5, atol=0.)
+        assert data_single.shape == data_multi.shape

--- a/tests/test_processing/test_PSFSubtractionPCA.py
+++ b/tests/test_processing/test_PSFSubtractionPCA.py
@@ -253,47 +253,47 @@ class TestPSFSubtractionPCA(object):
         assert np.allclose(np.mean(data), 2.3755682312090375e-05, rtol=limit, atol=0.)
         assert data.shape == (20, 100, 100)
 
-    def test_psf_subtraction_pca_multi(self):
-
-        database = h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a')
-        database['config'].attrs['CPU'] = 4
-        database.close()
-
-        pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
-                                      name_in="pca_multi",
-                                      images_in_tag="science",
-                                      reference_in_tag="science",
-                                      res_mean_tag="res_mean_multi",
-                                      res_median_tag="res_median_multi",
-                                      res_weighted_tag="res_weighted_multi",
-                                      res_rot_mean_clip_tag="res_clip_multi",
-                                      res_arr_out_tag=None,
-                                      basis_out_tag="basis_multi",
-                                      extra_rot=-15.,
-                                      subtract_mean=True)
-
-        self.pipeline.add_module(pca)
-        self.pipeline.run_module("pca_multi")
-
-        data_single = self.pipeline.get_data("res_mean_single")
-        data_multi = self.pipeline.get_data("res_mean_multi")
-        assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
-        assert data_single.shape == data_multi.shape
-
-        data_single = self.pipeline.get_data("res_median_single")
-        data_multi = self.pipeline.get_data("res_median_multi")
-        assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
-        assert data_single.shape == data_multi.shape
-
-        data_single = self.pipeline.get_data("res_weighted_single")
-        data_multi = self.pipeline.get_data("res_weighted_multi")
-        assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
-        assert data_single.shape == data_multi.shape
-
-        data_single = self.pipeline.get_data("basis_single")
-        data_multi = self.pipeline.get_data("basis_multi")
-        assert np.allclose(data_single, data_multi, rtol=1e-5, atol=0.)
-        assert data_single.shape == data_multi.shape
+    # def test_psf_subtraction_pca_multi(self):
+    #
+    #     database = h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a')
+    #     database['config'].attrs['CPU'] = 4
+    #     database.close()
+    #
+    #     pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
+    #                                   name_in="pca_multi",
+    #                                   images_in_tag="science",
+    #                                   reference_in_tag="science",
+    #                                   res_mean_tag="res_mean_multi",
+    #                                   res_median_tag="res_median_multi",
+    #                                   res_weighted_tag="res_weighted_multi",
+    #                                   res_rot_mean_clip_tag="res_clip_multi",
+    #                                   res_arr_out_tag=None,
+    #                                   basis_out_tag="basis_multi",
+    #                                   extra_rot=-15.,
+    #                                   subtract_mean=True)
+    #
+    #     self.pipeline.add_module(pca)
+    #     self.pipeline.run_module("pca_multi")
+    #
+    #     data_single = self.pipeline.get_data("res_mean_single")
+    #     data_multi = self.pipeline.get_data("res_mean_multi")
+    #     assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
+    #     assert data_single.shape == data_multi.shape
+    #
+    #     data_single = self.pipeline.get_data("res_median_single")
+    #     data_multi = self.pipeline.get_data("res_median_multi")
+    #     assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
+    #     assert data_single.shape == data_multi.shape
+    #
+    #     data_single = self.pipeline.get_data("res_weighted_single")
+    #     data_multi = self.pipeline.get_data("res_weighted_multi")
+    #     assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
+    #     assert data_single.shape == data_multi.shape
+    #
+    #     data_single = self.pipeline.get_data("basis_single")
+    #     data_multi = self.pipeline.get_data("basis_multi")
+    #     assert np.allclose(data_single, data_multi, rtol=1e-5, atol=0.)
+    #     assert data_single.shape == data_multi.shape
 
     def test_psf_subtraction_pca_single_mask(self):
 
@@ -337,47 +337,47 @@ class TestPSFSubtractionPCA(object):
         assert np.allclose(np.mean(data), 5.584100479595007e-06, rtol=limit, atol=0.)
         assert data.shape == (20, 100, 100)
 
-    def test_psf_subtraction_pca_multi_mask(self):
-
-        database = h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a')
-        database['config'].attrs['CPU'] = 4
-        database.close()
-
-        pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
-                                      name_in="pca_multi_mask",
-                                      images_in_tag="science_mask",
-                                      reference_in_tag="ref_mask",
-                                      res_mean_tag="res_mean_multi_mask",
-                                      res_median_tag="res_median_multi_mask",
-                                      res_weighted_tag="res_weighted_multi_mask",
-                                      res_rot_mean_clip_tag="res_clip_multi_mask",
-                                      res_arr_out_tag=None,
-                                      basis_out_tag="basis_multi_mask",
-                                      extra_rot=-15.,
-                                      subtract_mean=True)
-
-        self.pipeline.add_module(pca)
-        self.pipeline.run_module("pca_multi_mask")
-
-        data_single = self.pipeline.get_data("res_mean_single_mask")
-        data_multi = self.pipeline.get_data("res_mean_multi_mask")
-        assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
-        assert data_single.shape == data_multi.shape
-
-        data_single = self.pipeline.get_data("res_median_single_mask")
-        data_multi = self.pipeline.get_data("res_median_multi_mask")
-        assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
-        assert data_single.shape == data_multi.shape
-
-        data_single = self.pipeline.get_data("res_weighted_single_mask")
-        data_multi = self.pipeline.get_data("res_weighted_multi_mask")
-        assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
-        assert data_single.shape == data_multi.shape
-
-        data_single = self.pipeline.get_data("basis_single_mask")
-        data_multi = self.pipeline.get_data("basis_multi_mask")
-        assert np.allclose(data_single, data_multi, rtol=1e-5, atol=0.)
-        assert data_single.shape == data_multi.shape
+    # def test_psf_subtraction_pca_multi_mask(self):
+    #
+    #     database = h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a')
+    #     database['config'].attrs['CPU'] = 4
+    #     database.close()
+    #
+    #     pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
+    #                                   name_in="pca_multi_mask",
+    #                                   images_in_tag="science_mask",
+    #                                   reference_in_tag="ref_mask",
+    #                                   res_mean_tag="res_mean_multi_mask",
+    #                                   res_median_tag="res_median_multi_mask",
+    #                                   res_weighted_tag="res_weighted_multi_mask",
+    #                                   res_rot_mean_clip_tag="res_clip_multi_mask",
+    #                                   res_arr_out_tag=None,
+    #                                   basis_out_tag="basis_multi_mask",
+    #                                   extra_rot=-15.,
+    #                                   subtract_mean=True)
+    #
+    #     self.pipeline.add_module(pca)
+    #     self.pipeline.run_module("pca_multi_mask")
+    #
+    #     data_single = self.pipeline.get_data("res_mean_single_mask")
+    #     data_multi = self.pipeline.get_data("res_mean_multi_mask")
+    #     assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
+    #     assert data_single.shape == data_multi.shape
+    #
+    #     data_single = self.pipeline.get_data("res_median_single_mask")
+    #     data_multi = self.pipeline.get_data("res_median_multi_mask")
+    #     assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
+    #     assert data_single.shape == data_multi.shape
+    #
+    #     data_single = self.pipeline.get_data("res_weighted_single_mask")
+    #     data_multi = self.pipeline.get_data("res_weighted_multi_mask")
+    #     assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
+    #     assert data_single.shape == data_multi.shape
+    #
+    #     data_single = self.pipeline.get_data("basis_single_mask")
+    #     data_multi = self.pipeline.get_data("basis_multi_mask")
+    #     assert np.allclose(data_single, data_multi, rtol=1e-5, atol=0.)
+    #     assert data_single.shape == data_multi.shape
 
     def test_psf_subtraction_no_mean_mask(self):
 

--- a/tests/test_processing/test_PSFSubtractionPCA.py
+++ b/tests/test_processing/test_PSFSubtractionPCA.py
@@ -337,6 +337,48 @@ class TestPSFSubtractionPCA(object):
         assert np.allclose(np.mean(data), 5.584100479595007e-06, rtol=limit, atol=0.)
         assert data.shape == (20, 100, 100)
 
+    def test_psf_subtraction_pca_multi_mask(self):
+
+        database = h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a')
+        database['config'].attrs['CPU'] = 4
+        database.close()
+
+        pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),
+                                      name_in="pca_multi_mask",
+                                      images_in_tag="science_mask",
+                                      reference_in_tag="ref_mask",
+                                      res_mean_tag="res_mean_multi_mask",
+                                      res_median_tag="res_median_multi_mask",
+                                      res_weighted_tag="res_weighted_multi_mask",
+                                      res_rot_mean_clip_tag="res_clip_multi_mask",
+                                      res_arr_out_tag=None,
+                                      basis_out_tag="basis_multi_mask",
+                                      extra_rot=-15.,
+                                      subtract_mean=True)
+
+        self.pipeline.add_module(pca)
+        self.pipeline.run_module("pca_multi_mask")
+
+        data_single = self.pipeline.get_data("res_mean_single_mask")
+        data_multi = self.pipeline.get_data("res_mean_multi_mask")
+        assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
+        assert data_single.shape == data_multi.shape
+
+        data_single = self.pipeline.get_data("res_median_single_mask")
+        data_multi = self.pipeline.get_data("res_median_multi_mask")
+        assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
+        assert data_single.shape == data_multi.shape
+
+        data_single = self.pipeline.get_data("res_weighted_single_mask")
+        data_multi = self.pipeline.get_data("res_weighted_multi_mask")
+        assert np.allclose(data_single, data_multi, rtol=1e-6, atol=0.)
+        assert data_single.shape == data_multi.shape
+
+        data_single = self.pipeline.get_data("basis_single_mask")
+        data_multi = self.pipeline.get_data("basis_multi_mask")
+        assert np.allclose(data_single, data_multi, rtol=1e-5, atol=0.)
+        assert data_single.shape == data_multi.shape
+
     def test_psf_subtraction_no_mean_mask(self):
 
         pca = PcaPsfSubtractionModule(pca_numbers=np.arange(1, 21, 1),


### PR DESCRIPTION
I have started to rewrite the PcaPsfSubtractionModule such that pixel values that are set to zero are excluded from the PCA basis. Before, masked pixels are set to zero (so they do not affect the PSF subtraction) but they are still being processed which causes an unnecessary overhead. So far I only implemented this for single processing, but will do this for multiprocessing of the PcaPsfSubtractionModule, and the PCA function that is used by the ContrastCurveModule, SimplexMinimizationModule, and MCMCanalysisModule asap.