### PR TITLE
Aperture and prior options for MCMCsamplingModule

### DIFF
--- a/PynPoint/Core/DataIO.py
+++ b/PynPoint/Core/DataIO.py
@@ -631,7 +631,7 @@ class OutputPort(Port):
                 data_shape = (None, first_data.shape[0], first_data.shape[1])
                 first_data = first_data[np.newaxis, :, :]
 
-        if isinstance(first_data[0], str):
+        if np.size(first_data > 0) and isinstance(first_data[0], str):
             first_data = np.array(first_data, dtype="|S")
 
         self._m_data_storage.m_data_bank.create_dataset(tag,

--- a/PynPoint/Core/DataIO.py
+++ b/PynPoint/Core/DataIO.py
@@ -631,8 +631,8 @@ class OutputPort(Port):
                 data_shape = (None, first_data.shape[0], first_data.shape[1])
                 first_data = first_data[np.newaxis, :, :]
 
-        if np.size(first_data > 0) and isinstance(first_data[0], str):
-            first_data = np.array(first_data, dtype="|S")
+        if np.size(first_data) > 0 and isinstance(first_data[0], str):
+                first_data = np.array(first_data, dtype="|S")
 
         self._m_data_storage.m_data_bank.create_dataset(tag,
                                                         data=first_data,

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -247,7 +247,9 @@ class SimplexMinimizationModule(ProcessingModule):
                       or *sum*, to minimize the sum of the absolute pixel values
                       (Wertz et al. 2017).
         :type merit: str
-        :param aperture: Aperture radius (arcsec) used for the minimization at *position*.
+        :param aperture: Either the aperture radius (arcsec) at the position specified at *position*
+                         or a dictionary with the aperture properties. See
+                         Util.AnalysisTools.create_aperture for details.
         :type aperture: float
         :param sigma: Standard deviation (arcsec) of the Gaussian kernel which is used to smooth
                       the images before the function of merit is calculated (in order to reduce

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -722,6 +722,8 @@ class MCMCsamplingModule(ProcessingModule):
 
         mask = create_mask(im_shape, self.m_mask)
 
+        print self.m_aperture
+
         if isinstance(self.m_aperture, float):
             center = image_center(images) # (y, x)
 
@@ -734,13 +736,14 @@ class MCMCsamplingModule(ProcessingModule):
                         'radius':self.m_aperture/pixscale}
 
         elif isinstance(self.m_aperture, dict):
+            print self.m_aperture
+
             if aperture['type'] == 'circular':
                 aperture['radius'] /= pixscale
 
             elif aperture['type'] == 'elliptical':
                 aperture['semimajor'] /= pixscale
                 aperture['semiminor'] /= pixscale
-            # aperture = (self.m_aperture[1], self.m_aperture[0], self.m_aperture[2]/pixscale)
 
         initial = np.zeros((self.m_nwalkers, ndim))
 

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -722,28 +722,24 @@ class MCMCsamplingModule(ProcessingModule):
 
         mask = create_mask(im_shape, self.m_mask)
 
-        print self.m_aperture
-
         if isinstance(self.m_aperture, float):
             center = image_center(images) # (y, x)
 
             x_pos = center[1]+self.m_param[0]*math.cos(math.radians(self.m_param[1]+90.))/pixscale
             y_pos = center[0]+self.m_param[0]*math.sin(math.radians(self.m_param[1]+90.))/pixscale
 
-            aperture = {'type':'circular',
-                        'pos_x':x_pos,
-                        'pos_y':y_pos,
-                        'radius':self.m_aperture/pixscale}
+            self.m_aperture = {'type':'circular',
+                               'pos_x':x_pos,
+                               'pos_y':y_pos,
+                               'radius':self.m_aperture/pixscale}
 
         elif isinstance(self.m_aperture, dict):
-            print self.m_aperture
+            if self.m_aperture['type'] == 'circular':
+                self.m_aperture['radius'] /= pixscale
 
-            if aperture['type'] == 'circular':
-                aperture['radius'] /= pixscale
-
-            elif aperture['type'] == 'elliptical':
-                aperture['semimajor'] /= pixscale
-                aperture['semiminor'] /= pixscale
+            elif self.m_aperture['type'] == 'elliptical':
+                self.m_aperture['semimajor'] /= pixscale
+                self.m_aperture['semiminor'] /= pixscale
 
         initial = np.zeros((self.m_nwalkers, ndim))
 
@@ -764,7 +760,7 @@ class MCMCsamplingModule(ProcessingModule):
                                                pixscale,
                                                self.m_pca_number,
                                                self.m_extra_rot,
-                                               aperture]),
+                                               self.m_aperture]),
                                         threads=cpu)
 
         for i, _ in enumerate(sampler.sample(p0=initial, iterations=self.m_nsteps)):

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -720,7 +720,9 @@ class MCMCsamplingModule(ProcessingModule):
         if self.m_mask[1] is not None:
             self.m_mask[1] /= pixscale
 
-        mask = create_mask(im_shape, self.m_mask)
+        # create the mask and get the unmasked image indices
+        mask = create_mask(im_shape[-2:], self.m_mask)
+        indices = np.where(mask.reshape(-1) != 0.)[0]
 
         if isinstance(self.m_aperture, float):
             center = image_center(images) # (y, x)
@@ -760,7 +762,8 @@ class MCMCsamplingModule(ProcessingModule):
                                                pixscale,
                                                self.m_pca_number,
                                                self.m_extra_rot,
-                                               self.m_aperture]),
+                                               self.m_aperture,
+                                               indices]),
                                         threads=cpu)
 
         for i, _ in enumerate(sampler.sample(p0=initial, iterations=self.m_nsteps)):

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -579,6 +579,7 @@ class MCMCsamplingModule(ProcessingModule):
                  aperture=0.1,
                  mask=None,
                  extra_rot=0.,
+                 prior="flat",
                  **kwargs):
         """
         Constructor of MCMCsamplingModule.
@@ -624,6 +625,10 @@ class MCMCsamplingModule(ProcessingModule):
         :type mask: tuple(float, float)
         :param extra_rot: Additional rotation angle of the images (deg).
         :type extra_rot: float
+        :param prior: Prior can be set to "flat" or "aperture". With "flat", the values of *bounds*
+                      are used as uniform priors. With "aperture", the prior probability is set to
+                      zero beyond the aperture and unity within the aperture.
+        :type prior: str
         :param \**kwargs:
             See below.
 
@@ -667,6 +672,7 @@ class MCMCsamplingModule(ProcessingModule):
         self.m_pca_number = pca_number
         self.m_aperture = aperture
         self.m_extra_rot = extra_rot
+        self.m_prior = prior
 
         if mask is None:
             self.m_mask = np.array((None, None))
@@ -763,7 +769,8 @@ class MCMCsamplingModule(ProcessingModule):
                                                self.m_pca_number,
                                                self.m_extra_rot,
                                                self.m_aperture,
-                                               indices]),
+                                               indices,
+                                               self.m_prior]),
                                         threads=cpu)
 
         for i, _ in enumerate(sampler.sample(p0=initial, iterations=self.m_nsteps)):

--- a/PynPoint/ProcessingModules/FluxAndPosition.py
+++ b/PynPoint/ProcessingModules/FluxAndPosition.py
@@ -18,7 +18,7 @@ from photutils import aperture_photometry, CircularAperture
 
 from PynPoint.Core.Processing import ProcessingModule
 from PynPoint.Util.AnalysisTools import fake_planet, merit_function
-from PynPoint.Util.ImageTools import create_mask, image_center, polar_to_cartesian
+from PynPoint.Util.ImageTools import create_mask, polar_to_cartesian
 from PynPoint.Util.MCMCtools import lnprob
 from PynPoint.Util.ModuleTools import progress, memory_frames, image_size_port, \
                                       number_images_port, rotate_coordinates

--- a/PynPoint/ProcessingModules/FrameSelection.py
+++ b/PynPoint/ProcessingModules/FrameSelection.py
@@ -34,7 +34,7 @@ class RemoveFramesModule(ProcessingModule):
 
         :param frames: A tuple or array with the frame indices that have to be removed or a
                        database tag pointing to a list of frame indices.
-        :type frames: int or str
+        :type frames: str or tuple or numpy.ndarray
         :param name_in: Unique name of the module instance.
         :type name_in: str
         :param image_in_tag: Tag of the database entry that is read as input.
@@ -69,7 +69,9 @@ class RemoveFramesModule(ProcessingModule):
             self.m_index_in_port = self.add_input_port(frames)
         else:
             self.m_index_in_port = None
-            self.m_frames = np.asarray(frames, dtype=np.int)
+
+            if isinstance(frames, (tuple, list)):
+                self.m_frames = np.asarray(frames, dtype=np.int)
 
     def _initialize(self):
 

--- a/PynPoint/Util/AnalysisTools.py
+++ b/PynPoint/Util/AnalysisTools.py
@@ -27,7 +27,7 @@ def false_alarm(image,
     the related false positive fraction (Mawet et al. 2014).
 
     :param image: Input image.
-    :type image: ndarray
+    :type image: numpy.ndarray
     :param x_pos: Position (pix) along the x-axis.
     :type x_pos: float
     :param y_pos: Position (pix) along the y-axis.
@@ -97,9 +97,9 @@ def fake_planet(images,
     Function to inject artificial planets in a dataset.
 
     :param images: Input images.
-    :type images: ndarray
+    :type images: numpy.ndarray
     :param psf: PSF template.
-    :type psf: ndarray
+    :type psf: numpy.ndarray
     :param parang: Parallactic angles (deg).
     :type parang: float
     :param position: Separation (pix) and position angle (deg) measured in counterclockwise
@@ -113,7 +113,7 @@ def fake_planet(images,
     :type interpolation: str
 
     :return: Images with artificial planet injected.
-    :rtype: ndarray
+    :rtype: numpy.ndarray
     """
 
     sep = position[0]

--- a/PynPoint/Util/AnalysisTools.py
+++ b/PynPoint/Util/AnalysisTools.py
@@ -217,11 +217,12 @@ def create_aperture(aperture):
     Function to create a circular or elliptical aperture.
 
     :param aperture: Dictionary with the aperture properties. The aperture 'type' can be
-                     'circular' or 'elliptical'. Both types of apertures require a position
-                     'pos_x' and 'pos_y' (float) where the aperture is placed. The circular
+                     'circular' or 'elliptical' (str). Both types of apertures require a position,
+                     'pos_x' and 'pos_y' (float), where the aperture is placed. The circular
                      aperture requires a 'radius' (in pixels, float) and the elliptical
                      aperture requires a 'semimajor' and 'semiminor' axis (in pixels, float),
-                     and an 'angle' (deg).
+                     and an 'angle' (deg). The rotation angle in degrees of the semimajor axis
+                     from the positive x axis. The rotation angle increases counterclockwise.
     :type aperture: dict
 
     :return: Aperture object.
@@ -239,7 +240,7 @@ def create_aperture(aperture):
         phot_ap = EllipticalAperture((aperture['pos_x'], aperture['pos_y']),
                                      aperture['semimajor'],
                                      aperture['semiminor'],
-                                     math.degrees(aperture['angle']))
+                                     math.radians(aperture['angle']))
 
     else:
 

--- a/PynPoint/Util/AnalysisTools.py
+++ b/PynPoint/Util/AnalysisTools.py
@@ -11,7 +11,7 @@ import numpy as np
 from scipy.stats import t
 from scipy.ndimage.filters import gaussian_filter
 from skimage.feature import hessian_matrix
-from photutils import aperture_photometry, CircularAperture
+from photutils import aperture_photometry, CircularAperture, EllipticalAperture
 from six.moves import range
 
 from PynPoint.Util.ImageTools import shift_image
@@ -148,7 +148,6 @@ def fake_planet(images,
 
 def merit_function(residuals,
                    function,
-                   position,
                    aperture,
                    sigma):
 
@@ -159,10 +158,9 @@ def merit_function(residuals,
     :type residuals: ndarray
     :param function: Figure of merit ("hessian" or "sum").
     :type function: str
-    :param position: Center position (y, x) of the circular aperture (pix).
-    :type position: (float, float)
-    :param aperture: Aperture radius (pix).
-    :type aperture: float
+    :param aperture: Dictionary with the aperture properties. See
+                     Util.AnalysisTools.create_aperture for details.
+    :type aperture: dict
     :param sigma: Standard deviation (pix) of the Gaussian kernel which is used to smooth
                   the residuals before the function of merit is calculated.
     :type sigma: float
@@ -173,10 +171,16 @@ def merit_function(residuals,
 
     if function == "hessian":
 
+        if aperture['type'] != 'circular':
+            raise ValueError("Measuring the Hessian is only possible with a circular aperture.")
+
         npix = residuals.shape[-1]
 
-        x_grid = np.linspace(-(position[1]+0.5), npix-(position[1]+0.5), npix)
-        y_grid = np.linspace(-(position[0]+0.5), npix-(position[0]+0.5), npix)
+        pos_x = aperture['pos_x']
+        pos_y = aperture['pos_y']
+
+        x_grid = np.linspace(-(pos_x+0.5), npix-(pos_x+0.5), npix)
+        y_grid = np.linspace(-(pos_y+0.5), npix-(pos_y+0.5), npix)
 
         xx_grid, yy_grid = np.meshgrid(x_grid, y_grid)
         rr_grid = np.sqrt(xx_grid*xx_grid+yy_grid*yy_grid)
@@ -188,7 +192,7 @@ def merit_function(residuals,
                                                             order='rc')
 
         hes_det = (hessian_rr*hessian_cc) - (hessian_rc*hessian_rc)
-        hes_det[rr_grid > aperture] = 0.
+        hes_det[rr_grid > aperture['radius']] = 0.
         merit = np.sum(np.abs(hes_det))
 
     elif function == "sum":
@@ -196,8 +200,10 @@ def merit_function(residuals,
         if sigma > 0.:
             residuals = gaussian_filter(input=residuals, sigma=sigma)
 
-        aperture = CircularAperture((position[1], position[0]), aperture)
-        phot_table = aperture_photometry(np.abs(residuals), aperture, method='exact')
+        phot_table = aperture_photometry(np.abs(residuals),
+                                         create_aperture(aperture),
+                                         method='exact')
+
         merit = phot_table['aperture_sum']
 
     else:
@@ -205,3 +211,38 @@ def merit_function(residuals,
         raise ValueError("Merit function not recognized.")
 
     return merit
+
+def create_aperture(aperture):
+    """
+    Function to create a circular or elliptical aperture.
+
+    :param aperture: Dictionary with the aperture properties. The aperture 'type' can be
+                     'circular' or 'elliptical'. Both types of apertures require a position
+                     'pos_x' and 'pos_y' (float) where the aperture is placed. The circular
+                     aperture requires a 'radius' (in pixels, float) and the elliptical
+                     aperture requires a 'semimajor' and 'semiminor' axis (in pixels, float),
+                     and an 'angle' (deg).
+    :type aperture: dict
+
+    :return: Aperture object.
+    :rtype: photutils.aperture.circle.CircularAperture or
+            photutils.aperture.circle.EllipticalAperture
+    """
+
+    if aperture['type'] == "circular":
+
+        phot_ap = CircularAperture((aperture['pos_x'], aperture['pos_y']),
+                                   aperture['radius'])
+
+    elif aperture['type'] == "elliptical":
+
+        phot_ap = EllipticalAperture((aperture['pos_x'], aperture['pos_y']),
+                                     aperture['semimajor'],
+                                     aperture['semiminor'],
+                                     math.degrees(aperture['angle']))
+
+    else:
+
+        raise ValueError("Aperture type not recognized.")
+
+    return phot_ap

--- a/PynPoint/Util/ImageTools.py
+++ b/PynPoint/Util/ImageTools.py
@@ -227,7 +227,7 @@ def polar_to_cartesian(image, sep, ang):
 
     center = image_center(image) # (y, x)
 
-    x_pos = center[1] + sep*math.cos(math.radians(ang-90.))
-    y_pos = center[0] + sep*math.sin(math.radians(ang-90.))
+    x_pos = center[1] + sep*math.cos(math.radians(ang+90.))
+    y_pos = center[0] + sep*math.sin(math.radians(ang+90.))
 
     return x_pos, y_pos

--- a/PynPoint/Util/ImageTools.py
+++ b/PynPoint/Util/ImageTools.py
@@ -4,6 +4,8 @@ Functions for image processing.
 
 from __future__ import absolute_import
 
+import math
+
 import numpy as np
 
 from scipy.ndimage import fourier_shift
@@ -18,7 +20,7 @@ def image_center(image):
     can not be unambiguously defined for an even-sized image.
 
     :param image: Input image (2D or 3D).
-    :type image: ndarray
+    :type image: numpy.ndarray
 
     :return: Pixel position (y, x) of the image center.
     :rtype: (int, int)
@@ -45,7 +47,7 @@ def crop_image(image,
     Function to crop square images around a specified position.
 
     :param image: Input image (2D or 3D).
-    :type image: ndarray
+    :type image: numpy.ndarray
     :param center: Tuple (y, x) with the new image center. The center of the image is used if
                    set to None.
     :type center: (int, int)
@@ -54,7 +56,7 @@ def crop_image(image,
     :type size: int
 
     :return: Cropped odd-sized image.
-    :rtype: ndarray
+    :rtype: numpy.ndarray
     """
 
     if center is None or (center[0] is None and center[1] is None):
@@ -90,12 +92,12 @@ def rotate_images(images,
     Function to rotate all images in clockwise direction.
 
     :param images: Stack of images.
-    :type images: ndarray
+    :type images: numpy.ndarray
     :param angle: Rotation angles (deg).
-    :type angle: ndarray
+    :type angle: numpy.ndarray
 
     :return: Rotated images.
-    :rtype: ndarray
+    :rtype: numpy.ndarray
     """
 
     im_rot = np.zeros(images.shape)
@@ -120,7 +122,7 @@ def create_mask(im_shape,
     :type size: (float, float)
 
     :return: Image mask.
-    :rtype: ndarray
+    :rtype: numpy.ndarray
     """
 
     mask = np.ones(im_shape)
@@ -155,14 +157,14 @@ def shift_image(image,
     Function to shift an image.
 
     :param images: Input image.
-    :type images: ndarray
+    :type images: numpy.ndarray
     :param shift_yx: Shift (y, x) to be applied (pixel).
     :type shift_yx: (float, float)
     :param interpolation: Interpolation type (spline, bilinear, fft)
     :type interpolation: str
 
     :return: Shifted image.
-    :rtype: ndarray
+    :rtype: numpy.ndarray
     """
 
     if interpolation == "spline":
@@ -184,14 +186,14 @@ def scale_image(image,
     Function to spatially scale an image.
 
     :param images: Input image.
-    :type images: ndarray
+    :type images: numpy.ndarray
     :param scaling_x: Scaling factor x.
     :type scaling_x: float
     :param scaling_y: Scaling factor y.
     :type scaling_y: float
 
     :return: Shifted image.
-    :rtype: ndarray
+    :rtype: numpy.ndarray
     """
 
     sum_before = np.sum(image)
@@ -206,3 +208,26 @@ def scale_image(image,
     sum_after = np.sum(im_scale)
 
     return im_scale * (sum_before / sum_after)
+
+def polar_to_cartesian(image, sep, ang):
+    """
+    Function to convert polar coordinates to pixel coordinates.
+
+    :param image: Input image (2D or 3D).
+    :type image: numpy.ndarray
+    :param sep: Separation (pix).
+    :type sep: float
+    :param ang: Position angle (deg), measured counterclockwise with respect to the positive
+                y-axis.
+    :type ang: float
+
+    :return: Pixel position (y, x) of the image center.
+    :rtype: (int, int)
+    """
+
+    center = image_center(image) # (y, x)
+
+    x_pos = center[1] + sep*math.cos(math.radians(ang-90.))
+    y_pos = center[0] + sep*math.sin(math.radians(ang-90.))
+
+    return x_pos, y_pos

--- a/PynPoint/Util/MCMCtools.py
+++ b/PynPoint/Util/MCMCtools.py
@@ -55,8 +55,9 @@ def lnprob(param,
     :type pca_number: int
     :param extra_rot: Additional rotation angle of the images (deg).
     :type extra_rot: float
-    :param aperture: Aperture position and radius (pos_y, pos_x, radius) in pixels.
-    :type aperture: (float, float, float)
+    :param aperture: Dictionary with the aperture properties. See
+                     Util.AnalysisTools.create_aperture for details.
+    :type aperture: dict
 
     :return: Log posterior.
     :rtype: float
@@ -110,8 +111,7 @@ def lnprob(param,
 
         merit = merit_function(residuals=stack,
                                function="sum",
-                               position=aperture[0:2],
-                               aperture=aperture[2],
+                               aperture=aperture,
                                sigma=0.)
 
         return -0.5*merit

--- a/PynPoint/Util/MCMCtools.py
+++ b/PynPoint/Util/MCMCtools.py
@@ -23,7 +23,8 @@ def lnprob(param,
            pixscale,
            pca_number,
            extra_rot,
-           aperture):
+           aperture,
+           indices):
     """
     Function for the log posterior function. Should be placed at the highest level of the
     Python module in order to be pickled.
@@ -58,6 +59,8 @@ def lnprob(param,
     :param aperture: Dictionary with the aperture properties. See
                      Util.AnalysisTools.create_aperture for details.
     :type aperture: dict
+    :param indices: Non-masked image indices.
+    :type indices: numpy.ndarray
 
     :return: Log posterior.
     :rtype: float
@@ -105,7 +108,8 @@ def lnprob(param,
 
         _, im_res = pca_psf_subtraction(images=fake,
                                         angles=-1.*parang+extra_rot,
-                                        pca_number=pca_number)
+                                        pca_number=pca_number,
+                                        indices=indices)
 
         stack = combine_residuals(method="mean", res_rot=im_res)
 

--- a/PynPoint/Util/MCMCtools.py
+++ b/PynPoint/Util/MCMCtools.py
@@ -160,7 +160,7 @@ def lnprob(param,
         merit = merit_function(residuals=stack,
                                function="sum",
                                aperture=aperture,
-                               sigma=0.)
+                               sigma=0.)[0]
 
         return -0.5*merit
 

--- a/PynPoint/Util/MCMCtools.py
+++ b/PynPoint/Util/MCMCtools.py
@@ -9,7 +9,7 @@ import math
 import numpy as np
 
 from PynPoint.Util.AnalysisTools import fake_planet, merit_function
-from PynPoint.Util.ImageTools import image_center
+from PynPoint.Util.ImageTools import polar_to_cartesian
 from PynPoint.Util.PSFSubtractionTools import pca_psf_subtraction
 from PynPoint.Util.Residuals import combine_residuals
 
@@ -93,15 +93,12 @@ def lnprob(param,
                 ln_prior = -np.inf
 
         elif prior == "aperture":
-            center = image_center(images) # (y, x)
-
-            x_pos = center[1]+(param[0]/pixscale)*math.sin(math.radians(param[1]))
-            y_pos = center[0]+(param[0]/pixscale)*math.cos(math.radians(param[1]))
+            x_pos, y_pos = polar_to_cartesian(images, param[0]/pixscale, param[1])
 
             delta_x = aperture['pos_x'] - x_pos
             delta_y = aperture['pos_y'] - y_pos
 
-            if math.sqrt(delta_x**2+delta_y**2) < aperture['radius'] and \
+            if math.sqrt(delta_x**2+delta_y**2)*pixscale < aperture['radius'] and \
                bounds[2][0] <= param[2] <= bounds[2][1]:
 
                 ln_prior = 0.

--- a/PynPoint/Util/PSFSubtractionTools.py
+++ b/PynPoint/Util/PSFSubtractionTools.py
@@ -32,7 +32,8 @@ def pca_psf_subtraction(images,
     :param im_shape: Original shape of the stack with images. Required if pca_sklearn is not
                      set to None.
     :type im_shape: tuple(int, int, int)
-    :param indices: Non-masked image indices, required if pca_sklearn is not set to None.
+    :param indices: Non-masked image indices, required if pca_sklearn is not set to None. Optional
+                    if pca_sklearn is set to None.
     :type indices: numpy.ndarray
 
     :return: Mean residuals of the PSF subtraction.
@@ -44,9 +45,10 @@ def pca_psf_subtraction(images,
 
         im_shape = images.shape
 
-        # select the first image and get the unmasked image indices
-        im_star = images[0, ].reshape(-1)
-        indices = np.where(im_star != 0.)[0]
+        if indices is None:
+            # select the first image and get the unmasked image indices
+            im_star = images[0, ].reshape(-1)
+            indices = np.where(im_star != 0.)[0]
 
         # reshape the images and select the unmasked pixels
         im_reshape = images.reshape(im_shape[0], im_shape[1]*im_shape[2])

--- a/tests/test_processing/test_FluxAndPosition.py
+++ b/tests/test_processing/test_FluxAndPosition.py
@@ -277,7 +277,8 @@ class TestFluxAndPosition(object):
                                   mask=None,
                                   extra_rot=0.,
                                   scale=2.,
-                                  sigma=(1e-3, 1e-1, 1e-2))
+                                  sigma=(1e-3, 1e-1, 1e-2),
+                                  prior="flat")
 
         self.pipeline.add_module(mcmc)
         self.pipeline.run_module("mcmc")


### PR DESCRIPTION
- Added PynPoint.Util.ImageTools.polar_to_cartesian to convert a separation and angle to pixel coordinates.

- Added Util.AnalysisTools.create_aperture to create a circular or elliptical aperture.

- The aperture parameter of MCMCsamplingModule and SimplexMinimizationModule can be a dictionary with aperture properties. With a float, it runs as before, i.e. using the float as aperture radius at the position parameter (SimplexMinimizationModule) or param parameter (MCMCsamplingModule).

- Possible aperture dictionaries are, for example,  {'type':'circular', 'pos_x':94., 'pos_y':20., 'radius':0.1} or {'type':'elliptical', 'pos_x':52.2, 'pos_y':66.5, 'semimajor':0.270, 'semiminor':0.128, 'angle':50.}.

- The elliptical aperture is not implemented for the Hessian.

- Added a prior parameter to MCMCsamplingModule which can be set to "flat" (default) or "aperture". With the latter the prior probability is set to zero if a negative planet is injected outside the aperture radius.