### PR TITLE
Variance parameter MCMC

### DIFF
--- a/pynpoint/processing/darkflat.py
+++ b/pynpoint/processing/darkflat.py
@@ -40,8 +40,8 @@ def _master_frame(data,
     if data.shape != shape_in:
         cal_shape = data.shape
 
-        x_off = (cal_shape[0] - shape_in[0]) / 2
-        y_off = (cal_shape[1] - shape_in[1]) / 2
+        x_off = (cal_shape[0] - shape_in[0]) // 2
+        y_off = (cal_shape[1] - shape_in[1]) // 2
 
         data = data[x_off:x_off+shape_in[0], y_off:y_off+shape_in[1]]
 

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -17,7 +17,7 @@ from scipy.optimize import minimize
 from photutils import aperture_photometry, CircularAperture
 
 from pynpoint.core.processing import ProcessingModule
-from pynpoint.util.analysis import fake_planet, merit_function
+from pynpoint.util.analysis import fake_planet, merit_function, false_alarm
 from pynpoint.util.image import create_mask, polar_to_cartesian
 from pynpoint.util.mcmc import lnprob
 from pynpoint.util.module import progress, memory_frames, image_size_port, number_images_port, \
@@ -724,8 +724,6 @@ class MCMCsamplingModule(ProcessingModule):
         :rtype: float
         """
 
-        print(aperture)
-
         _, residuals = pca_psf_subtraction(images=images,
                                            angles=-1.*parang+self.m_extra_rot,
                                            pca_number=self.m_pca_number)
@@ -735,8 +733,6 @@ class MCMCsamplingModule(ProcessingModule):
                                   y_pos=aperture['pos_y'],
                                   size=aperture['radius'],
                                   ignore=False)
-
-        print(noise)
 
         return noise**2
 

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -388,6 +388,7 @@ class SimplexMinimizationModule(ProcessingModule):
 
             merit = merit_function(residuals=stack,
                                    function=self.m_merit,
+                                   variance="poisson",
                                    aperture=self.m_aperture,
                                    sigma=self.m_sigma)
 
@@ -583,6 +584,7 @@ class MCMCsamplingModule(ProcessingModule):
                  mask=None,
                  extra_rot=0.,
                  prior="flat",
+                 variance="poisson",
                  **kwargs):
         """
         Constructor of MCMCsamplingModule.
@@ -632,6 +634,8 @@ class MCMCsamplingModule(ProcessingModule):
                       are used as uniform priors. With "aperture", the prior probability is set to
                       zero beyond the aperture and unity within the aperture.
         :type prior: str
+        :param variance: Variance used in the likelihood function ("poisson" or "gaussian").
+        :type variance: str
         :param kwargs:
             See below.
 
@@ -676,6 +680,7 @@ class MCMCsamplingModule(ProcessingModule):
         self.m_aperture = aperture
         self.m_extra_rot = extra_rot
         self.m_prior = prior
+        self.m_variance = variance
 
         if mask is None:
             self.m_mask = np.array((None, None))
@@ -779,7 +784,8 @@ class MCMCsamplingModule(ProcessingModule):
                                                self.m_extra_rot,
                                                self.m_aperture,
                                                indices,
-                                               self.m_prior]),
+                                               self.m_prior,
+                                               self.m_variance]),
                                         threads=cpu)
 
         for i, _ in enumerate(sampler.sample(p0=initial, iterations=self.m_nsteps)):

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -728,7 +728,9 @@ class MCMCsamplingModule(ProcessingModule):
                                            angles=-1.*parang+self.m_extra_rot,
                                            pca_number=self.m_pca_number)
 
-        noise, _, _ = false_alarm(image=residuals,
+        stack = combine_residuals(method="mean", res_rot=residuals)
+
+        noise, _, _ = false_alarm(image=stack,
                                   x_pos=aperture['pos_x'],
                                   y_pos=aperture['pos_y'],
                                   size=aperture['radius'],

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -712,6 +712,10 @@ class MCMCsamplingModule(ProcessingModule):
                 self.m_aperture['semimajor'] /= pixscale
                 self.m_aperture['semiminor'] /= pixscale
 
+        if self.m_variance == 'gaussian' and self.m_aperture['type'] != 'circular':
+            raise ValueError('Gaussian variance can only be used in combination with a'
+                             'circular aperture.')
+
     def gaussian_noise(self,
                        images,
                        parang,

--- a/pynpoint/readwrite/fitsreading.py
+++ b/pynpoint/readwrite/fitsreading.py
@@ -253,7 +253,7 @@ class FitsReadingModule(ReadingModule):
 
         files = []
         for filename in os.listdir(location):
-            if filename.endswith('.fits'):
+            if filename.endswith('.fits') and not filename.startswith('._'):
                 files.append(filename)
 
         files.sort()

--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -148,6 +148,7 @@ def fake_planet(images,
 
 def merit_function(residuals,
                    function,
+                   variance,
                    aperture,
                    sigma):
 
@@ -158,6 +159,9 @@ def merit_function(residuals,
     :type residuals: ndarray
     :param function: Figure of merit ("hessian" or "sum").
     :type function: str
+    :param variance: Variance used in the likelihood function ("poisson" or "gaussian") when
+                     function is "sum".
+    :type variance: str
     :param aperture: Dictionary with the aperture properties. See
                      Util.AnalysisTools.create_aperture for details.
     :type aperture: dict
@@ -205,6 +209,15 @@ def merit_function(residuals,
                                          method='exact')
 
         merit = phot_table['aperture_sum']
+
+        if variance == "gaussian":
+            noise, _, _ = false_alarm(image=residuals,
+                                      x_pos=aperture['pos_x'],
+                                      y_pos=aperture['pos_y'],
+                                      size=aperture['radius'],
+                                      ignore=False)
+
+            merit = (merit[0]/noise)**2
 
     else:
 

--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -210,8 +210,6 @@ def merit_function(residuals,
 
         merit = phot_table['aperture_sum'][0]
 
-        print(merit, variance[1])
-
         if variance[0] == "gaussian":
             merit = merit**2/variance[1]
 

--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -210,6 +210,8 @@ def merit_function(residuals,
 
         merit = phot_table['aperture_sum'][0]
 
+        print(merit, variance[1])
+
         if variance[0] == "gaussian":
             merit = merit**2/variance[1]
 

--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -159,9 +159,9 @@ def merit_function(residuals,
     :type residuals: ndarray
     :param function: Figure of merit ("hessian" or "sum").
     :type function: str
-    :param variance: Variance used in the likelihood function ("poisson" or "gaussian") when
-                     function is "sum".
-    :type variance: str
+    :param variance: Variance type and value for the likelihood function. The value is set to None
+                     in case a Poisson distribution is assumed.
+    :type variance: tuple(str, float)
     :param aperture: Dictionary with the aperture properties. See
                      Util.AnalysisTools.create_aperture for details.
     :type aperture: dict
@@ -208,16 +208,10 @@ def merit_function(residuals,
                                          create_aperture(aperture),
                                          method='exact')
 
-        merit = phot_table['aperture_sum']
+        merit = phot_table['aperture_sum'][0]
 
-        if variance == "gaussian":
-            noise, _, _ = false_alarm(image=residuals,
-                                      x_pos=aperture['pos_x'],
-                                      y_pos=aperture['pos_y'],
-                                      size=aperture['radius'],
-                                      ignore=False)
-
-            merit = (merit[0]/noise)**2
+        if variance[0] == "gaussian":
+            merit = merit**2/variance[1]
 
     else:
 

--- a/pynpoint/util/mcmc.py
+++ b/pynpoint/util/mcmc.py
@@ -26,7 +26,8 @@ def lnprob(param,
            extra_rot,
            aperture,
            indices,
-           prior):
+           prior,
+           variance):
     """
     Function for the log posterior function. Should be placed at the highest level of the
     Python module to be pickable for the multiprocessing.
@@ -67,6 +68,8 @@ def lnprob(param,
                   are used as uniform priors. With "aperture", the prior probability is set to
                   zero beyond the aperture and unity within the aperture.
     :type prior: str
+    :param variance: Variance used in the likelihood function ("poisson" or "gaussian").
+    :type variance: str
 
     :return: Log posterior probability.
     :rtype: float
@@ -159,6 +162,7 @@ def lnprob(param,
 
         merit = merit_function(residuals=stack,
                                function="sum",
+                               variance=variance,
                                aperture=aperture,
                                sigma=0.)[0]
 

--- a/pynpoint/util/mcmc.py
+++ b/pynpoint/util/mcmc.py
@@ -68,8 +68,9 @@ def lnprob(param,
                   are used as uniform priors. With "aperture", the prior probability is set to
                   zero beyond the aperture and unity within the aperture.
     :type prior: str
-    :param variance: Variance used in the likelihood function ("poisson" or "gaussian").
-    :type variance: str
+    :param variance: Variance type and value for the likelihood function. The value is set to None
+                     in case a Poisson distribution is assumed.
+    :type variance: tuple(str, float)
 
     :return: Log posterior probability.
     :rtype: float
@@ -164,7 +165,7 @@ def lnprob(param,
                                function="sum",
                                variance=variance,
                                aperture=aperture,
-                               sigma=0.)[0]
+                               sigma=0.)
 
         return -0.5*merit
 

--- a/pynpoint/util/multiproc.py
+++ b/pynpoint/util/multiproc.py
@@ -3,12 +3,9 @@ Utilities for poison pill multiprocessing. Provides abstract interfaces as well 
 implementation needed to process lines in time as used in the wavelet time denoising.
 """
 
-from __future__ import absolute_import
-
 import multiprocessing
 
 from abc import ABCMeta, abstractmethod
-# from . import multiprocessing
 
 import six
 import numpy as np
@@ -202,7 +199,8 @@ class TaskProcessor(six.with_metaclass(ABCMeta, multiprocessing.Process)):
             self.m_result_queue.put(result)
 
     @abstractmethod
-    def run_job(self, tmp_task):
+    def run_job(self,
+                tmp_task):
         """
         Abstract interface for the run_job method which is called from run() for each task
         individually.
@@ -235,7 +233,8 @@ class TaskWriter(multiprocessing.Process):
         self.m_data_mutex = data_mutex_in
         self.m_data_out_port = data_out_port_in
 
-    def check_poison_pill(self, next_result):
+    def check_poison_pill(self,
+                          next_result):
         """
         Checks if the next result is a poison pill.
 
@@ -355,7 +354,8 @@ class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
         return tmp_processors
 
     @abstractmethod
-    def init_creator(self, image_in_port):
+    def init_creator(self,
+                     image_in_port):
         """
         Called from the constructor to create a creator object.
 
@@ -397,7 +397,9 @@ class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
 
 
 # ----- Handler to apply a function ------
-def apply_function(tmp_data, func, func_args):
+def apply_function(tmp_data,
+                   func,
+                   func_args):
     """
     Applies the function func with its arguments func_args to the tmp_data
 
@@ -544,7 +546,8 @@ class LineProcessingCapsule(MultiprocessingCapsule):
 
         return tmp_processors
 
-    def init_creator(self, image_in_port):
+    def init_creator(self,
+                     image_in_port):
 
         reader = LineReader(image_in_port,
                             self.m_tasks_queue,

--- a/pynpoint/util/psf.py
+++ b/pynpoint/util/psf.py
@@ -36,8 +36,8 @@ def pca_psf_subtraction(images,
                     if pca_sklearn is set to None.
     :type indices: numpy.ndarray
 
-    :return: Mean residuals of the PSF subtraction.
-    :rtype: ndarray
+    :return: Mean residuals of the PSF subtraction and the derotated but non-stacked residuals.
+    :rtype: numpy.ndarray, numpy.ndarray
     """
 
     if pca_sklearn is None:


### PR DESCRIPTION
- Added the `variance` parameter in the `MCMCsamplingModule`. This sets the variance in the likelihood function to either "poisson" (default, Wertz+2017), or "gaussian". The latter uses the variance as formulated by Mawet+2014, i.e. Gaussian with a correction for small sample statistics.

- Integer division fix in `darkflat` for compatibility with Python 3.

- Ignoring files starting with `._` when importing FITS files. On a Mac, such hidden files may have been created by the OS.