### PR TITLE
optimize parameter FalsePositiveModule

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -23,7 +23,7 @@ The pipeline works with two different components:
 2. The actual pipeline :class:`pynpoint.core.pypeline` which capsules a list of pipeline modules.
 
 .. important::
-   Pixel coordinates are zero-indexed, meaning that (x, y) = (0, 0) corresponds to the center of the pixel in the bottom-left corner of the image. The coordinate of the bottom-left corner is therefore (x, y) = (-0.5, -0.5). This means that there is an offset of 1.0 in both directions with respect to the pixel coordinates of DS9, for which the bottom-left corner is (x, y) = (0.5, 0.5).
+   Pixel coordinates are zero-indexed, meaning that (x, y) = (0, 0) corresponds to the center of the pixel in the bottom-left corner of the image. The coordinate of the bottom-left corner is therefore (x, y) = (-0.5, -0.5). This means that there is an offset of -1.0 in both directions with respect to the pixel coordinates of DS9, for which the bottom-left corner is (x, y) = (0.5, 0.5).
 
 .. _data-types:
 

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -444,7 +444,8 @@ class FalsePositiveModule(ProcessingModule):
                  name_in="snr",
                  image_in_tag="im_arr",
                  snr_out_tag="snr_fpf",
-                 optimize=False):
+                 optimize=False,
+                 **kwargs):
         """
         Constructor of FalsePositiveModule.
 
@@ -471,9 +472,20 @@ class FalsePositiveModule(ProcessingModule):
         :param optimize: Optimize the SNR. The aperture position is written in the history. The
                          size of the aperture is kept fixed.
         :type optimize: bool
+        :param kwargs:
+            See below.
+
+        :Keyword arguments:
+            **tolerance** (*float*) -- The absolute tolerance (pix) on the position for the
+                                       optimization to end. Default is set to 0.01 pix.
 
         :return: None
         """
+
+        if "tolerance" in kwargs:
+            self.m_tolerance = kwargs["tolerance"]
+        else:
+            self.m_tolerance = 1e-2
 
         super(FalsePositiveModule, self).__init__(name_in)
 
@@ -523,7 +535,7 @@ class FalsePositiveModule(ProcessingModule):
                                   x0=[self.m_position[0], self.m_position[1]],
                                   method="Nelder-Mead",
                                   tol=None,
-                                  options={'fatol':float("inf"), 'ftol':1e-6})
+                                  options={'xatol':self.m_tolerance, 'fatol':float("inf")})
 
                 _, snr, fpf = false_alarm(image=image,
                                           x_pos=result.x[0],

--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -14,7 +14,7 @@ from skimage.feature import hessian_matrix
 from photutils import aperture_photometry, CircularAperture, EllipticalAperture
 from six.moves import range
 
-from pynpoint.util.image import shift_image
+from pynpoint.util.image import shift_image, image_center_subpixel
 
 
 def false_alarm(image,
@@ -23,14 +23,16 @@ def false_alarm(image,
                 size,
                 ignore):
     """
-    Function for the formal t-test for high-contrast imaging at small working angles, as well as
-    the related false positive fraction (Mawet et al. 2014).
+    Function for the formal t-test for high-contrast imaging at small working angles and the
+    related false positive fraction (Mawet et al. 2014).
 
     :param image: Input image.
     :type image: numpy.ndarray
-    :param x_pos: Position (pix) along the x-axis.
+    :param x_pos: Position (pix) along the horizontal axis. The pixel coordinates of the
+                  bottom-left corner of the image are (-0.5, -0.5).
     :type x_pos: float
-    :param y_pos: Position (pix) along the y-axis.
+    :param y_pos: Position (pix) along the vertical axis. The pixel coordinates of the
+                  bottom-left corner of the image are (-0.5, -0.5).
     :type y_pos: float
     :param size: Aperture radius (pix).
     :type size: float
@@ -41,7 +43,7 @@ def false_alarm(image,
     :rtype: float, float, float
     """
 
-    center = (np.size(image, 0)/2., np.size(image, 1)/2.)
+    center = image_center_subpixel(image)
     radius = math.sqrt((center[0]-y_pos)**2.+(center[1]-x_pos)**2.)
 
     num_ap = int(math.pi*radius/size)
@@ -53,13 +55,13 @@ def false_alarm(image,
 
     if num_ap < 3:
         raise ValueError("Number of apertures (num_ap=%s) is too small to calculate the "
-                         "false positive fraction. Increase the lower limit of the "
-                         "separation argument." % num_ap)
+                         "false positive fraction." % num_ap)
 
     ap_phot = np.zeros(num_ap)
     for i, theta in enumerate(ap_theta):
         x_tmp = center[1] + (x_pos-center[1])*math.cos(theta) - \
                             (y_pos-center[0])*math.sin(theta)
+
         y_tmp = center[0] + (x_pos-center[1])*math.sin(theta) + \
                             (y_pos-center[0])*math.cos(theta)
 

--- a/pynpoint/util/image.py
+++ b/pynpoint/util/image.py
@@ -18,7 +18,7 @@ def image_center_pixel(image):
     """
     Function to get the pixel position of the image center. Note that this position
     can not be unambiguously defined for an even-sized image. Python indexing starts
-    at 0 so the coordinates of the pixel in the bottom left corner are (0, 0).
+    at 0 so the coordinates of the pixel in the bottom-left corner are (0, 0).
 
     :param image: Input image (2D or 3D).
     :type image: numpy.ndarray
@@ -88,11 +88,11 @@ def crop_image(image,
     if size%2 == 0:
         size += 1
 
-    x_start = center[1] - (size-1) // 2
-    x_end = center[1] + (size-1) // 2 + 1
+    x_start = center[1] - (size-1)//2
+    x_end = center[1] + (size-1)//2 + 1
 
-    y_start = center[0] - (size-1) // 2
-    y_end = center[0] + (size-1) // 2 + 1
+    y_start = center[0] - (size-1)//2
+    y_end = center[0] + (size-1)//2 + 1
 
     if x_start < 0 or y_start < 0 or x_end > image.shape[1] or y_end > image.shape[0]:
         raise ValueError("Target image resolution does not fit inside the input image resolution.")
@@ -249,7 +249,8 @@ def cartesian_to_polar(image, x_pos, y_pos):
     center = image_center_subpixel(image) # (y, x)
 
     sep = math.sqrt((center[1]-x_pos)**2.+(center[0]-y_pos)**2.)
-    ang = (math.atan2(y_pos-center[1], x_pos-center[0])*180./math.pi - 90.)%360.
+    ang = math.atan2(y_pos-center[1], x_pos-center[0])
+    ang = (math.degrees(ang)-90.)%360.
 
     return sep, ang
 

--- a/pynpoint/util/image.py
+++ b/pynpoint/util/image.py
@@ -228,6 +228,31 @@ def scale_image(image,
 
     return im_scale * (sum_before / sum_after)
 
+def cartesian_to_polar(image, x_pos, y_pos):
+    """
+    Function to convert pixel coordinates to polar coordinates.
+
+    :param image: Input image (2D or 3D).
+    :type image: numpy.ndarray
+    :param x_pos: Pixel coordinate along the horizontal axis. The bottom left corner of the image
+                  is (-0.5, -0.5).
+    :type x_pos: float
+    :param y_pos: Pixel coordinate along the vertical axis. The bottom left corner of the image
+                  is (-0.5, -0.5).
+    :type y_pos: float
+
+    :return: Polar coordinates as separation (pix) and position angle (deg). The angle is measured
+             counterclockwise with respect to the positive y-axis.
+    :rtype: float, float
+    """
+
+    center = image_center_subpixel(image) # (y, x)
+
+    sep = math.sqrt((center[1]-x_pos)**2.+(center[0]-y_pos)**2.)
+    ang = (math.atan2(y_pos-center[1], x_pos-center[0])*180./math.pi - 90.)%360.
+
+    return sep, ang
+
 def polar_to_cartesian(image, sep, ang):
     """
     Function to convert polar coordinates to pixel coordinates.
@@ -250,3 +275,29 @@ def polar_to_cartesian(image, sep, ang):
     y_pos = center[0] + sep*math.sin(math.radians(ang+90.))
 
     return x_pos, y_pos
+
+def get_image(input_port, index, nimages):
+    """
+    Function to get an image from an input port based on its index.
+
+    :param input_port: Input port with the stack of images.
+    :type input_port: pynpoint.core.dataio.InputPort
+    :param index: Index in the stack of images.
+    :type index: int
+    :param nimages: Total number of images in the stack.
+    :type nimages: int
+
+    :return: Selected image.
+    :rtype: numpy.ndarray
+    """
+
+    if nimages == 1:
+        image = input_port.get_all()
+
+        if image.ndim == 3:
+            image = np.squeeze(image, axis=0)
+
+    else:
+        image = input_port[index, ]
+
+    return image

--- a/tests/test_processing/test_fluxposition.py
+++ b/tests/test_processing/test_fluxposition.py
@@ -176,10 +176,12 @@ class TestFluxAndPosition(object):
         self.pipeline.run_module("false")
 
         data = self.pipeline.get_data("snr_fpf")
-        assert np.allclose(data[0, 2], 0.5280553948214145, rtol=limit, atol=0.)
-        assert np.allclose(data[0, 3], 94.39870535499551, rtol=limit, atol=0.)
-        assert np.allclose(data[0, 4], 8.542166952478182, rtol=limit, atol=0.)
-        assert np.allclose(data[0, 5], 9.54772666372783e-07, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 0], 31.0, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 1], 49.0, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 2], 0.513710034941892, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 3], 93.01278750418334, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 4], 7.633199090133858, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 5], 3.029521252528866e-06, rtol=limit, atol=0.)
 
     def test_simplex_minimization(self):
 

--- a/tests/test_processing/test_limits.py
+++ b/tests/test_processing/test_limits.py
@@ -89,7 +89,7 @@ class TestDetectionLimits(object):
 
             data = self.pipeline.get_data("limits_"+item)
             assert np.allclose(data[0, 0], 5.00000000e-01, rtol=limit, atol=0.)
-            assert np.allclose(data[0, 1], 6.647211555936695, rtol=limit, atol=0.)
-            assert np.allclose(data[0, 2], 0.07837070875760642, rtol=limit, atol=0.)
+            assert np.allclose(data[0, 1], 6.791207747570333, rtol=limit, atol=0.)
+            assert np.allclose(data[0, 2], 0.09527007675032029, rtol=limit, atol=0.)
             assert np.allclose(data[0, 3], 0.0002012649090622487, rtol=limit, atol=0.)
             assert data.shape == (1, 4)


### PR DESCRIPTION
- `optimize` parameter for `FalsePositiveModule`. If set to True, the FPF is minimized by leaving the position of the planet aperture as free parameter. The aperture radius is kept fixed. The absolute tolerance is set to infinity and the fractional tolerance on the FPF to 1e-6.
- `util.image.cartesian_to_polar` function to convert pixel coordinates to polar coordinates.
- `util.image.get_image` function to select an image from a database tag by its index number.

