### PR TITLE
Angle shift and shape check

### DIFF
--- a/pynpoint/processing/centering.py
+++ b/pynpoint/processing/centering.py
@@ -52,7 +52,9 @@ class StarExtractionModule(ProcessingModule):
             *image_in_tag*.
         index_out_tag : str
             List with image indices for which the image size is too large to be cropped around the
-            brightest pixel. No data is written if set to None.
+            brightest pixel. No data is written if set to None. This tag name can be provided to
+            the *frames* parameter in
+            :class:`~pynpoint.processing.frameselection.RemoveFramesModule`.
         image_size : float
             Cropped image size (arcsec).
         fwhm_star : float

--- a/pynpoint/processing/pcabackground.py
+++ b/pynpoint/processing/pcabackground.py
@@ -46,9 +46,6 @@ class PCABackgroundPreparationModule(ProcessingModule):
             position, and *first* the index value of the first cube which contains the star
             (Python indexing starts at zero). Sorting is based on the DITHER_X and DITHER_Y
             attributes when *cubes* is set to None.
-        mean : bool
-            Subtract the mean pixel value from each image separately, both star and background
-            frames.
         name_in : str
             Unique name of the module instance.
         image_in_tag : str

--- a/pynpoint/processing/psfpreparation.py
+++ b/pynpoint/processing/psfpreparation.py
@@ -563,6 +563,14 @@ class AngleCalculationModule(ProcessingModule):
             # See SPHERE manual page 64 (v102)
             new_angles_corr = new_angles - self.m_pupil_offset
 
+        indices = np.where(new_angles_corr < -180.)[0]
+        if indices.size > 0:
+            new_angles_corr[indices] += 360.
+
+        indices = np.where(new_angles_corr > 180.)[0]
+        if indices.size > 0:
+            new_angles_corr[indices] -= 360.
+
         self.m_data_out_port.add_attribute("PARANG", new_angles_corr, static=False)
 
         sys.stdout.write("Running AngleCalculationModule... [DONE]\n")

--- a/pynpoint/processing/stacksubset.py
+++ b/pynpoint/processing/stacksubset.py
@@ -470,7 +470,7 @@ class CombineTagsModule(ProcessingModule):
 
         for i, item in enumerate(self.m_image_in_tags):
             image_in_port.append(self.add_input_port(item))
-            im_shape.append(image_in_port[i].get_shape())
+            im_shape.append(image_in_port[i].get_shape()[-2:])
 
         if len(set(im_shape)) > 1:
             raise ValueError("The size of the images should be the same for all datasets.")

--- a/tests/test_processing/test_psfpreparation.py
+++ b/tests/test_processing/test_psfpreparation.py
@@ -111,14 +111,15 @@ class TestPSFpreparation(object):
         assert len(warning) == 2
         assert warning[0].message.args[0] == "AngleCalculationModule has not been tested for " \
                                              "SPHERE/IFS data."
-        assert warning[1].message.args[0] == "For SPHERE data it is recommended to use the header keywords " \
-                          "\"ESO INS4 DROT2 RA/DEC\" to specify the object's position. " \
-                          "The input will be parsed accordingly. Using the regular " \
-                          "RA/DEC parameters will lead to wrong parallactic angles." \
+        assert warning[1].message.args[0] == "For SPHERE data it is recommended to use the " \
+                                             "header keywords \"ESO INS4 DROT2 RA/DEC\" to " \
+                                             "specify the object's position. The input will be " \
+                                             "parsed accordingly. Using the regular RA/DEC "\
+                                             "parameters will lead to wrong parallactic angles." \
 
         data = self.pipeline.get_data("header_read/PARANG")
-        assert np.allclose(data[0], 270.87102733657815, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 270.9724409967988, rtol=limit, atol=0.)
+        assert np.allclose(data[0], -89.12897266342185, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), -89.02755900320116, rtol=limit, atol=0.)
         assert data.shape == (40, )
 
     def test_angle_interpolation_mismatch(self):


### PR DESCRIPTION
- Additional correction of 360 deg in `AngleCalculationModule` if the calculated parallactic angles are smaller than -180 deg or larger than 180 deg, just to have them in a more intuitive range (which was not always the case because of the additional rotation offsets that are applied). @18alex96 could you have a brief look?

- Check in `CombineTagsModule` if the images of all datasets have the same size. If not, an error is raised.