### PR TITLE
Psf_in_tag in ContrastCurveModule doesn't accept 2D image

### DIFF
--- a/pynpoint/processing/limits.py
+++ b/pynpoint/processing/limits.py
@@ -186,11 +186,11 @@ class ContrastCurveModule(ProcessingModule):
 
         self.m_aperture /= pixscale
 
-        if psf.ndim == 3 and psf.shape[0] != images.shape[0]:
-            raise ValueError('The number of frames in psf_in_tag does not match with the number of '
-                             'frames in image_in_tag. The DerotateAndStackModule can be used to '
-                             'average the PSF frames (without derotating) before applying the '
-                             'ContrastCurveModule.')
+        if psf.shape[0] != 1 and psf.shape[0] != images.shape[0]:
+            raise ValueError('The number of frames in psf_in_tag {0} does not match with the '
+                             'number of frames in image_in_tag {1}. The DerotateAndStackModule can '
+                             'be used to average the PSF frames (without derotating) before '
+                             'applying the ContrastCurveModule.'.format(psf.shape, images.shape))
 
         pos_r = np.arange(self.m_separation[0]/pixscale,
                           self.m_separation[1]/pixscale,
@@ -214,7 +214,7 @@ class ContrastCurveModule(ProcessingModule):
 
         pos_r = np.delete(pos_r, index_del)
 
-        sys.stdout.write("Running ContrastCurveModule\r")
+        sys.stdout.write("Running ContrastCurveModule...\r")
         sys.stdout.flush()
 
         positions = []
@@ -269,7 +269,7 @@ class ContrastCurveModule(ProcessingModule):
 
             progress(i, len(jobs), "Running ConstrastCurveModule...")
 
-        # Send termination sentinel to queue and block till all tasks are done
+        # Send termination sentinel to queue
         queue.put(None)
 
         while True:

--- a/pynpoint/util/limits.py
+++ b/pynpoint/util/limits.py
@@ -37,10 +37,10 @@ def contrast_limit(tmp_images,
     Function for calculating the contrast limit at a specified position by iterating towards
     a threshold for the false positive fraction, with a correction for small sample statistics.
 
-    :param images: Stack of images.
-    :type images: numpy.ndarray
-    :param psf: PSF template for the fake planet (2D or 3D).
-    :type psf: numpy.ndarray
+    :param images: System location of the stack of images.
+    :type images: string
+    :param psf: System location of the PSF template for the fake planet (1 or multiple frames).
+    :type psf: string
     :param parang: Derotation angles (deg).
     :type parang: numpy.ndarray
     :param psf_scaling: Additional scaling factor of the planet flux (e.g., to correct for a
@@ -90,6 +90,9 @@ def contrast_limit(tmp_images,
 
     images = np.load(tmp_images)
     psf = np.load(tmp_psf)
+
+    if psf.shape[0] == 1:
+        psf = np.array(psf[0, :, :])
 
     if threshold[0] == "sigma":
         fpf_threshold = student_fpf(sigma=threshold[1],

--- a/pynpoint/util/limits.py
+++ b/pynpoint/util/limits.py
@@ -38,9 +38,10 @@ def contrast_limit(tmp_images,
     a threshold for the false positive fraction, with a correction for small sample statistics.
 
     :param images: System location of the stack of images.
-    :type images: string
-    :param psf: System location of the PSF template for the fake planet (1 or multiple frames).
-    :type psf: string
+    :type images: str
+    :param psf: System location of the PSF template for the fake planet. Either a single image
+                or a stack of images equal in size to *images*.
+    :type psf: str
     :param parang: Derotation angles (deg).
     :type parang: numpy.ndarray
     :param psf_scaling: Additional scaling factor of the planet flux (e.g., to correct for a


### PR DESCRIPTION
Hi Tomas,

I get an error when I use the contrastcurvemodule where the psf_in_tag is a single, 2D image (512, 512). This is because the fitsreadingmodule converts the (512, 512) array into (1, 512, 512). I changed the fitsreadingmodule such that it keeps the 2D size if there is only a single fits file found in the folder and that fits file contains only 1 image.

Another way would be to  change the way the psf_in_tag  in the contrastcurvemodule reads the image and allow it to accept (1, 512, 512) and read it as a single image.

The error:
ValueError: The number of frames in psf_in_tag does not match with the number of frames in image_in_tag. The DerotateAndStackModule can be used to average the PSF frames (without derotating) before applying the ContrastCurveModule.

Jasper