### PR TITLE
Converting 2D to 3D arrays

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -135,6 +135,6 @@ Stacking
 ~~~~~~~~
 
 * :class:`~pynpoint.processing.stacksubset.StackAndSubsetModule`: Stack and/or select a random subset of the images.
-* :class:`~pynpoint.processing.stacksubset.MeanCubeModule`: Compute the mean of each original data cube.
+* :class:`~pynpoint.processing.stacksubset.StackCubeModule`: Collapse each original data cube separately.
 * :class:`~pynpoint.processing.stacksubset.DerotateAndStackModule`: Derotate and/or stack the images.
 * :class:`~pynpoint.processing.stacksubset.CombineTagsModule`: Combine multiple database tags into a single dataset.

--- a/pynpoint/__init__.py
+++ b/pynpoint/__init__.py
@@ -59,6 +59,7 @@ from pynpoint.processing.resizing import CropImagesModule, \
 
 from pynpoint.processing.stacksubset import StackAndSubsetModule, \
                                             MeanCubeModule, \
+                                            StackCubeModule, \
                                             DerotateAndStackModule, \
                                             CombineTagsModule
 

--- a/pynpoint/processing/background.py
+++ b/pynpoint/processing/background.py
@@ -13,7 +13,7 @@ from six.moves import range
 
 from pynpoint.core.processing import ProcessingModule
 from pynpoint.util.image import create_mask
-from pynpoint.util.module import progress, image_size_port
+from pynpoint.util.module import progress
 
 
 class SimpleBackgroundSubtractionModule(ProcessingModule):
@@ -339,7 +339,7 @@ class LineSubtractionModule(ProcessingModule):
         """
 
         pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
-        im_shape = image_size_port(self.m_image_in_port)
+        im_shape = self.m_image_in_port.get_shape()[-2:]
 
         def _subtract_line(image_in, mask):
             image_tmp = np.copy(image_in)

--- a/pynpoint/processing/basic.py
+++ b/pynpoint/processing/basic.py
@@ -10,7 +10,7 @@ from scipy.ndimage import rotate
 from six.moves import range
 
 from pynpoint.core.processing import ProcessingModule
-from pynpoint.util.module import progress, memory_frames, number_images_port
+from pynpoint.util.module import progress, memory_frames
 
 
 class SubtractImagesModule(ProcessingModule):
@@ -224,8 +224,10 @@ class RotateImagesModule(ProcessingModule):
             raise ValueError("Input and output port should have a different tag.")
 
         memory = self._m_config_port.get_attribute("MEMORY")
+
         ndim = self.m_image_in_port.get_ndim()
-        nimages = number_images_port(self.m_image_in_port)
+        nimages = self.m_image_in_port.get_shape()[0]
+
         frames = memory_frames(memory, nimages)
 
         for i, _ in enumerate(frames[:-1]):

--- a/pynpoint/processing/frameselection.py
+++ b/pynpoint/processing/frameselection.py
@@ -14,7 +14,7 @@ from six.moves import range
 
 from pynpoint.core.processing import ProcessingModule
 from pynpoint.util.image import crop_image
-from pynpoint.util.module import progress, memory_frames, number_images_port, locate_star
+from pynpoint.util.module import progress, memory_frames, locate_star
 from pynpoint.util.remove import write_selected_data, write_selected_attributes
 
 
@@ -117,7 +117,7 @@ class RemoveFramesModule(ProcessingModule):
 
         memory = self._m_config_port.get_attribute("MEMORY")
 
-        nimages = number_images_port(self.m_image_in_port)
+        nimages = self.m_image_in_port.get_shape()[0]
         frames = memory_frames(memory, nimages)
 
         if memory == 0 or memory >= nimages:
@@ -346,7 +346,7 @@ class FrameSelectionModule(ProcessingModule):
         self._initialize()
 
         pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
-        nimages = number_images_port(self.m_image_in_port)
+        nimages = self.m_image_in_port.get_shape()[0]
 
         aperture = _get_aperture(self.m_aperture)
         starpos = _get_starpos(self.m_fwhm, self.m_position)

--- a/pynpoint/processing/psfpreparation.py
+++ b/pynpoint/processing/psfpreparation.py
@@ -15,7 +15,7 @@ from scipy import ndimage
 from six.moves import range
 
 from pynpoint.core.processing import ProcessingModule
-from pynpoint.util.module import progress, memory_frames, number_images_port
+from pynpoint.util.module import progress, memory_frames
 from pynpoint.util.image import create_mask, scale_image, shift_image
 
 
@@ -99,8 +99,8 @@ class PSFpreparationModule(ProcessingModule):
         if self.m_edge_size is not None:
             self.m_edge_size /= pixscale
 
-        nimages = number_images_port(self.m_image_in_port)
         im_shape = self.m_image_in_port.get_shape()
+        nimages = im_shape[0]
 
         if self.m_norm:
             im_norm = np.linalg.norm(self.m_image_in_port.get_all(),
@@ -644,7 +644,7 @@ class SDIpreparationModule(ProcessingModule):
         wvl_factor = self.m_line_wvl/self.m_cnt_wvl
         width_factor = self.m_line_width/self.m_cnt_width
 
-        nimages = number_images_port(self.m_image_in_port)
+        nimages = self.m_image_in_port.get_shape()[0]
 
         for i in range(nimages):
             progress(i, nimages, "Running SDIpreparationModule...")

--- a/pynpoint/processing/stacksubset.py
+++ b/pynpoint/processing/stacksubset.py
@@ -218,6 +218,9 @@ class MeanCubeModule(ProcessingModule):
 
         super(MeanCubeModule, self).__init__(name_in=name_in)
 
+        warnings.warn("The MeanCubeModule will be be deprecated in a future release. Please use "
+                      "the StackCubeModule instead.", DeprecationWarning)
+
         self.m_image_in_port = self.add_input_port(image_in_tag)
         self.m_image_out_port = self.add_output_port(image_out_tag)
 
@@ -235,23 +238,28 @@ class MeanCubeModule(ProcessingModule):
         if self.m_image_in_port.tag == self.m_image_out_port.tag:
             raise ValueError("Input and output port should have a different tag.")
 
-        non_static = self.m_image_in_port.get_all_non_static_attributes()
-
-        nframes = self.m_image_in_port.get_attribute("NFRAMES")
-
         self.m_image_out_port.del_all_data()
         self.m_image_out_port.del_all_attributes()
 
+        non_static = self.m_image_in_port.get_all_non_static_attributes()
+        nframes = self.m_image_in_port.get_attribute("NFRAMES")
+
+        if "PARANG" in non_static:
+            parang = self.m_image_in_port.get_attribute("PARANG")
+        else:
+            parang = None
+
         current = 0
+        parang_new = []
 
         for i, frames in enumerate(nframes):
             progress(i, len(nframes), "Running MeanCubeModule...")
 
-            mean_frame = np.mean(self.m_image_in_port[current:current+frames, ],
-                                 axis=0)
+            mean_frame = np.mean(self.m_image_in_port[current:current+frames, ], axis=0)
+            self.m_image_out_port.append(mean_frame, data_dim=3)
 
-            self.m_image_out_port.append(mean_frame,
-                                         data_dim=3)
+            if parang is not None:
+                parang_new.append(np.mean(parang[current:current+frames]))
 
             current += frames
 
@@ -269,6 +277,112 @@ class MeanCubeModule(ProcessingModule):
         if "NFRAMES" in non_static:
             nframes = np.ones(nimages, dtype=np.int)
             self.m_image_out_port.add_attribute("NFRAMES", nframes, static=False)
+
+        if "PARANG" in non_static:
+            self.m_image_out_port.add_attribute("PARANG", parang_new, static=False)
+
+        self.m_image_out_port.close_port()
+
+
+class StackCubeModule(ProcessingModule):
+    """
+    Module for calculating the mean or median of each original data cube associated with a
+    database tag.
+    """
+
+    def __init__(self,
+                 name_in="stack_cube",
+                 image_in_tag="im_arr",
+                 image_out_tag="im_stack",
+                 combine="mean"):
+        """
+        Constructor of StackCubeModule.
+
+        Parameters
+        ----------
+        name_in : str
+            Unique name of the module instance.
+        image_in_tag : str
+            Tag of the database entry that is read as input.
+        image_out_tag : str
+            Tag of the database entry with the mean or median collapsed images that are written
+            as output. Should be different from *image_in_tag*.
+        combine : str
+            Method to combine the images ("mean" or "median").
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        super(StackCubeModule, self).__init__(name_in=name_in)
+
+        self.m_image_in_port = self.add_input_port(image_in_tag)
+        self.m_image_out_port = self.add_output_port(image_out_tag)
+
+        self.m_combine = combine
+
+    def run(self):
+        """
+        Run method of the module. Uses the NFRAMES attribute to select the images of each cube,
+        calculates the mean or median of each cube, and saves the data and attributes.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        if self.m_image_in_port.tag == self.m_image_out_port.tag:
+            raise ValueError("Input and output port should have a different tag.")
+
+        self.m_image_out_port.del_all_data()
+        self.m_image_out_port.del_all_attributes()
+
+        non_static = self.m_image_in_port.get_all_non_static_attributes()
+        nframes = self.m_image_in_port.get_attribute("NFRAMES")
+
+        if "PARANG" in non_static:
+            parang = self.m_image_in_port.get_attribute("PARANG")
+        else:
+            parang = None
+
+        current = 0
+        parang_new = []
+
+        for i, frames in enumerate(nframes):
+            progress(i, len(nframes), "Running StackCubeModule...")
+
+            if self.m_combine == "mean":
+                im_stack = np.mean(self.m_image_in_port[current:current+frames, ], axis=0)
+            elif self.m_combine == "median":
+                im_stack = np.median(self.m_image_in_port[current:current+frames, ], axis=0)
+
+            self.m_image_out_port.append(im_stack, data_dim=3)
+
+            if parang is not None:
+                parang_new.append(np.mean(parang[current:current+frames]))
+
+            current += frames
+
+        sys.stdout.write("Running StackCubeModule... [DONE]\n")
+        sys.stdout.flush()
+
+        nimages = np.size(nframes)
+
+        self.m_image_out_port.copy_attributes(self.m_image_in_port)
+
+        if "INDEX" in non_static:
+            index = np.arange(0, nimages, 1, dtype=np.int)
+            self.m_image_out_port.add_attribute("INDEX", index, static=False)
+
+        if "NFRAMES" in non_static:
+            nframes = np.ones(nimages, dtype=np.int)
+            self.m_image_out_port.add_attribute("NFRAMES", nframes, static=False)
+
+        if "PARANG" in non_static:
+            self.m_image_out_port.add_attribute("PARANG", parang_new, static=False)
 
         self.m_image_out_port.close_port()
 

--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -1,5 +1,5 @@
 """
-Functions for analysis of a planet signal.
+Functions for analysis of a point source.
 """
 
 from __future__ import absolute_import
@@ -26,21 +26,29 @@ def false_alarm(image,
     Function for the formal t-test for high-contrast imaging at small working angles and the
     related false positive fraction (Mawet et al. 2014).
 
-    :param image: Input image (2D).
-    :type image: numpy.ndarray
-    :param x_pos: Position (pix) along the horizontal axis. The pixel coordinates of the
-                  bottom-left corner of the image are (-0.5, -0.5).
-    :type x_pos: float
-    :param y_pos: Position (pix) along the vertical axis. The pixel coordinates of the
-                  bottom-left corner of the image are (-0.5, -0.5).
-    :type y_pos: float
-    :param size: Aperture radius (pix).
-    :type size: float
-    :param ignore: Ignore neighboring aperture for the noise.
-    :type ignore: bool
+    Parameters
+    ----------
+    image : numpy.ndarray
+        Input image (2D).
+    x_pos : float
+        Position (pix) along the horizontal axis. The pixel coordinates of the bottom-left
+        corner of the image are (-0.5, -0.5).
+    y_pos : float
+        Position (pix) along the vertical axis. The pixel coordinates of the bottom-left corner
+        of the image are (-0.5, -0.5).
+    size : float
+        Aperture radius (pix).
+    ignore : bool
+        Ignore the neighboring apertures for the noise estimate.
 
-    :return: Noise level, SNR, FPF
-    :rtype: float, float, float
+    Returns
+    -------
+    float
+        Noise level.
+    float
+        Signal-to-noise ratio.
+    float
+        False positive fraction (FPF).
     """
 
     center = center_subpixel(image)
@@ -80,9 +88,26 @@ def student_fpf(sigma,
                 ignore):
     """
     Function to calculate the false positive fraction for a given sigma level (Mawet et al. 2014).
+
+    Parameters
+    ----------
+    sigma : float
+        Sigma level.
+    radius : float
+        Aperture radius (pix).
+    size : float
+        Separation of the point source (pix).
+    ignore : bool
+        Ignore neighboring apertures of the point source to exclude the self-subtraction lobes.
+
+    Returns
+    -------
+    float
+        False positive fraction (FPF).
     """
 
     num_ap = int(math.pi*radius/size)
+
     if ignore:
         num_ap -= 2
 
@@ -98,6 +123,8 @@ def fake_planet(images,
     """
     Function to inject artificial planets in a dataset.
 
+    Parameters
+    ----------
     :param images: Input images.
     :type images: numpy.ndarray
     :param psf: PSF template.
@@ -114,6 +141,8 @@ def fake_planet(images,
     :param interpolation: Interpolation type (spline, bilinear, fft)
     :type interpolation: str
 
+    Returns
+    -------
     :return: Images with artificial planet injected.
     :rtype: numpy.ndarray
     """
@@ -153,6 +182,8 @@ def merit_function(residuals,
     """
     Function to calculate the merit function at a given position in the image residuals.
 
+    Parameters
+    ----------
     :param residuals: Residuals of the PSF subtraction (2D).
     :type residuals: numpy.ndarray
     :param function: Figure of merit ("hessian" or "sum").
@@ -167,6 +198,8 @@ def merit_function(residuals,
                   the residuals before the function of merit is calculated.
     :type sigma: float
 
+    Returns
+    -------
     :return: Merit value.
     :rtype: float
     """
@@ -227,6 +260,8 @@ def create_aperture(aperture):
     """
     Function to create a circular or elliptical aperture.
 
+    Parameters
+    ----------
     :param aperture: Dictionary with the aperture properties. The aperture 'type' can be
                      'circular' or 'elliptical' (str). Both types of apertures require a position,
                      'pos_x' and 'pos_y' (float), where the aperture is placed. The circular
@@ -236,6 +271,8 @@ def create_aperture(aperture):
                      from the positive x axis. The rotation angle increases counterclockwise.
     :type aperture: dict
 
+    Returns
+    -------
     :return: Aperture object.
     :rtype: photutils.aperture.circle.CircularAperture or
             photutils.aperture.circle.EllipticalAperture

--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -26,7 +26,7 @@ def false_alarm(image,
     Function for the formal t-test for high-contrast imaging at small working angles and the
     related false positive fraction (Mawet et al. 2014).
 
-    :param image: Input image.
+    :param image: Input image (2D).
     :type image: numpy.ndarray
     :param x_pos: Position (pix) along the horizontal axis. The pixel coordinates of the
                   bottom-left corner of the image are (-0.5, -0.5).
@@ -129,22 +129,18 @@ def fake_planet(images,
 
     im_shift = np.zeros(images.shape)
 
-    if images.ndim == 2:
-        im_shift = shift_image(psf, (y_shift, x_shift), interpolation, mode='reflect')
+    for i in range(images.shape[0]):
+        if psf.shape[0] == 1:
+            im_shift[i, ] = shift_image(psf[0, ],
+                                        (y_shift[i], x_shift[i]),
+                                        interpolation,
+                                        mode='reflect')
 
-    elif images.ndim == 3:
-        for i in range(images.shape[0]):
-            if psf.ndim == 2:
-                im_shift[i, ] = shift_image(psf,
-                                            (y_shift[i], x_shift[i]),
-                                            interpolation,
-                                            mode='reflect')
-
-            elif psf.ndim == 3:
-                im_shift[i, ] = shift_image(psf[i, ],
-                                            (y_shift[i], x_shift[i]),
-                                            interpolation,
-                                            mode='reflect')
+        else:
+            im_shift[i, ] = shift_image(psf[i, ],
+                                        (y_shift[i], x_shift[i]),
+                                        interpolation,
+                                        mode='reflect')
 
     return images + im_shift
 
@@ -157,15 +153,15 @@ def merit_function(residuals,
     """
     Function to calculate the merit function at a given position in the image residuals.
 
-    :param residuals: Residuals of the PSF subtraction.
-    :type residuals: ndarray
+    :param residuals: Residuals of the PSF subtraction (2D).
+    :type residuals: numpy.ndarray
     :param function: Figure of merit ("hessian" or "sum").
     :type function: str
     :param variance: Variance type and value for the likelihood function. The value is set to None
                      in case a Poisson distribution is assumed.
     :type variance: tuple(str, float)
-    :param aperture: Dictionary with the aperture properties. See
-                     Util.AnalysisTools.create_aperture for details.
+    :param aperture: Dictionary with the aperture properties. See for more information
+                     :func:`~pynpoint.util.analysis.create_aperture`.
     :type aperture: dict
     :param sigma: Standard deviation (pix) of the Gaussian kernel which is used to smooth
                   the residuals before the function of merit is calculated.

--- a/pynpoint/util/limits.py
+++ b/pynpoint/util/limits.py
@@ -107,7 +107,7 @@ def contrast_limit(tmp_images,
     else:
         raise ValueError("Threshold type not recognized.")
 
-    x_fake, y_fake = polar_to_cartesian(images, position[0], position[1]-extra_rot)
+    xy_fake = polar_to_cartesian(images, position[0], position[1]-extra_rot)
 
     list_fpf = []
     list_mag = [magnitude[0]]
@@ -137,9 +137,9 @@ def contrast_limit(tmp_images,
 
         stack = combine_residuals(method=residuals, res_rot=im_res)
 
-        _, _, fpf = false_alarm(image=stack,
-                                x_pos=x_fake,
-                                y_pos=y_fake,
+        _, _, fpf = false_alarm(image=stack[0, ],
+                                x_pos=xy_fake[0],
+                                y_pos=xy_fake[1],
                                 size=aperture,
                                 ignore=ignore)
 

--- a/pynpoint/util/mcmc.py
+++ b/pynpoint/util/mcmc.py
@@ -33,59 +33,60 @@ def lnprob(param,
     Function for the log posterior function. Should be placed at the highest level of the
     Python module to be pickable for the multiprocessing.
 
-    :param param: Tuple with the separation (arcsec), angle (deg), and contrast
-                  (mag). The angle is measured in counterclockwise direction with
-                  respect to the positive y-axis.
-    :type param: (float, float, float)
-    :param bounds: Tuple with the boundaries of the separation (arcsec), angle (deg),
-                   and contrast (mag). Each set of boundaries is specified as a tuple.
-    :type bounds: ((float, float), (float, float), (float, float))
-    :param images: Stack with images.
-    :type images: numpy.ndarray
-    :param psf: PSF template, either a single image (2D) or a cube (3D) with the dimensions
-                equal to *images*.
-    :type psf: numpy.ndarray
-    :param mask: Array with the circular mask (zeros) of the central and outer regions.
-    :type mask: numpy.ndarray
-    :param parang: Array with the angles for derotation.
-    :type parang: numpy.ndarray
-    :param psf_scaling: Additional scaling factor of the planet flux (e.g., to correct for a
-                        neutral density filter). Should be negative in order to inject negative
-                        fake planets.
-    :type psf_scaling: float
-    :param pixscale: Additional scaling factor of the planet flux (e.g., to correct for a neutral
-                     density filter). Should be negative in order to inject negative fake planets.
-    :type pixscale: float
-    :param pca_number: Number of principal components used for the PSF subtraction.
-    :type pca_number: int
-    :param extra_rot: Additional rotation angle of the images (deg).
-    :type extra_rot: float
-    :param aperture: Dictionary with the aperture properties. See
-                     Util.AnalysisTools.create_aperture for details.
-    :type aperture: dict
-    :param indices: Non-masked image indices.
-    :type indices: numpy.ndarray
-    :param prior: Prior can be set to "flat" or "aperture". With "flat", the values of *bounds*
-                  are used as uniform priors. With "aperture", the prior probability is set to
-                  zero beyond the aperture and unity within the aperture.
-    :type prior: str
-    :param variance: Variance type and value for the likelihood function. The value is set to None
-                     in case a Poisson distribution is assumed.
-    :type variance: tuple(str, float)
-    :param residuals: Method used for combining the residuals ("mean", "median", "weighted", or
-                      "clipped").
-    :type residuals: str
+    param : tuple(float, float, float)
+        Tuple with the separation (arcsec), angle (deg), and contrast (mag). The angle is measured
+        in counterclockwise direction with respect to the positive y-axis.
+    bounds : tuple(tuple(float, float), tuple(float, float), tuple(float, float))
+        Tuple with the boundaries of the separation (arcsec), angle (deg), and contrast (mag). Each
+        set of boundaries is specified as a tuple.
+    images : numpy.ndarray
+        Stack with images.
+    psf : numpy.ndarray
+        PSF template, either a single image (2D) or a cube (3D) with the dimensions equal to
+        *images*.
+    mask : numpy.ndarray
+        Array with the circular mask (zeros) of the central and outer regions.
+    parang : numpy.ndarray
+        Array with the angles for derotation.
+    psf_scaling : float
+        Additional scaling factor of the planet flux (e.g., to correct for a neutral density
+        filter). Should be negative in order to inject negative fake planets.
+    pixscale : float
+        Additional scaling factor of the planet flux (e.g., to correct for a neutral density
+        filter). Should be negative in order to inject negative fake planets.
+    pca_number : int
+        Number of principal components used for the PSF subtraction.
+    extra_rot : float
+        Additional rotation angle of the images (deg).
+    aperture : dict
+        Dictionary with the aperture properties. See for more information
+        :func:`~pynpoint.util.analysis.create_aperture`.
+    indices : numpy.ndarray
+        Non-masked image indices.
+    prior : str
+        Prior can be set to "flat" or "aperture". With "flat", the values of *bounds* are used
+        as uniform priors. With "aperture", the prior probability is set to zero beyond the
+        aperture and unity within the aperture.
+    variance : tuple(str, float)
+        Variance type and value for the likelihood function. The value is set to None in case
+        a Poisson distribution is assumed.
+    residuals : str
+        Method used for combining the residuals ("mean", "median", "weighted", or "clipped").
 
-    :return: Log posterior probability.
-    :rtype: float
+    Returns
+    -------
+    float
+        Log posterior probability.
     """
 
     def _lnprior():
         """
         Internal function for the log prior function.
 
-        :return: Log prior.
-        :rtype: float
+        Returns
+        -------
+        float
+            Log prior.
         """
 
         if prior == "flat":
@@ -102,10 +103,10 @@ def lnprob(param,
 
         elif prior == "aperture":
 
-            x_pos, y_pos = polar_to_cartesian(images, param[0]/pixscale, param[1])
+            xy_pos = polar_to_cartesian(images, param[0]/pixscale, param[1])
 
-            delta_x = x_pos - aperture['pos_x']
-            delta_y = y_pos - aperture['pos_y']
+            delta_x = xy_pos[0] - aperture['pos_x']
+            delta_y = xy_pos[1] - aperture['pos_y']
 
             if aperture['type'] == "circular":
 
@@ -146,8 +147,10 @@ def lnprob(param,
         either a Poisson distribution (see Wertz et al. 2017) or a Gaussian distribution with a
         correction for small sample statistics (see Mawet et al. 2014).
 
-        :return: Log likelihood.
-        :rtype: float
+        Returns
+        -------
+        float
+            Log likelihood.
         """
 
         sep, ang, mag = param
@@ -166,7 +169,7 @@ def lnprob(param,
 
         stack = combine_residuals(method=residuals, res_rot=im_res)
 
-        merit = merit_function(residuals=stack,
+        merit = merit_function(residuals=stack[0, ],
                                function="sum",
                                variance=variance,
                                aperture=aperture,

--- a/pynpoint/util/module.py
+++ b/pynpoint/util/module.py
@@ -18,6 +18,20 @@ def progress(current,
              message):
     """
     Function to show and update the progress as standard output.
+
+    Parameters
+    ----------
+    current : int
+        Current index.
+    total : int
+        Total index number.
+    message : str
+        Message that is printed.
+
+    Returns
+    -------
+    NoneType
+        None
     """
 
     fraction = float(current)/float(total)
@@ -30,10 +44,21 @@ def memory_frames(memory,
                   nimages):
     """
     Function to subdivide the input images is in quantities of MEMORY.
+
+    Parameters
+    ----------
+    memory : int
+        Number of images that is simultaneously loaded into the memory.
+    nimages : int
+        Number of images in the stack.
+
+    Returns
+    -------
+    numpy.ndarray
     """
 
     if memory == 0 or memory >= nimages:
-        frames = [0, nimages]
+        frames = np.asarray([0, nimages])
 
     else:
         frames = np.linspace(0,
@@ -47,32 +72,6 @@ def memory_frames(memory,
 
     return frames
 
-def number_images_port(port):
-    """
-    Function to get the number of images of an input port.
-    """
-
-    if port.get_ndim() == 2:
-        nimages = 1
-
-    elif port.get_ndim() == 3:
-        nimages = port.get_shape()[0]
-
-    return nimages
-
-def image_size_port(port):
-    """
-    Function to get the image size of an input port.
-    """
-
-    if port.get_ndim() == 2:
-        size = port.get_shape()
-
-    elif port.get_ndim() == 3:
-        size = (port.get_shape()[1], port.get_shape()[2])
-
-    return size
-
 def locate_star(image,
                 center,
                 width,
@@ -80,17 +79,21 @@ def locate_star(image,
     """
     Function to locate the star by finding the brightest pixel.
 
-    :param image: Input image.
-    :type image: ndarray
-    :param center: Pixel center (y, x) of the subframe. The full image is used if set to None.
-    :type center: (int, int)
-    :param width: The width (pixel) of the subframe. The full image is used if set to None.
-    :type width: int
-    :param fwhm: Full width at half maximum of the Gaussian kernel.
-    :type fwhm: int
+    Parameters
+    ----------
+    image : numpy.ndarray
+        Input image (2D).
+    center : tuple(int, int)
+        Pixel center (y, x) of the subframe. The full image is used if set to None.
+    width : int
+        The width (pix) of the subframe. The full image is used if set to None.
+    fwhm : int
+        Full width at half maximum of the Gaussian kernel.
 
-    :return: Position (y, x) of the brightest pixel.
-    :rtype: (int, int)
+    Returns
+    -------
+    tuple(int, int)
+        Position (y, x) of the brightest pixel.
     """
 
     if width is not None:
@@ -118,15 +121,19 @@ def rotate_coordinates(center,
     """
     Function to rotate coordinates around the image center.
 
-    :param center: Image center (y, x).
-    :type center: (float, float)
-    :param position: Position (y, x) in the image.
-    :type position: (float, float)
-    :param angle: Angle (deg) to rotate in counterclockwise direction.
-    :type angle: float
+    Parameters
+    ----------
+    center : tuple(float, float)
+        Image center (y, x).
+    position : tuple(float, float)
+        Position (y, x) in the image.
+    angle : float
+        Angle (deg) to rotate in counterclockwise direction.
 
-    :return: Position (y, x) of the brightest pixel.
-    :rtype: (int, int)
+    Returns
+    -------
+    tuple(float, float)
+        New position (y, x).
     """
 
     pos_x = (position[1]-center[1])*math.cos(np.radians(angle)) - \

--- a/pynpoint/util/remove.py
+++ b/pynpoint/util/remove.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import
 
 import numpy as np
 
-from pynpoint.util.module import number_images_port
-
 
 def write_selected_data(images,
                         indices,
@@ -16,16 +14,21 @@ def write_selected_data(images,
     """
     Function to write a selected number of images from a data set.
 
-    :param images: Stack of images.
-    :type images: ndarray
-    :param indices: Indices that are removed.
-    :type indices: ndarray
-    :param port_selected: Port to store the selected images.
-    :type port_selected: OutputPort
-    :param port_removed: Port to store the removed images.
-    :type port_removed: OutputPort
+    Parameters
+    ----------
+    images : numpy.ndarray
+        Stack of images.
+    indices : numpy.ndarray
+        Indices that are removed.
+    port_selected : pynpoint.core.dataio.OutputPort
+        Port to store the selected images.
+    port_removed : pynpoint.core.dataio.OutputPort
+        Port to store the removed images.
 
-    :return: None
+    Returns
+    -------
+    NoneType
+        None
     """
 
     if np.size(indices) > 0:
@@ -48,27 +51,29 @@ def write_selected_attributes(indices,
     """
     Function to write the attributes of a selected number of images.
 
-    :param indices: Indices that are removed.
-    :type indices: ndarray
-    :param port_input: Port to the input data.
-    :type port_input: InputPort
-    :param port_selected: Port to store the attributes of the selected images.
-    :type port_selected: OutputPort
-    :param port_removed: Port to store the attributes of the removed images. Not written if
-                         set to None.
-    :type port_removed: OutputPort
+    Parameters
+    ----------
+    indices : numpy.ndarray
+        Indices that are removed.
+    port_input : pynpoint.core.dataio.InputPort
+        Port to the input data.
+    port_selected : pynpoint.core.dataio.OutputPort
+        Port to store the attributes of the selected images.
+    port_removed : pynpoint.core.dataio.OutputPort
+        Port to store the attributes of the removed images. Not written if set to None.
 
-    :return: None
+    Returns
+    -------
+    NoneType
+        None
     """
-
-    nimages = number_images_port(port_input)
 
     non_static = port_input.get_all_non_static_attributes()
 
     for i, item in enumerate(non_static):
         values = port_input.get_attribute(item)
 
-        if values.shape[0] == nimages:
+        if values.shape[0] == port_input.get_shape()[0]:
 
             if port_selected is not None:
                 if np.size(indices) > 0:

--- a/pynpoint/util/residuals.py
+++ b/pynpoint/util/residuals.py
@@ -10,23 +10,29 @@ from scipy.ndimage import rotate
 from six.moves import range
 
 
-def combine_residuals(method, res_rot, residuals=None, angles=None):
+def combine_residuals(method,
+                      res_rot,
+                      residuals=None,
+                      angles=None):
     """
     Function for combining the derotated residuals of the PSF subtraction.
 
-    :param method: Method used for combining the residuals ("mean", "median", "weighted", or
-                   "clipped").
-    :type method: str
-    :param res_rot: Derotated residuals of the PSF subtraction (3D).
-    :type res_rot: numpy.ndimage
-    :param residuals: Non-derotated residuals of the PSF subtraction (3D). Only required for the
-                      noise-weighted residuals.
-    :type residuals: numpy.ndimage
-    :param angles: Derotation angles (deg). Only required for the noise-weighted residuals.
-    :type angles: numpy.ndimage
+    Paraneters
+    ----------
+    method : str
+        Method used for combining the residuals ("mean", "median", "weighted", or "clipped").
+    res_rot : numpy.ndimage
+        Derotated residuals of the PSF subtraction (3D).
+    residuals : numpy.ndimage
+        Non-derotated residuals of the PSF subtraction (3D). Only required for the noise-weighted
+        residuals.
+    angles : numpy.ndimage
+        Derotation angles (deg). Only required for the noise-weighted residuals.
 
-    :return: Combined residuals (2D).
-    :rtype: numpy.ndimage
+    Returns
+    -------
+    numpy.ndimage
+        Combined residuals.
     """
 
     if method == "mean":
@@ -82,5 +88,6 @@ def combine_residuals(method, res_rot, residuals=None, angles=None):
 
                     stack[i, j] = temp.mean() + part2.mean()
 
+    stack = stack[np.newaxis, ...]
 
     return stack

--- a/tests/test_core/test_processing.py
+++ b/tests/test_core/test_processing.py
@@ -26,7 +26,7 @@ class TestPypeline(object):
         np.random.seed(1)
 
         image_3d = np.random.normal(loc=0, scale=2e-4, size=(4, 10, 10))
-        image_2d = np.random.normal(loc=0, scale=2e-4, size=(10, 10))
+        image_2d = np.random.normal(loc=0, scale=2e-4, size=(1, 10, 10))
         science = np.random.normal(loc=0, scale=2e-4, size=(4, 10, 10))
         dark = np.random.normal(loc=0, scale=2e-4, size=(4, 10, 10))
 
@@ -101,11 +101,11 @@ class TestPypeline(object):
 
         data = self.pipeline.get_data("image_2d")
         assert np.allclose(np.mean(data), 1.2869483197883442e-05, rtol=limit, atol=0.)
-        assert data.shape == (10, 10)
+        assert data.shape == (1, 10, 10)
 
         data = self.pipeline.get_data("remove_2d")
         assert np.allclose(np.mean(data), 1.3957075246029751e-05, rtol=limit, atol=0.)
-        assert data.shape == (10, 9)
+        assert data.shape == (1, 10, 9)
 
     def test_apply_function_to_images_same_port(self):
         dark = DarkCalibrationModule(name_in="dark1",
@@ -195,7 +195,7 @@ class TestPypeline(object):
 
         data = self.pipeline.get_data("scale_2d")
         assert np.allclose(np.mean(data), 8.937141109641279e-05, rtol=limit, atol=0.)
-        assert data.shape == (12, 12)
+        assert data.shape == (1, 12, 12)
 
         attribute = self.pipeline.get_attribute("scale_2d", "PIXSCALE", static=True)
         assert np.allclose(attribute, 0.08333333333333334, rtol=limit, atol=0.)

--- a/tests/test_processing/test_fluxposition.py
+++ b/tests/test_processing/test_fluxposition.py
@@ -261,7 +261,7 @@ class TestFluxAndPosition(object):
         self.pipeline.run_module("take_psf_avg")
 
         data = self.pipeline.get_data("psf_avg")
-        assert data.shape == (15, 15)
+        assert data.shape == (1, 15, 15)
 
         mcmc = MCMCsamplingModule(param=(0.1485, 0., 0.),
                                   bounds=((0.1, 0.25), (-5., 5.), (-0.5, 0.5)),

--- a/tests/test_processing/test_psfsubtraction.py
+++ b/tests/test_processing/test_psfsubtraction.py
@@ -152,7 +152,7 @@ class TestPSFSubtractionPCA(object):
 
         data = self.pipeline.get_data("cadi_stack")
         assert np.allclose(np.mean(data), -8.318786331552922e-08, rtol=limit, atol=0.)
-        assert data.shape == (100, 100)
+        assert data.shape == (1, 100, 100)
 
     def test_classical_adi_threshold(self):
 
@@ -174,7 +174,7 @@ class TestPSFSubtractionPCA(object):
 
         data = self.pipeline.get_data("cadi_stack")
         assert np.allclose(np.mean(data), 1.413437242880268e-07, rtol=limit, atol=0.)
-        assert data.shape == (100, 100)
+        assert data.shape == (1, 100, 100)
 
     def test_psf_subtraction_pca_single(self):
 

--- a/tests/test_processing/test_stacksubsample.py
+++ b/tests/test_processing/test_stacksubsample.py
@@ -122,9 +122,9 @@ class TestStackingAndSubsampling(object):
         self.pipeline.run_module("derotate1")
 
         data = self.pipeline.get_data("derotate1")
-        assert np.allclose(data[50, 50], 0.09689679769268554, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 50, 50], 0.09689679769268554, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.00010021671152246617, rtol=limit, atol=0.)
-        assert data.shape == (100, 100)
+        assert data.shape == (1, 100, 100)
 
         derotate = DerotateAndStackModule(name_in="derotate2",
                                           image_in_tag="images",
@@ -137,9 +137,9 @@ class TestStackingAndSubsampling(object):
         self.pipeline.run_module("derotate2")
 
         data = self.pipeline.get_data("derotate2")
-        assert np.allclose(data[50, 50], 0.09809001768003645, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 50, 50], 0.09809001768003645, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.00010033064394962, rtol=limit, atol=0.)
-        assert data.shape == (100, 100)
+        assert data.shape == (1, 100, 100)
 
     def test_combine_tags(self):
 

--- a/tests/test_processing/test_stacksubsample.py
+++ b/tests/test_processing/test_stacksubsample.py
@@ -7,7 +7,8 @@ import numpy as np
 from pynpoint.core.pypeline import Pypeline
 from pynpoint.readwrite.fitsreading import FitsReadingModule
 from pynpoint.processing.stacksubset import StackAndSubsetModule, MeanCubeModule, \
-                                            DerotateAndStackModule, CombineTagsModule
+                                            DerotateAndStackModule, CombineTagsModule, \
+                                            StackCubeModule
 from pynpoint.util.tests import create_config, create_star_data, remove_test_data
 
 warnings.simplefilter("always")
@@ -95,6 +96,29 @@ class TestStackingAndSubsampling(object):
 
         self.pipeline.add_module(mean)
         self.pipeline.run_module("mean")
+
+        data = self.pipeline.get_data("mean")
+        assert np.allclose(data[0, 50, 50], 0.09805840100024205, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.00010029494781738069, rtol=limit, atol=0.)
+        assert data.shape == (4, 100, 100)
+
+        attribute = self.pipeline.get_attribute("mean", "INDEX", static=False)
+        assert np.allclose(np.mean(attribute), 1.5, rtol=limit, atol=0.)
+        assert attribute.shape == (4, )
+
+        attribute = self.pipeline.get_attribute("mean", "NFRAMES", static=False)
+        assert np.allclose(np.mean(attribute), 1, rtol=limit, atol=0.)
+        assert attribute.shape == (4, )
+
+    def test_stack_cube(self):
+
+        module = StackCubeModule(name_in="stackcube",
+                                 image_in_tag="images",
+                                 image_out_tag="mean",
+                                 combine="mean")
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module("stackcube")
 
         data = self.pipeline.get_data("mean")
         assert np.allclose(data[0, 50, 50], 0.09805840100024205, rtol=limit, atol=0.)


### PR DESCRIPTION
Following #320, I have consistently updated the pipeline modules such that single images are always stored in a 3D array with the first dimension set to unity.