### PR TITLE
Docs NEAR: Fixed tag name

### DIFF
--- a/docs/near.rst
+++ b/docs/near.rst
@@ -131,7 +131,7 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    pipeline.add_module(module)
 
-   # Crop the Nod A and reference PSF around the approximate center
+   # Crop the Nod A and reference PSF to a 5 x 5 arcsecond image around the approximate center
 
    module = CropImagesModule(size=5.,
                              center=(256, 256),
@@ -184,7 +184,7 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
    pipeline.add_module(module)
 
    # To mask the central and outer part of the Nod A data
-   
+
    module = PSFpreparationModule(name_in='prep',
                                  image_in_tag='nodA_center',
                                  image_out_tag='nodA_prep',
@@ -196,7 +196,7 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    pipeline.add_module(module)
 
-   # Tun the PSF subtraction with PCA for the first 30 components
+   # Do the PSF subtraction with PCA for the first 30 components
 
    module = PcaPsfSubtractionModule(pca_numbers=range(1, 31),
                                     name_in='pca',
@@ -234,7 +234,7 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    # Datasets can be exported to FITS files by their tag name in the database
    # Here we will export the centered Nod A data to the default output place
-   
+
    module = FitsWritingModule(name_in='write1',
                               file_name='nodA_center.fits',
                               output_dir=None,
@@ -249,7 +249,7 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
    module = FitsWritingModule(name_in='write2',
                               file_name='res_median.fits',
                               output_dir=None,
-                              data_tag='res_median',
+                              data_tag='residuals',
                               data_range=None,
                               overwrite=True)
 


### PR DESCRIPTION
Hi Tomas, 

The updated docs on the NEAR data looks really sweet! I ran the script on there and found a small error in a tagname, as the one called didn't exist.

Lastly, I am curious how your centering result look. If I check the output of centering, "nodA_center", not all frames are properly centered. It also gives me the following warnings (multiple times):
<pre>Running StarCenteringModule... 
.../lib/python3.7/site-packages/PynPoint/pynpoint/processing/centering.py:679: RuntimeWarning: invalid value encountered in sqrt
  perr = np.sqrt(np.diag(pcov))
.../lib/python3.7/site-packages/scipy/optimize/minpack.py:787: OptimizeWarning: Covariance of the parameters could not be estimated
  category=OptimizeWarning)
</pre>

<pre>Fit could not converge on 471 image(s). [WARNING]
../lib/python3.7/site-packages/PynPoint/pynpoint/processing/centering.py:622: RuntimeWarning: invalid value encountered in sqrt
  alpha_x = 0.5*fwhm_x/np.sqrt(2.**(1./beta)-1.)
</pre>

Below an example of the difference in the frames (with ZSCALE):

1)
![Screenshot from 2019-04-08 15-49-46](https://user-images.githubusercontent.com/44026484/55729199-fb64a180-5a15-11e9-8ff2-94b37276cfb2.png)
2)
![Screenshot from 2019-04-08 15-50-38](https://user-images.githubusercontent.com/44026484/55729269-1c2cf700-5a16-11e9-9292-bcc4598f2a33.png)
3)
![Screenshot from 2019-04-08 15-53-38](https://user-images.githubusercontent.com/44026484/55729480-8180e800-5a16-11e9-97c8-4eb306a986bf.png)

I'm not entirely sure what is a better way yet, as the data is so non-symmetric/non-psf like. I'll see if I find a way.


