### PR TITLE
Add check if a header keyword together with its value is too long for…

### DIFF
--- a/pynpoint/readwrite/fitswriting.py
+++ b/pynpoint/readwrite/fitswriting.py
@@ -110,7 +110,7 @@ class FitsWritingModule(WritingModule):
                     if len(key + value) >= 75:
                         warnings.warn("Key '{}' with value '{}' is too long "
                                       "for the FITS format. To avoid an "
-                                      "error, the value was truncated to '{}'!"
+                                      "error, the value was truncated to '{}'."
                                       .format(key, value, value[:max_val_len]))
 
                     prihdr[key] = value[:max_val_len]

--- a/pynpoint/readwrite/fitswriting.py
+++ b/pynpoint/readwrite/fitswriting.py
@@ -97,8 +97,24 @@ class FitsWritingModule(WritingModule):
             attributes = self.m_data_port.get_all_static_attributes()
 
             for attr in attributes:
+
                 if len(attr) > 8:
-                    prihdr["hierarch "+attr] = str(attributes[attr])
+
+                    # Check if the header keyword together with its value is
+                    # too long for the FITS format. If that is the case, raise
+                    # a warning and truncate the value to avoid a ValueError.
+                    key = "hierarch " + attr
+                    value = str(attributes[attr])
+                    max_val_len = 75 - len(key)
+
+                    if len(key + value) >= 75:
+                        warnings.warn("Key '{}' with value '{}' is too long "
+                                      "for the FITS format. To avoid an "
+                                      "error, the value was truncated to '{}'!"
+                                      .format(key, value, value[:max_val_len]))
+
+                    prihdr[key] = value[:max_val_len]
+
                 else:
                     prihdr[attr] = attributes[attr]
 

--- a/tests/test_readwrite/test_fitswriting.py
+++ b/tests/test_readwrite/test_fitswriting.py
@@ -110,3 +110,31 @@ class TestFitsWritingModule(object):
         assert len(warning) == 1
         assert warning[0].message.args[0] == "Filename already present. Use overwrite=True " \
                                              "to overwrite an existing FITS file."
+
+    def test_attribute_length(self):
+
+        text = "long_text_long_text_long_text_long_text_long_text_long_text_long_text_long_text"
+
+        self.pipeline.set_attribute("images", "short", "value", static=True)
+        self.pipeline.set_attribute("images", "longer_than_eight1", "value", static=True)
+        self.pipeline.set_attribute("images", "longer_than_eight2", text, static=True)
+
+        write = FitsWritingModule(file_name="test.fits",
+                                  name_in="write6",
+                                  output_dir=None,
+                                  data_tag="images",
+                                  data_range=None,
+                                  overwrite=True)
+
+        self.pipeline.add_module(write)
+
+        with pytest.warns(UserWarning) as warning:
+            self.pipeline.run_module("write6")
+
+        assert len(warning) == 1
+        assert warning[0].message.args[0] == "Key 'hierarch longer_than_eight2' with value " \
+                                             "'long_text_long_text_long_text_long_text_long_" \
+                                             "text_long_text_long_text_long_text' is too " \
+                                             "long for the FITS format. To avoid an error, " \
+                                             "the value was truncated to 'long_text_long_text" \
+                                             "_long_text_long_text_long_tex'."


### PR DESCRIPTION
… the FITS format to avoid ValueErrors.