### PR TITLE
Multiple small fixes

### DIFF
--- a/pynpoint/core/pypeline.py
+++ b/pynpoint/core/pypeline.py
@@ -172,7 +172,8 @@ class Pypeline(object):
 
         def _read_config(config_file, attributes):
             config = configparser.ConfigParser()
-            config.read_file(open(config_file))
+            with open(config_file) as cf:
+                config.read_file(cf)
 
             for key, val in six.iteritems(attributes):
                 if config.has_option(val["config"], key):

--- a/tests/test_processing/test_background.py
+++ b/tests/test_processing/test_background.py
@@ -10,12 +10,13 @@ from pynpoint.processing.background import MeanBackgroundSubtractionModule, \
                                            LineSubtractionModule, \
                                            NoddingBackgroundModule
 from pynpoint.processing.pcabackground import DitheringBackgroundModule
-from pynpoint.processing.stacksubset import MeanCubeModule
+from pynpoint.processing.stacksubset import StackCubesModule
 from pynpoint.util.tests import create_config, create_fake, remove_test_data
 
 warnings.simplefilter("always")
 
 limit = 1e-10
+
 
 class TestBackgroundSubtraction(object):
 
@@ -275,9 +276,10 @@ class TestBackgroundSubtraction(object):
 
     def test_nodding_background(self):
 
-        mean = MeanCubeModule(name_in="mean",
-                              image_in_tag="sky",
-                              image_out_tag="mean")
+        mean = StackCubesModule(name_in="mean",
+                                image_in_tag="sky",
+                                image_out_tag="mean",
+                                combine="mean")
 
         self.pipeline.add_module(mean)
         self.pipeline.run_module("mean")

--- a/tests/test_readwrite/test_fitsreading.py
+++ b/tests/test_readwrite/test_fitsreading.py
@@ -85,25 +85,25 @@ class TestFitsReadingModule(object):
 
     def test_static_changing(self):
 
-        hdu = fits.open(self.test_dir+"fits/image01.fits")
-        header = hdu[0].header
-        header['HIERARCH ESO DET DIT'] = 0.1
-        hdu.writeto(self.test_dir+"fits/image01.fits", overwrite=True)
+        with fits.open(self.test_dir+"fits/image01.fits") as hdu:
+            header = hdu[0].header
+            header['HIERARCH ESO DET DIT'] = 0.1
+            hdu.writeto(self.test_dir+"fits/image01.fits", overwrite=True)
 
-        hdu = fits.open(self.test_dir+"fits/image02.fits")
-        header = hdu[0].header
-        header['HIERARCH ESO DET DIT'] = 0.1
-        hdu.writeto(self.test_dir+"fits/image02.fits", overwrite=True)
+        with fits.open(self.test_dir+"fits/image02.fits") as hdu:
+            header = hdu[0].header
+            header['HIERARCH ESO DET DIT'] = 0.1
+            hdu.writeto(self.test_dir+"fits/image02.fits", overwrite=True)
 
-        hdu = fits.open(self.test_dir+"fits/image03.fits")
-        header = hdu[0].header
-        header['HIERARCH ESO DET DIT'] = 0.2
-        hdu.writeto(self.test_dir+"fits/image03.fits", overwrite=True)
+        with fits.open(self.test_dir+"fits/image03.fits") as hdu:
+            header = hdu[0].header
+            header['HIERARCH ESO DET DIT'] = 0.2
+            hdu.writeto(self.test_dir+"fits/image03.fits", overwrite=True)
 
-        hdu = fits.open(self.test_dir+"fits/image04.fits")
-        header = hdu[0].header
-        header['HIERARCH ESO DET DIT'] = 0.2
-        hdu.writeto(self.test_dir+"fits/image04.fits", overwrite=True)
+        with fits.open(self.test_dir+"fits/image04.fits") as hdu:
+            header = hdu[0].header
+            header['HIERARCH ESO DET DIT'] = 0.2
+            hdu.writeto(self.test_dir+"fits/image04.fits", overwrite=True)
 
         read = FitsReadingModule(name_in="read4",
                                  input_dir=self.test_dir+"fits",
@@ -128,27 +128,28 @@ class TestFitsReadingModule(object):
                                              "value is updated."
 
     def test_header_attribute(self):
-        hdu = fits.open(self.test_dir+"fits/image01.fits")
-        header = hdu[0].header
-        header['PARANG'] = 1.0
-        hdu.writeto(self.test_dir+"fits/image01.fits", overwrite=True)
 
-        hdu = fits.open(self.test_dir+"fits/image02.fits")
-        header = hdu[0].header
-        header['PARANG'] = 2.0
-        hdu.writeto(self.test_dir+"fits/image02.fits", overwrite=True)
+        with fits.open(self.test_dir+"fits/image01.fits") as hdu:
+            header = hdu[0].header
+            header['PARANG'] = 1.0
+            hdu.writeto(self.test_dir+"fits/image01.fits", overwrite=True)
 
-        hdu = fits.open(self.test_dir+"fits/image03.fits")
-        header = hdu[0].header
-        header['PARANG'] = 3.0
-        header['HIERARCH ESO DET DIT'] = 0.1
-        hdu.writeto(self.test_dir+"fits/image03.fits", overwrite=True)
+        with fits.open(self.test_dir+"fits/image02.fits") as hdu:
+            header = hdu[0].header
+            header['PARANG'] = 2.0
+            hdu.writeto(self.test_dir+"fits/image02.fits", overwrite=True)
 
-        hdu = fits.open(self.test_dir+"fits/image04.fits")
-        header = hdu[0].header
-        header['PARANG'] = 4.0
-        header['HIERARCH ESO DET DIT'] = 0.1
-        hdu.writeto(self.test_dir+"fits/image04.fits", overwrite=True)
+        with fits.open(self.test_dir+"fits/image03.fits") as hdu:
+            header = hdu[0].header
+            header['PARANG'] = 3.0
+            header['HIERARCH ESO DET DIT'] = 0.1
+            hdu.writeto(self.test_dir+"fits/image03.fits", overwrite=True)
+
+        with fits.open(self.test_dir+"fits/image04.fits") as hdu:
+            header = hdu[0].header
+            header['PARANG'] = 4.0
+            header['HIERARCH ESO DET DIT'] = 0.1
+            hdu.writeto(self.test_dir+"fits/image04.fits", overwrite=True)
 
         read = FitsReadingModule(name_in="read5",
                                  input_dir=self.test_dir+"fits",
@@ -163,11 +164,11 @@ class TestFitsReadingModule(object):
         self.pipeline.set_attribute("config", "DIT", "None", static=True)
 
         for i in range(1, 5):
-            hdu = fits.open(self.test_dir+"fits/image0"+str(i)+".fits")
-            header = hdu[0].header
-            del header['HIERARCH ESO DET DIT']
-            del header['HIERARCH ESO DET EXP NO']
-            hdu.writeto(self.test_dir+"fits/image0"+str(i)+".fits", overwrite=True)
+            with fits.open(self.test_dir+"fits/image0"+str(i)+".fits") as hdu:
+                header = hdu[0].header
+                del header['HIERARCH ESO DET DIT']
+                del header['HIERARCH ESO DET EXP NO']
+                hdu.writeto(self.test_dir+"fits/image0"+str(i)+".fits", overwrite=True)
 
         read = FitsReadingModule(name_in="read6",
                                  input_dir=self.test_dir+"fits",


### PR DESCRIPTION
Here's three small fixes for things that were causing warnings when running the unit tests:
* Reading config files now uses a context manager (to avoid file descriptor leaks)
* Reading and writing FITS files for test cases also uses context managers now (see above)
* `test_background.py` now uses the `StackCubesModule` instead of the deprecated `MeanCubeModule`