### PR TITLE
Multiprocessing docs and util structure

### DIFF
--- a/docs/pynpoint.util.rst
+++ b/docs/pynpoint.util.rst
@@ -52,6 +52,14 @@ pynpoint.util.module module
     :undoc-members:
     :show-inheritance:
 
+pynpoint.util.multiline module
+------------------------------
+
+.. automodule:: pynpoint.util.multiline
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 pynpoint.util.multipca module
 -----------------------------
 

--- a/pynpoint/core/processing.py
+++ b/pynpoint/core/processing.py
@@ -88,6 +88,129 @@ class PypelineModule(six.with_metaclass(ABCMeta)):
         """
 
 
+class ReadingModule(six.with_metaclass(ABCMeta, PypelineModule)):
+    """
+    The abstract class ReadingModule is an interface for processing steps in the Pypeline which
+    have only read access to the central data storage. One can specify a directory on the hard
+    drive where the input data for the module is located. If no input directory is given then
+    default Pypeline input directory is used. Reading modules have a dictionary of output ports
+    (self._m_out_ports) but no input ports.
+    """
+
+    def __init__(self,
+                 name_in,
+                 input_dir=None):
+        """
+        Abstract constructor of ReadingModule which needs the unique name identifier as input
+        (more information: :class:`pynpoint.core.processing.PypelineModule`). An input directory
+        can be specified for the location of the data or else the Pypeline default directory is
+        used. This function is called in all *__init__()* functions inheriting from this class.
+
+        Parameters
+        ----------
+        name_in : str
+            The name of the ReadingModule.
+        input_dir : str
+            Directory where the input files are located.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        super(ReadingModule, self).__init__(name_in)
+
+        assert (os.path.isdir(str(input_dir)) or input_dir is None), 'Input directory for ' \
+            'reading module does not exist - input requested: %s.' % input_dir
+
+        self.m_input_location = input_dir
+        self._m_output_ports = {}
+
+    def add_output_port(self,
+                        tag,
+                        activation=True):
+        """
+        Function which creates an OutputPort for a ReadingModule and appends it to the internal
+        OutputPort dictionary. This function should be used by classes inheriting from
+        ReadingModule to make sure that only output ports with unique tags are added. The new
+        port can be used as: ::
+
+             port = self._m_output_ports[tag]
+
+        or by using the returned Port.
+
+        Parameters
+        ----------
+        tag : str
+            Tag of the new output port.
+        activation : bool
+            Activation status of the Port after creation. Deactivated ports will not save their
+            results until they are activated.
+
+        Returns
+        -------
+        pynpoint.core.dataio.OutputPort
+            The new OutputPort for the ReadingModule.
+        """
+
+        port = OutputPort(tag, activate_init=activation)
+
+        if tag in self._m_output_ports:
+            warnings.warn("Tag '%s' of ReadingModule '%s' is already used."
+                          % (tag, self._m_name))
+
+        if self._m_data_base is not None:
+            port.set_database_connection(self._m_data_base)
+
+        self._m_output_ports[tag] = port
+
+        return port
+
+    def connect_database(self,
+                         data_base_in):
+        """
+        Function used by a ReadingModule to connect all ports in the internal input and output
+        port dictionaries to the database. The function is called by Pypeline and connects the
+        DataStorage object to all module ports.
+
+        Parameters
+        ----------
+        data_base_in : pynpoint.core.dataio.DataStorage
+            The central database.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        for port in six.itervalues(self._m_output_ports):
+            port.set_database_connection(data_base_in)
+
+        self._m_config_port.set_database_connection(data_base_in)
+
+        self._m_data_base = data_base_in
+
+    def get_all_output_tags(self):
+        """
+        Returns a list of all output tags to the ReadingModule.
+
+        Returns
+        -------
+        list(str, )
+            List of output tags.
+        """
+
+        return list(self._m_output_ports.keys())
+
+    @abstractmethod
+    def run(self):
+        """
+        Abstract interface for the run method of a ReadingModule which inheres the actual
+        algorithm behind the module.
+        """
+
 class WritingModule(six.with_metaclass(ABCMeta, PypelineModule)):
     """
     The abstract class WritingModule is an interface for processing steps in the pipeline which
@@ -344,12 +467,12 @@ class ProcessingModule(six.with_metaclass(ABCMeta, PypelineModule)):
         ----------
         func : function
             The input function.
-        image_in_port : InputPort
-            InputPort which is linked to the input data.
-        image_out_port : OutputPort
-            OutputPort which is linked to the result place.
-        func_args : tuple
-            Additional arguments which are needed by the function *func*.
+        image_in_port : pynpoint.core.dataio.InputPort
+            Input port which is linked to the input data.
+        image_out_port : pynpoint.core.dataio.OutputPort
+            Output port which is linked to the results.
+        func_args : tuple, None
+            Additional arguments which are required by the input function. Not used if set to None.
 
         Returns
         -------
@@ -359,26 +482,22 @@ class ProcessingModule(six.with_metaclass(ABCMeta, PypelineModule)):
 
         init_line = image_in_port[:, 0, 0]
 
+        im_shape = image_in_port.get_shape()
+
         size = apply_function(init_line, func, func_args).shape[0]
 
-        # if image_out_port.tag == image_in_port.tag and size != image_in_port.get_shape()[0]:
-        #     raise ValueError("Input and output port have the same tag while %s is changing " \
-        #         "the length of the signal. Use different input and output ports instead." % func)
-
-        image_out_port.set_all(np.zeros((size,
-                                         image_in_port.get_shape()[1],
-                                         image_in_port.get_shape()[2])),
+        image_out_port.set_all(np.zeros((size, im_shape[1], im_shape[2])),
                                data_dim=3,
                                keep_attributes=False)
 
         cpu = self._m_config_port.get_attribute("CPU")
 
-        line_processor = LineProcessingCapsule(image_in_port,
-                                               image_out_port,
-                                               cpu,
-                                               func,
-                                               func_args,
-                                               size)
+        line_processor = LineProcessingCapsule(image_in_port=image_in_port,
+                                               image_out_port=image_out_port,
+                                               num_proc=cpu,
+                                               function=func,
+                                               function_args=func_args,
+                                               data_length=size)
 
         line_processor.run()
 
@@ -405,13 +524,13 @@ class ProcessingModule(six.with_metaclass(ABCMeta, PypelineModule)):
                              parameter3)
 
         image_in_port : pynpoint.core.dataio.InputPort
-            InputPort which is linked to the input data.
+            Input port which is linked to the input data.
         image_out_port : pynpoint.core.dataio.OutputPort
-            OutputPort which is linked to the result place. No data is written if set to None.
+            Output port which is linked to the results. No data is written if set to None.
         message : str
             Progress message that is printed.
         func_args : tuple
-            Additional arguments which are needed by the function *func*.
+            Additional arguments that are required by the input function.
 
         Returns
         -------
@@ -510,129 +629,5 @@ class ProcessingModule(six.with_metaclass(ABCMeta, PypelineModule)):
     def run(self):
         """
         Abstract interface for the run method of a ProcessingModule which inheres the actual
-        algorithm behind the module.
-        """
-
-
-class ReadingModule(six.with_metaclass(ABCMeta, PypelineModule)):
-    """
-    The abstract class ReadingModule is an interface for processing steps in the Pypeline which
-    have only read access to the central data storage. One can specify a directory on the hard
-    drive where the input data for the module is located. If no input directory is given then
-    default Pypeline input directory is used. Reading modules have a dictionary of output ports
-    (self._m_out_ports) but no input ports.
-    """
-
-    def __init__(self,
-                 name_in,
-                 input_dir=None):
-        """
-        Abstract constructor of ReadingModule which needs the unique name identifier as input
-        (more information: :class:`pynpoint.core.processing.PypelineModule`). An input directory
-        can be specified for the location of the data or else the Pypeline default directory is
-        used. This function is called in all *__init__()* functions inheriting from this class.
-
-        Parameters
-        ----------
-        name_in : str
-            The name of the ReadingModule.
-        input_dir : str
-            Directory where the input files are located.
-
-        Returns
-        -------
-        NoneType
-            None
-        """
-
-        super(ReadingModule, self).__init__(name_in)
-
-        assert (os.path.isdir(str(input_dir)) or input_dir is None), 'Input directory for ' \
-            'reading module does not exist - input requested: %s.' % input_dir
-
-        self.m_input_location = input_dir
-        self._m_output_ports = {}
-
-    def add_output_port(self,
-                        tag,
-                        activation=True):
-        """
-        Function which creates an OutputPort for a ReadingModule and appends it to the internal
-        OutputPort dictionary. This function should be used by classes inheriting from
-        ReadingModule to make sure that only output ports with unique tags are added. The new
-        port can be used as: ::
-
-             port = self._m_output_ports[tag]
-
-        or by using the returned Port.
-
-        Parameters
-        ----------
-        tag : str
-            Tag of the new output port.
-        activation : bool
-            Activation status of the Port after creation. Deactivated ports will not save their
-            results until they are activated.
-
-        Returns
-        -------
-        pynpoint.core.dataio.OutputPort
-            The new OutputPort for the ReadingModule.
-        """
-
-        port = OutputPort(tag, activate_init=activation)
-
-        if tag in self._m_output_ports:
-            warnings.warn("Tag '%s' of ReadingModule '%s' is already used."
-                          % (tag, self._m_name))
-
-        if self._m_data_base is not None:
-            port.set_database_connection(self._m_data_base)
-
-        self._m_output_ports[tag] = port
-
-        return port
-
-    def connect_database(self,
-                         data_base_in):
-        """
-        Function used by a ReadingModule to connect all ports in the internal input and output
-        port dictionaries to the database. The function is called by Pypeline and connects the
-        DataStorage object to all module ports.
-
-        Parameters
-        ----------
-        data_base_in : pynpoint.core.dataio.DataStorage
-            The central database.
-
-        Returns
-        -------
-        NoneType
-            None
-        """
-
-        for port in six.itervalues(self._m_output_ports):
-            port.set_database_connection(data_base_in)
-
-        self._m_config_port.set_database_connection(data_base_in)
-
-        self._m_data_base = data_base_in
-
-    def get_all_output_tags(self):
-        """
-        Returns a list of all output tags to the ReadingModule.
-
-        Returns
-        -------
-        list(str, )
-            List of output tags.
-        """
-
-        return list(self._m_output_ports.keys())
-
-    @abstractmethod
-    def run(self):
-        """
-        Abstract interface for the run method of a ReadingModule which inheres the actual
         algorithm behind the module.
         """

--- a/pynpoint/core/processing.py
+++ b/pynpoint/core/processing.py
@@ -14,8 +14,9 @@ import six
 import numpy as np
 
 from pynpoint.core.dataio import ConfigPort, InputPort, OutputPort
-from pynpoint.util.multiproc import LineProcessingCapsule, apply_function
 from pynpoint.util.module import progress, memory_frames
+from pynpoint.util.multiline import LineProcessingCapsule
+from pynpoint.util.multiproc import apply_function
 
 
 class PypelineModule(six.with_metaclass(ABCMeta)):

--- a/pynpoint/processing/timedenoising.py
+++ b/pynpoint/processing/timedenoising.py
@@ -218,7 +218,7 @@ class WaveletTimeDenoisingModule(ProcessingModule):
                 """
 
                 cwt_capsule = WaveletAnalysisCapsule(
-                    signal_in,
+                    signal_in=signal_in,
                     padding=self.m_padding,
                     wavelet_in=self.m_wavelet_configuration.m_wavelet,
                     order=self.m_wavelet_configuration.m_wavelet_order,

--- a/pynpoint/util/multiline.py
+++ b/pynpoint/util/multiline.py
@@ -1,0 +1,217 @@
+"""
+Utilities for multiprocessing for lines in time with the poison pill pattern.
+
+"""
+
+import six
+import numpy as np
+
+from pynpoint.util.multiproc import TaskInput, TaskResult, TaskCreator, TaskProcessor, \
+                                    MultiprocessingCapsule, apply_function
+
+
+class LineTaskProcessor(TaskProcessor):
+    """
+    Line Task Processors are part of the parallel line processing. They take a row of lines in time
+    and apply a function to them.
+    """
+
+    def __init__(self,
+                 tasks_queue_in,
+                 result_queue_in,
+                 function,
+                 function_args):
+        """
+        Parameters
+        ----------
+        tasks_queue_in : multiprocessing.queues.JoinableQueue
+            Tasks queue.
+        result_queue_in : multiprocessing.queues.JoinableQueue
+            Results queue.
+        function : function
+            Input function.
+        function_args :
+            Function arguments.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        super(LineTaskProcessor, self).__init__(tasks_queue_in, result_queue_in)
+
+        self.m_function = function
+        self.m_function_args = function_args
+
+    def run_job(self,
+                tmp_task):
+        result_arr = np.zeros((tmp_task.m_job_parameter[0],
+                               tmp_task.m_input_data.shape[1],
+                               tmp_task.m_input_data.shape[2]))
+
+        for i in six.moves.range(tmp_task.m_input_data.shape[1]):
+            for j in six.moves.range(tmp_task.m_input_data.shape[2]):
+                tmp_line = tmp_task.m_input_data[:, i, j]
+
+                result_arr[:, i, j] = apply_function(tmp_line,
+                                                     self.m_function,
+                                                     self.m_function_args)
+
+        result = TaskResult(result_arr, tmp_task.m_job_parameter[1])
+
+        return result
+
+
+class LineReader(TaskCreator):
+    """
+    Line Reader are part of the parallel line processing. They continuously read all rows of a data
+    set and puts them into a task queue.
+    """
+
+    def __init__(self,
+                 data_port_in,
+                 tasks_queue_in,
+                 data_mutex_in,
+                 number_of_processors,
+                 data_length):
+        """
+        Parameters
+        ----------
+        data_port_in : pynpoint.core.dataio.InputPort
+            Input port.
+        tasks_queue_in : multiprocessing.queues.JoinableQueue
+            Tasks queue.
+        data_mutex_in : multiprocessing.synchronize.Lock
+            A mutex shared with the writer to ensure that no read and write operations happen at
+            the same time.
+        number_of_processors : int
+            Number of processors.
+        data_length : int
+            Length of the processed data.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        super(LineReader, self).__init__(data_port_in,
+                                         tasks_queue_in,
+                                         data_mutex_in,
+                                         number_of_processors)
+
+        self.m_data_length = data_length
+
+    def run(self):
+        """
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        total_number_of_rows = self.m_data_in_port.get_shape()[1]
+        row_length = int(np.ceil(self.m_data_in_port.get_shape()[1] /
+                                 float(self.m_number_of_processors)))
+
+        i = 0
+        while i < total_number_of_rows:
+            # read rows from i to j
+            j = min((i + row_length), total_number_of_rows)
+
+            # lock Mutex and read data
+            with self.m_data_mutex:
+                # print "Reading lines from " + str(i) + " to " + str(j)
+                tmp_data = self.m_data_in_port[:, i:j, :]
+
+            self.m_task_queue.put(TaskInput(tmp_data,
+                                            (self.m_data_length,
+                                             ((None, None, None),
+                                              (i, j, None),
+                                              (None, None, None)))))
+            i = j
+
+        self.create_poison_pills()
+
+
+class LineProcessingCapsule(MultiprocessingCapsule):
+    """
+    The central processing class for parallel line processing. Use this class to apply a function
+    in time in parallel, for example as in
+    :class:`~pynpoint.processing.timedenoising.WaveletTimeDenoisingModule`.
+    """
+
+    def __init__(self,
+                 image_in_port,
+                 image_out_port,
+                 num_processors,
+                 function,
+                 function_args,
+                 data_length):
+        """
+        Parameters
+        ----------
+        image_in_port : pynpoint.core.dataio.InputPort
+            Input port.
+        image_out_port : pynpoint.core.dataio.OutputPort
+            Output port.
+        num_processors : int
+            Number of processors.
+        function : function
+            Input function.
+        function_args :
+            Function arguments.
+        data_length : int
+            Length of the processed data.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        self.m_function = function
+        self.m_function_args = function_args
+        self.m_data_length = data_length
+
+        super(LineProcessingCapsule, self).__init__(image_in_port, image_out_port, num_processors)
+
+    def create_processors(self):
+        """
+        Returns
+        -------
+        list(pynpoint.util.multiproc.LineTaskProcessor, )
+            List with line task processors.
+        """
+
+        tmp_processors = []
+
+        for _ in six.moves.range(self.m_num_processors):
+
+            tmp_processors.append(LineTaskProcessor(tasks_queue_in=self.m_tasks_queue,
+                                                    result_queue_in=self.m_result_queue,
+                                                    function=self.m_function,
+                                                    function_args=self.m_function_args))
+
+        return tmp_processors
+
+    def init_creator(self,
+                     image_in_port):
+        """
+        Parameters
+        ----------
+        image_in_port : pynpoint.core.dataio.InputPort
+            Input port.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        return LineReader(image_in_port,
+                          self.m_tasks_queue,
+                          self.m_data_mutex,
+                          self.m_num_processors,
+                          self.m_data_length)

--- a/pynpoint/util/multiline.py
+++ b/pynpoint/util/multiline.py
@@ -9,6 +9,75 @@ from pynpoint.util.multiproc import TaskInput, TaskResult, TaskCreator, TaskProc
                                     MultiprocessingCapsule, apply_function
 
 
+class LineReader(TaskCreator):
+    """
+    Line Reader are part of the parallel line processing. They continuously read all rows of a data
+    set and puts them into a task queue.
+    """
+
+    def __init__(self,
+                 data_port_in,
+                 tasks_queue_in,
+                 data_mutex_in,
+                 num_proc,
+                 data_length):
+        """
+        Parameters
+        ----------
+        data_port_in : pynpoint.core.dataio.InputPort
+            Input port.
+        tasks_queue_in : multiprocessing.queues.JoinableQueue
+            Tasks queue.
+        data_mutex_in : multiprocessing.synchronize.Lock
+            A mutex shared with the writer to ensure that no read and write operations happen at
+            the same time.
+        num_proc : int
+            Number of processors.
+        data_length : int
+            Length of the processed data.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        super(LineReader, self).__init__(data_port_in,
+                                         tasks_queue_in,
+                                         data_mutex_in,
+                                         num_proc)
+
+        self.m_data_length = data_length
+
+    def run(self):
+        """
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        n_rows = self.m_data_in_port.get_shape()[1]
+        row_length = int(np.ceil(self.m_data_in_port.get_shape()[1]/float(self.m_num_proc)))
+
+        i = 0
+        while i < n_rows:
+            # read rows from i to j
+            j = min((i + row_length), n_rows)
+
+            # lock mutex and read data
+            with self.m_data_mutex:
+                # reading lines from i to j
+                tmp_data = self.m_data_in_port[:, i:j, :]
+
+            param = (self.m_data_length, ((None, None, None), (i, j, None), (None, None, None)))
+            self.m_task_queue.put(TaskInput(tmp_data, param))
+
+            i = j
+
+        self.create_poison_pills()
+
+
 class LineTaskProcessor(TaskProcessor):
     """
     Line Task Processors are part of the parallel line processing. They take a row of lines in time
@@ -72,76 +141,6 @@ class LineTaskProcessor(TaskProcessor):
         return TaskResult(result_arr, tmp_task.m_job_parameter[1])
 
 
-class LineReader(TaskCreator):
-    """
-    Line Reader are part of the parallel line processing. They continuously read all rows of a data
-    set and puts them into a task queue.
-    """
-
-    def __init__(self,
-                 data_port_in,
-                 tasks_queue_in,
-                 data_mutex_in,
-                 number_of_processors,
-                 data_length):
-        """
-        Parameters
-        ----------
-        data_port_in : pynpoint.core.dataio.InputPort
-            Input port.
-        tasks_queue_in : multiprocessing.queues.JoinableQueue
-            Tasks queue.
-        data_mutex_in : multiprocessing.synchronize.Lock
-            A mutex shared with the writer to ensure that no read and write operations happen at
-            the same time.
-        number_of_processors : int
-            Number of processors.
-        data_length : int
-            Length of the processed data.
-
-        Returns
-        -------
-        NoneType
-            None
-        """
-
-        super(LineReader, self).__init__(data_port_in,
-                                         tasks_queue_in,
-                                         data_mutex_in,
-                                         number_of_processors)
-
-        self.m_data_length = data_length
-
-    def run(self):
-        """
-        Returns
-        -------
-        NoneType
-            None
-        """
-
-        total_number_of_rows = self.m_data_in_port.get_shape()[1]
-        row_length = int(np.ceil(self.m_data_in_port.get_shape()[1] /
-                                 float(self.m_number_of_processors)))
-
-        i = 0
-        while i < total_number_of_rows:
-            # read rows from i to j
-            j = min((i + row_length), total_number_of_rows)
-
-            # lock mutex and read data
-            with self.m_data_mutex:
-                # reading lines from i to j
-                tmp_data = self.m_data_in_port[:, i:j, :]
-
-            param = (self.m_data_length, ((None, None, None), (i, j, None), (None, None, None)))
-            self.m_task_queue.put(TaskInput(tmp_data, param))
-
-            i = j
-
-        self.create_poison_pills()
-
-
 class LineProcessingCapsule(MultiprocessingCapsule):
     """
     The central processing class for parallel line processing. Use this class to apply a function
@@ -152,7 +151,7 @@ class LineProcessingCapsule(MultiprocessingCapsule):
     def __init__(self,
                  image_in_port,
                  image_out_port,
-                 num_processors,
+                 num_proc,
                  function,
                  function_args,
                  data_length):
@@ -163,7 +162,7 @@ class LineProcessingCapsule(MultiprocessingCapsule):
             Input port.
         image_out_port : pynpoint.core.dataio.OutputPort
             Output port.
-        num_processors : int
+        num_proc : int
             Number of processors.
         function : function
             Input function.
@@ -182,7 +181,7 @@ class LineProcessingCapsule(MultiprocessingCapsule):
         self.m_function_args = function_args
         self.m_data_length = data_length
 
-        super(LineProcessingCapsule, self).__init__(image_in_port, image_out_port, num_processors)
+        super(LineProcessingCapsule, self).__init__(image_in_port, image_out_port, num_proc)
 
     def create_processors(self):
         """
@@ -194,7 +193,7 @@ class LineProcessingCapsule(MultiprocessingCapsule):
 
         tmp_processors = []
 
-        for _ in six.moves.range(self.m_num_processors):
+        for _ in six.moves.range(self.m_num_proc):
 
             tmp_processors.append(LineTaskProcessor(tasks_queue_in=self.m_tasks_queue,
                                                     result_queue_in=self.m_result_queue,
@@ -220,5 +219,5 @@ class LineProcessingCapsule(MultiprocessingCapsule):
         return LineReader(image_in_port,
                           self.m_tasks_queue,
                           self.m_data_mutex,
-                          self.m_num_processors,
+                          self.m_num_proc,
                           self.m_data_length)

--- a/pynpoint/util/multipca.py
+++ b/pynpoint/util/multipca.py
@@ -375,15 +375,13 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
             PCA task writer.
         """
 
-        writer = PcaTaskWriter(self.m_result_queue,
-                               self.m_mean_out_port,
-                               self.m_median_out_port,
-                               self.m_weighted_out_port,
-                               self.m_clip_out_port,
-                               self.m_data_mutex,
-                               self.m_requirements)
-
-        return writer
+        return PcaTaskWriter(self.m_result_queue,
+                             self.m_mean_out_port,
+                             self.m_median_out_port,
+                             self.m_weighted_out_port,
+                             self.m_clip_out_port,
+                             self.m_data_mutex,
+                             self.m_requirements)
 
     def init_creator(self, image_in_port):
         """
@@ -400,11 +398,9 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
             PCA task creator.
         """
 
-        creator = PcaTaskCreator(self.m_tasks_queue,
-                                 self.m_num_processors,
-                                 self.m_pca_numbers)
-
-        return creator
+        return PcaTaskCreator(self.m_tasks_queue,
+                              self.m_num_processors,
+                              self.m_pca_numbers)
 
     def create_processors(self):
         """

--- a/pynpoint/util/multipca.py
+++ b/pynpoint/util/multipca.py
@@ -25,7 +25,7 @@ class PcaTaskCreator(TaskCreator):
 
     def __init__(self,
                  tasks_queue_in,
-                 number_of_processors,
+                 num_proc,
                  pca_numbers):
         """
         Constructor of PcaTaskCreator.
@@ -34,7 +34,7 @@ class PcaTaskCreator(TaskCreator):
         ----------
         tasks_queue_in : multiprocessing.queues.JoinableQueue
             Input task queue.
-        number_of_processors : int
+        num_proc : int
             Number of processors.
         pca_numbers : numpy.ndarray
             Principal components for which the residuals are computed.
@@ -45,7 +45,7 @@ class PcaTaskCreator(TaskCreator):
             None
         """
 
-        super(PcaTaskCreator, self).__init__(None, tasks_queue_in, None, number_of_processors)
+        super(PcaTaskCreator, self).__init__(None, tasks_queue_in, None, num_proc)
 
         self.m_pca_numbers = pca_numbers
 
@@ -290,7 +290,7 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
                  median_out_port,
                  weighted_out_port,
                  clip_out_port,
-                 num_processors,
+                 num_proc,
                  pca_numbers,
                  pca_model,
                  star_reshape,
@@ -310,7 +310,7 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
             Output port for the noise-weighted residuals.
         clip_out_port : pynpoint.core.dataio.OutputPort
             Output port for the mean clipped residuals.
-        num_processors : int
+        num_proc : int
             Number of processors.
         pca_numbers : numpy.ndarray
             Number of principal components.
@@ -358,7 +358,7 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
 
         self.m_requirements = tuple(self.m_requirements)
 
-        super(PcaMultiprocessingCapsule, self).__init__(None, None, num_processors)
+        super(PcaMultiprocessingCapsule, self).__init__(None, None, num_proc)
 
     def create_writer(self, image_out_port):
         """
@@ -399,7 +399,7 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
         """
 
         return PcaTaskCreator(self.m_tasks_queue,
-                              self.m_num_processors,
+                              self.m_num_proc,
                               self.m_pca_numbers)
 
     def create_processors(self):
@@ -414,7 +414,7 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
 
         processors = []
 
-        for _ in range(self.m_num_processors):
+        for _ in range(self.m_num_proc):
             processors.append(PcaTaskProcessor(self.m_tasks_queue,
                                                self.m_result_queue,
                                                self.m_star_reshape,

--- a/pynpoint/util/multiproc.py
+++ b/pynpoint/util/multiproc.py
@@ -78,7 +78,7 @@ class TaskCreator(six.with_metaclass(ABCMeta, multiprocessing.Process)):
                  data_port_in,
                  tasks_queue_in,
                  data_mutex_in,
-                 number_of_processors):
+                 num_proc):
         """
         Parameters
         ----------
@@ -89,7 +89,7 @@ class TaskCreator(six.with_metaclass(ABCMeta, multiprocessing.Process)):
         data_mutex_in : multiprocessing.synchronize.Lock
             A mutex shared with the writer to ensure that no read and write operations happen at
             the same time.
-        number_of_processors : int
+        num_proc : int
             Maximum number of instances of :class:`~pynpoint.util.multiproc.TaskProcessor` that run
             simultaneously.
 
@@ -104,7 +104,7 @@ class TaskCreator(six.with_metaclass(ABCMeta, multiprocessing.Process)):
         self.m_data_mutex = data_mutex_in
         self.m_task_queue = tasks_queue_in
 
-        self.m_number_of_processors = number_of_processors
+        self.m_num_proc = num_proc
         self.m_data_in_port = data_port_in
 
     def create_poison_pills(self):
@@ -120,7 +120,7 @@ class TaskCreator(six.with_metaclass(ABCMeta, multiprocessing.Process)):
             None
         """
 
-        for _ in six.moves.range(self.m_number_of_processors-1):
+        for _ in six.moves.range(self.m_num_proc-1):
             # poison pills
             self.m_task_queue.put(1)
 
@@ -358,7 +358,7 @@ class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
     def __init__(self,
                  image_in_port,
                  image_out_port,
-                 num_processors):
+                 num_proc):
         """
         Parameters
         ----------
@@ -366,7 +366,7 @@ class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
             Port to the input data.
         image_in_port : pynpoint.core.dataio.OutputPort
             Port to the place where the output data will be stored.
-        num_processors : int
+        num_proc : int
             Number of task processors.
 
         Returns
@@ -376,9 +376,9 @@ class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
         """
 
         # buffer twice the data as processes are available
-        self.m_tasks_queue = multiprocessing.JoinableQueue(maxsize=num_processors)
-        self.m_result_queue = multiprocessing.JoinableQueue(maxsize=num_processors)
-        self.m_num_processors = num_processors
+        self.m_tasks_queue = multiprocessing.JoinableQueue(maxsize=num_proc)
+        self.m_result_queue = multiprocessing.JoinableQueue(maxsize=num_proc)
+        self.m_num_proc = num_proc
 
         # database mutex
         self.m_data_mutex = multiprocessing.Lock()
@@ -448,7 +448,7 @@ class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
     def run(self):
         """
         Run method that starts the :class:`~pynpoint.util.multiproc.TaskCreator`, the instances
-        of :class:`~pynpoint.util.multiproc.TaskProcessor`, and the TaskWriter and the
+        of :class:`~pynpoint.util.multiproc.TaskProcessor`, and the
         :class:`~pynpoint.util.multiproc.TaskWriter`. They will be shut down when all tasks have
         finished.
 
@@ -514,7 +514,7 @@ def to_slice(tuple_slice):
     Parameters
     ----------
     tuple_slice : tuple
-        Tuple to be converted to a slice.
+        Tuple to be converted into a slice.
 
     Returns
     -------

--- a/pynpoint/util/multiproc.py
+++ b/pynpoint/util/multiproc.py
@@ -1,7 +1,5 @@
 """
-Utilities for poison pill multiprocessing. Provides abstract interfaces as well as an
-implementation needed to process lines in time as used in the
-:class:`~pynpoint.processing.timedenoising.WaveletTimeDenoisingModule`
+Abstract interfaces for multiprocessing applications with the poison pill pattern.
 """
 
 import multiprocessing
@@ -12,51 +10,19 @@ import six
 import numpy as np
 
 
-# ----- General Multiprocessing classes using the poison pill pattern ------
-
-class TaskResult(object):
-    """
-    Result object which can be stored by the TaskWriter.
-    """
-
-    def __init__(self,
-                 data_array,
-                 position):
-        """
-        Constructor of TaskResult.
-
-        Parameters
-        ----------
-        data_array : numpy.ndarray
-            Some kind of 1/2/3D data which is the result for a given position.
-        position : tuple
-             The position where the result data will be stored
-
-        Returns
-        -------
-        NoneType
-            None
-        """
-
-        self.m_data_array = data_array
-        self.m_position = position
-
-
 class TaskInput(object):
     """
-    Data and parameter capsule for tasks to be processed by the TaskProcessor.
+    Class for tasks that are processed by the :class:`~pynpoint.util.multiproc.TaskProcessor`.
     """
 
     def __init__(self,
                  input_data,
                  job_parameter):
         """
-        Constructor of TaskInput.
-
         Parameters
         ----------
-        input_data : int, float, or numpy.ndarray
-            Data needed by the TaskProcessors.
+        input_data : int, float, numpy.ndarray
+            Input data for by the :class:`~pynpoint.util.multiproc.TaskProcessor`.
         job_parameter : tuple
             Additional data or parameters.
 
@@ -70,13 +36,42 @@ class TaskInput(object):
         self.m_job_parameter = job_parameter
 
 
+class TaskResult(object):
+    """
+    Class for results that can be stored by the :class:`~pynpoint.util.multiproc.TaskWriter`.
+    """
+
+    def __init__(self,
+                 data_array,
+                 position):
+        """
+        Parameters
+        ----------
+        data_array : numpy.ndarray
+            Array with the results for a given position.
+        position : tuple(tuple(int, int, int), tuple(int, int, int), tuple(int, int, int))
+             The position where the results will be stored.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        self.m_data_array = data_array
+        self.m_position = position
+
+
 class TaskCreator(six.with_metaclass(ABCMeta, multiprocessing.Process)):
     """
-    Abstract Interface for all TaskCreator classes. A TaskCreator is supposed to create instances
-    of TaskInput which can be processed by a TaskProcessor and appends them to a central task
-    queue. In general there is only one TaskCreator running for a poison pill multiprocessing
-    application. A TaskCreator needs to communicate to the writer in order to avoid simultaneously
-    access to the central database.
+    Abstract interface for :class:`~pynpoint.util.multiproc.TaskCreator` classes. A
+    :class:`~pynpoint.util.multiproc.TaskCreator` creates instances of
+    :class:`~pynpoint.util.multiproc.TaskInput`, which will be processed by the
+    :class:`~pynpoint.util.multiproc.TaskProcessor`, and appends them to the central task
+    queue. In general there is only one :class:`~pynpoint.util.multiproc.TaskCreator` running
+    for a poison pill multiprocessing application. A :class:`~pynpoint.util.multiproc.TaskCreator`
+    communicates with to the :class:`~pynpoint.util.multiproc.TaskWriter` in order to avoid
+    simultaneously access to the central database.
     """
 
     def __init__(self,
@@ -85,8 +80,6 @@ class TaskCreator(six.with_metaclass(ABCMeta, multiprocessing.Process)):
                  data_mutex_in,
                  number_of_processors):
         """
-        Constructor of TaskCreator. Can only be called by using super from children classes.
-
         Parameters
         ----------
         data_port_in : pynpoint.core.dataio.InputPort
@@ -97,7 +90,8 @@ class TaskCreator(six.with_metaclass(ABCMeta, multiprocessing.Process)):
             A mutex shared with the writer to ensure that no read and write operations happen at
             the same time.
         number_of_processors : int
-            Maximum number of TaskProcessors running at the same time.
+            Maximum number of instances of :class:`~pynpoint.util.multiproc.TaskProcessor` that run
+            simultaneously.
 
         Returns
         -------
@@ -113,22 +107,12 @@ class TaskCreator(six.with_metaclass(ABCMeta, multiprocessing.Process)):
         self.m_number_of_processors = number_of_processors
         self.m_data_in_port = data_port_in
 
-    @abstractmethod
-    def run(self):
-        """
-        Creates objects of TaskInput until all tasks are in the task queue
-
-        Returns
-        -------
-        NoneType
-            None
-        """
-
     def create_poison_pills(self):
         """
-        Function which creates the poison pills for TaskProcessor and TaskWriter. If a process
-        gets a poison pill as the new task it will shut down. Run the method at the end of the
-        run method.
+        Creates poison pills for the :class:`~pynpoint.util.multiproc.TaskProcessor` and
+        :class:`~pynpoint.util.multiproc.TaskWriter`. A process will shut down if it receives a
+        poison pill as a new task. This method should be executed at the end of the
+        :func:`~pynpoint.util.multiproc.TaskCreator.run` method.
 
         Returns
         -------
@@ -143,28 +127,39 @@ class TaskCreator(six.with_metaclass(ABCMeta, multiprocessing.Process)):
         # final poison pill
         self.m_task_queue.put(None)
 
+    @abstractmethod
+    def run(self):
+        """
+        Creates objects of the :class:`~pynpoint.util.multiproc.TaskInput` until all tasks are
+        placed in the task queue.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
 
 class TaskProcessor(six.with_metaclass(ABCMeta, multiprocessing.Process)):
     """
-    Abstract interface for a TaskProcessor. There are up to CPU count instances of TaskProcessor
-    running at the same time in a poison pill multiprocessing application. There is no guarantee
-    which process finishes first. A TaskProcessor takes tasks from a task-queue performs an
-    analysis and stores the result back into a result-queue. If the next task is a poison pill it
-    is should down.
+    Abstract interface for :class:`~pynpoint.util.multiproc.TaskProcessor` classes. The number of
+    instances of :class:`~pynpoint.util.multiproc.TaskProcessor` that run simultaneously in a
+    poison pill multiprocessing application can be set with `CPU` parameter in the central
+    configuration file. A :class:`~pynpoint.util.multiproc.TaskProcessor` takes tasks from a task
+    queue, processes the task, and stores the results back into a result queue. The process will
+    shut down if the next task is a poison pill. The order in which process finish is not fixed.
     """
 
     def __init__(self,
                  tasks_queue_in,
                  result_queue_in):
         """
-        Abstract constructor of TaskProcessor.
-
         Parameters
         ----------
         tasks_queue_in : multiprocessing.queues.JoinableQueue
-            The input task queue (contains TaskInput instances).
+            The input task queue with instances of :class:`~pynpoint.util.multiproc.TaskInput`.
         result_queue_in : multiprocessing.queues.JoinableQueue
-            The result task queue (contains TaskResult instances).
+            The result task queue with instances of :class:`~pynpoint.util.multiproc.TaskResult`.
 
         Returns
         -------
@@ -180,39 +175,43 @@ class TaskProcessor(six.with_metaclass(ABCMeta, multiprocessing.Process)):
     def check_poison_pill(self,
                           next_task):
         """
-        Run this function to check if the next task is a poison pill. The shut down of the process
-        needs to be done in its run method.
+        Function to check if the next task is a poison pill.
 
         Parameters
         ----------
-        next_task : pynpoint.util.multiproc.TaskInput
+        next_task : int, None, pynpoint.util.multiproc.TaskInput
             The next task.
 
         Returns
         -------
         bool
-            True if the next task is a poison pill, else False.
+            True if the next task is a poison pill, False otherwise.
         """
 
         if next_task == 1:
-            # Poison pill means shutdown
-            # print '%s: Exiting' % self.name
-            self.m_task_queue.task_done()
-            return True
+            # poison pill
+            poison_pill = True
 
-        if next_task is None:
-            # got final Poison pill
-            self.m_result_queue.put(None)  # shut down writer process
-            # print '%s: Exiting' % self.name
             self.m_task_queue.task_done()
-            return True
 
-        return False
+        elif next_task is None:
+            # final poison pill
+            poison_pill = True
+
+            # shut down writer process
+            self.m_result_queue.put(None)
+            self.m_task_queue.task_done()
+
+        else:
+            # no poison pill
+            poison_pill = False
+
+        return poison_pill
 
     def run(self):
         """
-        The run method is called to start a TaskProcessor. The process will continue to process
-        tasks from the input task queue until it gets a poison pill.
+        Run method to start the :class:`~pynpoint.util.multiproc.TaskProcessor`. The run method
+        will continue to process tasks from the input task queue until it receives a poison pill.
 
         Returns
         -------
@@ -220,7 +219,6 @@ class TaskProcessor(six.with_metaclass(ABCMeta, multiprocessing.Process)):
             None
         """
 
-        # Process till we get a poison pill
         while True:
             next_task = self.m_task_queue.get()
 
@@ -236,8 +234,9 @@ class TaskProcessor(six.with_metaclass(ABCMeta, multiprocessing.Process)):
     def run_job(self,
                 tmp_task):
         """
-        Abstract interface for the run_job method which is called from run() for each task
-        individually.
+        Abstract interface for the :func:`~pynpoint.util.multiproc.TaskProcessor.run_job` method
+        which is called from the :func:`~pynpoint.util.multiproc.TaskProcessor.run` method for each
+        task individually.
 
         Parameters
         ----------
@@ -250,11 +249,14 @@ class TaskProcessor(six.with_metaclass(ABCMeta, multiprocessing.Process)):
             None
         """
 
+
 class TaskWriter(multiprocessing.Process):
     """
-    The TaskWriter takes results from the result queue computed by a TaskProcessor and stores
-    them into the central database. It uses the position parameter of the TaskResult objects in
-    order to slice the result to the correct location in global output.
+    The :class:`~pynpoint.util.multiproc.TaskWriter` receives results from the result queue, which
+    have been computed by a :class:`~pynpoint.util.multiproc.TaskProcessor`, and stores the results
+    in the central database. The position parameter of the
+    :class:`~pynpoint.util.multiproc.TaskResult` is used to slice the result to the correct
+    position in the complete output dataset.
     """
 
     def __init__(self,
@@ -267,10 +269,10 @@ class TaskWriter(multiprocessing.Process):
         result_queue_in : multiprocessing.queues.JoinableQueue
             The result queue.
         data_out_port_in : pynpoint.core.dataio.OutputPort
-            The output port where the results are stored.
+            The output port where the results will be stored.
         data_mutex_in : multiprocessing.synchronize.Lock
-            A mutex shared with the writer to ensure that no read and write operations happen at
-            the same time.
+            A mutex that is shared with the :class:`~pynpoint.util.multiproc.TaskWriter` which
+            ensures that read and write operations to the database do not occur simultaneously.
 
         Returns
         -------
@@ -287,11 +289,11 @@ class TaskWriter(multiprocessing.Process):
     def check_poison_pill(self,
                           next_result):
         """
-        Checks if the next result is a poison pill.
+        Function to check if the next result is a poison pill.
 
         Parameters
         ----------
-        next_result : pynpoint.util.multiproc.TaskResult
+        next_result : None, pynpoint.util.multiproc.TaskResult
             The next result.
 
         Returns
@@ -302,24 +304,29 @@ class TaskWriter(multiprocessing.Process):
         """
 
         if next_result is None:
-            # check if no results are after the poison pill
+            # check if there are results after the poison pill
             if self.m_result_queue.empty():
-                # print "Shutting down writer..."
+                poison_pill = 1
+
+                # shut down the writer
                 self.m_result_queue.task_done()
-                return 1
 
-            # put pack the Poison pill for the moment
-            # print "put back poison pill"
-            self.m_result_queue.put(None)
-            self.m_result_queue.task_done()
-            return 2
+            else:
+                poison_pill = 2
 
-        return 0
+                # put back the poison pill for the moment
+                self.m_result_queue.put(None)
+                self.m_result_queue.task_done()
+
+        else:
+            poison_pill = 0
+
+        return poison_pill
 
     def run(self):
         """
-        The run method of the writer process is called once and will start him to store results
-        until it gets a poison pill.
+        Run method of the :class:`~pynpoint.util.multiproc.TaskWriter`. It is called once when
+        it has to start storing the results until it receives a poison pill.
 
         Returns
         -------
@@ -329,11 +336,11 @@ class TaskWriter(multiprocessing.Process):
 
         while True:
             next_result = self.m_result_queue.get()
-
-            # Poison Pill
             poison_pill_case = self.check_poison_pill(next_result)
+
             if poison_pill_case == 1:
                 break
+
             if poison_pill_case == 2:
                 continue
 
@@ -343,11 +350,9 @@ class TaskWriter(multiprocessing.Process):
             self.m_result_queue.task_done()
 
 
-# ------ Multiprocessing Capsule -------
 class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
     """
-    Abstract interface for multiprocessing capsules based on the poison pill patter. It consists
-    of a TaskCreator, a result writer as well as a list of Task Processors.
+    Abstract interface for multiprocessing capsules based on the poison pill pattern.
     """
 
     def __init__(self,
@@ -355,16 +360,14 @@ class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
                  image_out_port,
                  num_processors):
         """
-        Constructor can only be called from children classes by using super.
-
         Parameters
         ----------
         image_in_port : pynpoint.core.dataio.InputPort
             Port to the input data.
         image_in_port : pynpoint.core.dataio.OutputPort
-            Port to the place where the output will be stored.
+            Port to the place where the output data will be stored.
         num_processors : int
-            Maximum number of task processors
+            Number of task processors.
 
         Returns
         -------
@@ -377,43 +380,23 @@ class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
         self.m_result_queue = multiprocessing.JoinableQueue(maxsize=num_processors)
         self.m_num_processors = num_processors
 
-        # data base mutex
+        # database mutex
         self.m_data_mutex = multiprocessing.Lock()
 
         # create reader
         self.m_creator = self.init_creator(image_in_port)
 
-        # Start consumers
+        # create processors
         self.m_task_processors = self.create_processors()
 
         # create writer
         self.m_writer = self.create_writer(image_out_port)
 
-    def create_writer(self,
-                      image_out_port):
-        """
-        Called from the constructor to create the writer object.
-
-        Parameters
-        ----------
-        image_out_port : pynpoint.core.dataio.OutputPort
-            Output port for the creator.
-
-        Returns
-        -------
-        pynpoint.util.multiproc.TaskWriter
-            Task writer.
-        """
-
-
-        return TaskWriter(self.m_result_queue,
-                          image_out_port,
-                          self.m_data_mutex)
-
     @abstractmethod
     def create_processors(self):
         """
-        Called from the constructor to create a list of a TaskProcessor.
+        Function that is called from the constructor to create a list of instances of
+        :class:`~pynpoint.util.multiproc.TaskProcessor`.
 
         Returns
         -------
@@ -427,7 +410,8 @@ class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
     def init_creator(self,
                      image_in_port):
         """
-        Called from the constructor to create a creator object.
+        Function that is called from the constructor to create a
+        :class:`~pynpoint.util.multiproc.TaskCreator`.
 
         Parameters
         ----------
@@ -440,10 +424,33 @@ class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
             None
         """
 
+    def create_writer(self,
+                      image_out_port):
+        """
+        Function that is called from the constructor to create the
+        :class:`~pynpoint.util.multiproc.TaskWriter`.
+
+        Parameters
+        ----------
+        image_out_port : pynpoint.core.dataio.OutputPort
+            Output port for the creator.
+
+        Returns
+        -------
+        pynpoint.util.multiproc.TaskWriter
+            Task writer.
+        """
+
+        return TaskWriter(self.m_result_queue,
+                          image_out_port,
+                          self.m_data_mutex)
+
     def run(self):
         """
-        The run method starts the Creator, all Task Processors and the Writer Process. Finally it
-        will shut down them again after all tasks are done.
+        Run method that starts the :class:`~pynpoint.util.multiproc.TaskCreator`, the instances
+        of :class:`~pynpoint.util.multiproc.TaskProcessor`, and the TaskWriter and the
+        :class:`~pynpoint.util.multiproc.TaskWriter`. They will be shut down when all tasks have
+        finished.
 
         Returns
         -------
@@ -459,11 +466,11 @@ class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
 
         self.m_writer.start()
 
-        # Wait for all of the tasks to finish
+        # wait for all tasks to have finished
         self.m_tasks_queue.join()
         self.m_result_queue.join()
 
-        # Clean up Processes
+        # clean up the processes
         for processor in self.m_task_processors:
             processor.join()
 
@@ -471,12 +478,11 @@ class MultiprocessingCapsule(six.with_metaclass(ABCMeta, object)):
         self.m_creator.join()
 
 
-# ----- Handler to apply a function ------
 def apply_function(tmp_data,
                    func,
                    func_args):
     """
-    Applies the function func with its arguments func_args to the tmp_data
+    Apply a function with optional arguments to the input data.
 
     Parameters
     ----------
@@ -484,7 +490,7 @@ def apply_function(tmp_data,
         Input data.
     func : function
         Function.
-    func_args :
+    func_args : tuple or None
         Function arguments.
 
     Returns
@@ -493,17 +499,17 @@ def apply_function(tmp_data,
         The results of the function.
     """
 
-    # process line
-    # check if additional arguments are given
     if func_args is None:
-        return np.array(func(tmp_data))
+        result = np.array(func(tmp_data))
+    else:
+        result = np.array(func(tmp_data, *func_args))
 
-    return np.array(func(tmp_data, *func_args))
+    return result
 
 
 def to_slice(tuple_slice):
     """
-    This function is needed to pickle slices as reburied for multiprocessing queues.
+    Function to convert tuples into slices for a multiprocessing queue.
 
     Parameters
     ----------
@@ -519,210 +525,3 @@ def to_slice(tuple_slice):
     return (slice(tuple_slice[0][0], tuple_slice[0][1], tuple_slice[0][2]),
             slice(tuple_slice[1][0], tuple_slice[1][1], tuple_slice[1][2]),
             slice(tuple_slice[2][0], tuple_slice[2][1], tuple_slice[2][2]))
-
-
-# ----- Multiprocessing on lines ------
-class LineTaskProcessor(TaskProcessor):
-    """
-    Line Task Processors are part of the parallel line processing. They take a row of lines in time
-    and apply a function to them.
-    """
-
-    def __init__(self,
-                 tasks_queue_in,
-                 result_queue_in,
-                 function,
-                 function_args):
-        """
-        Parameters
-        ----------
-        tasks_queue_in : multiprocessing.queues.JoinableQueue
-            Tasks queue.
-        result_queue_in : multiprocessing.queues.JoinableQueue
-            Results queue.
-        function : function
-            Input function.
-        function_args :
-            Function arguments.
-
-        Returns
-        -------
-        NoneType
-            None
-        """
-
-        super(LineTaskProcessor, self).__init__(tasks_queue_in, result_queue_in)
-
-        self.m_function = function
-        self.m_function_args = function_args
-
-    def run_job(self,
-                tmp_task):
-        result_arr = np.zeros((tmp_task.m_job_parameter[0],
-                               tmp_task.m_input_data.shape[1],
-                               tmp_task.m_input_data.shape[2]))
-
-        for i in six.moves.range(tmp_task.m_input_data.shape[1]):
-            for j in six.moves.range(tmp_task.m_input_data.shape[2]):
-                tmp_line = tmp_task.m_input_data[:, i, j]
-
-                result_arr[:, i, j] = apply_function(tmp_line,
-                                                     self.m_function,
-                                                     self.m_function_args)
-
-        result = TaskResult(result_arr, tmp_task.m_job_parameter[1])
-
-        return result
-
-
-class LineReader(TaskCreator):
-    """
-    Line Reader are part of the parallel line processing. They continuously read all rows of a data
-    set and puts them into a task queue.
-    """
-
-    def __init__(self,
-                 data_port_in,
-                 tasks_queue_in,
-                 data_mutex_in,
-                 number_of_processors,
-                 data_length):
-        """
-        Parameters
-        ----------
-        data_port_in : pynpoint.core.dataio.InputPort
-            Input port.
-        tasks_queue_in : multiprocessing.queues.JoinableQueue
-            Tasks queue.
-        data_mutex_in : multiprocessing.synchronize.Lock
-            A mutex shared with the writer to ensure that no read and write operations happen at
-            the same time.
-        number_of_processors : int
-            Number of processors.
-        data_length : int
-            Length of the processed data.
-
-        Returns
-        -------
-        NoneType
-            None
-        """
-
-        super(LineReader, self).__init__(data_port_in,
-                                         tasks_queue_in,
-                                         data_mutex_in,
-                                         number_of_processors)
-
-        self.m_data_length = data_length
-
-    def run(self):
-        """
-        Returns
-        -------
-        NoneType
-            None
-        """
-
-        total_number_of_rows = self.m_data_in_port.get_shape()[1]
-        row_length = int(np.ceil(self.m_data_in_port.get_shape()[1] /
-                                 float(self.m_number_of_processors)))
-
-        i = 0
-        while i < total_number_of_rows:
-            # read rows from i to j
-            j = min((i + row_length), total_number_of_rows)
-
-            # lock Mutex and read data
-            with self.m_data_mutex:
-                # print "Reading lines from " + str(i) + " to " + str(j)
-                tmp_data = self.m_data_in_port[:, i:j, :]
-
-            self.m_task_queue.put(TaskInput(tmp_data,
-                                            (self.m_data_length,
-                                             ((None, None, None),
-                                              (i, j, None),
-                                              (None, None, None)))))
-            i = j
-
-        self.create_poison_pills()
-
-
-class LineProcessingCapsule(MultiprocessingCapsule):
-    """
-    The central processing class for parallel line processing. Use this class to apply a function
-    in time in parallel.
-    """
-
-    def __init__(self,
-                 image_in_port,
-                 image_out_port,
-                 num_processors,
-                 function,
-                 function_args,
-                 data_length):
-        """
-        Parameters
-        ----------
-        image_in_port : pynpoint.core.dataio.InputPort
-            Input port.
-        image_out_port : pynpoint.core.dataio.OutputPort
-            Output port.
-        num_processors : int
-            Number of processors.
-        function : function
-            Input function.
-        function_args :
-            Function arguments.
-        data_length : int
-            Length of the processed data.
-
-        Returns
-        -------
-        NoneType
-            None
-        """
-
-        self.m_function = function
-        self.m_function_args = function_args
-        self.m_data_length = data_length
-
-        super(LineProcessingCapsule, self).__init__(image_in_port, image_out_port, num_processors)
-
-    def create_processors(self):
-        """
-        Returns
-        -------
-        list(pynpoint.util.multiproc.LineTaskProcessor, )
-            List with line task processors.
-        """
-
-        tmp_processors = []
-
-        for _ in six.moves.range(self.m_num_processors):
-
-            tmp_processors.append(LineTaskProcessor(tasks_queue_in=self.m_tasks_queue,
-                                                    result_queue_in=self.m_result_queue,
-                                                    function=self.m_function,
-                                                    function_args=self.m_function_args))
-
-        return tmp_processors
-
-    def init_creator(self,
-                     image_in_port):
-        """
-        Parameters
-        ----------
-        image_in_port : pynpoint.core.dataio.InputPort
-            Input port
-
-        Returns
-        -------
-        NoneType
-            None
-        """
-
-        return LineReader(image_in_port,
-                          self.m_tasks_queue,
-                          self.m_data_mutex,
-                          self.m_num_processors,
-                          self.m_data_length)


### PR DESCRIPTION
- Moved the multiprocessing of lines utilities from `util.multiproc` to `util.multilines`.

- Improved the documentation of `util.multiproc`.