### PR TITLE
Use unbiased std estimate for SNR calculation

### DIFF
--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -80,7 +80,9 @@ def false_alarm(image,
         phot_table = aperture_photometry(image, aperture, method='exact')
         ap_phot[i] = phot_table['aperture_sum']
 
-    noise = np.std(ap_phot[1:]) * math.sqrt(1.+1./float(num_ap-1))
+    # Note: ddof=1 is a necessary argument in order to compute the *unbiased* estimate of the
+    # standard deviation, as suggested by eq. 8 of Mawet et al. (2014).
+    noise = np.std(ap_phot[1:], ddof=1) * math.sqrt(1.+1./float(num_ap-1))
     t_test = (ap_phot[0] - np.mean(ap_phot[1:])) / noise
 
     # Note that the number of degrees of freedom is given by nu = n-1 with n the number of samples.

--- a/tests/test_processing/test_fluxposition.py
+++ b/tests/test_processing/test_fluxposition.py
@@ -180,8 +180,8 @@ class TestFluxAndPosition(object):
         assert np.allclose(data[0, 1], 49.0, rtol=limit, atol=0.)
         assert np.allclose(data[0, 2], 0.513710034941892, rtol=limit, atol=0.)
         assert np.allclose(data[0, 3], 93.01278750418334, rtol=limit, atol=0.)
-        assert np.allclose(data[0, 4], 7.633199090133858, rtol=limit, atol=0.)
-        assert np.allclose(data[0, 5], 3.029521252528866e-06, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 4], 7.333740467578795, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 5], 4.5257622875993775e-06, rtol=limit, atol=0.)
 
     def test_simplex_minimization(self):
 

--- a/tests/test_processing/test_limits.py
+++ b/tests/test_processing/test_limits.py
@@ -85,7 +85,7 @@ class TestDetectionLimits(object):
 
             data = self.pipeline.get_data("limits_"+item)
             assert np.allclose(data[0, 0], 5.00000000e-01, rtol=limit, atol=0.)
-            assert np.allclose(data[0, 1], 2.3624384190310397, rtol=limit, atol=0.)
-            assert np.allclose(data[0, 2], 0.05234065236317515, rtol=limit, atol=0.)
+            assert np.allclose(data[0, 1], 1.2034060712266164, rtol=limit, atol=0.)
+            assert np.allclose(data[0, 2], 0.2594381985736874, rtol=limit, atol=0.)
             assert np.allclose(data[0, 3], 0.00012147700290954244, rtol=limit, atol=0.)
             assert data.shape == (1, 4)


### PR DESCRIPTION
Added `ddof=1` argument to `np.std()` in `false_alarm()`, as we had previously discussed. 
See also [here](https://github.com/vortex-exoplanet/VIP/issues/395) for more detailed background information.