### PR TITLE
Check if flux ratio is positive in ContrastCurveModule

### DIFF
--- a/pynpoint/util/limits.py
+++ b/pynpoint/util/limits.py
@@ -150,7 +150,12 @@ def contrast_limit(path_images,
 
     # Calculate the detection limit
     contrast = sigma*t_noise/(attenuation*star)
-    contrast = -2.5*math.log10(contrast)
+
+    # The flux_out can be negative, for example if the aperture includes self-subtraction regions
+    if contrast > 0.:
+        contrast = -2.5*math.log10(contrast)
+    else:
+        contrast = np.nan
 
     # Separation [pix], position antle [deg], contrast [mag], FPF
     queue.put((position[0], position[1], contrast, fpf))


### PR DESCRIPTION
Check if the flux ratio in `util.limits.contrast_limit` is positive (which is required for converting to magnitudes). Else, a NaN is stored for that position. See Issue #337.