### PR TITLE
Removed nodding for the NearReadingModule

### DIFF
--- a/pynpoint/readwrite/nearreading.py
+++ b/pynpoint/readwrite/nearreading.py
@@ -34,11 +34,8 @@ class NearReadingModule(ReadingModule):
     def __init__(self,
                  name_in='burst',
                  input_dir=None,
-                 noda_chopa_tag='noda_chopa',
-                 noda_chopb_tag='noda_chopb',
-                 nodb_chopa_tag='nodb_chopa',
-                 nodb_chopb_tag='nodb_chopb',
-                 scheme='ABBA'):
+                 chopa_out_tag='chopa',
+                 chopb_out_tag='chopb'):
         """
         Parameters
         ----------
@@ -47,16 +44,12 @@ class NearReadingModule(ReadingModule):
         input_dir : str, None
             Input directory where the FITS files are located. The default input folder of the
             Pypeline is used if set to None.
-        noda_chopa_tag : str
-            Database entry where chop A from the nod A data will be stored.
-        noda_chopb_tag : str
-            Database entry where chop B from the nod A data will be stored.
-        nodb_chopa_tag : str
-            Database entry where chop A from the nod B data will be stored.
-        nodb_chopb_tag : str
-            Database entry where chop B from the nod B data will be stored.
-        scheme : str
-            Nodding scheme ('ABBA' or 'ABAB').
+        chopa_out_tag : str
+            Database entry where the chop A images will be stored. Should be different from
+            `chop_b_out_tag`.
+        chopb_out_tag : str
+            Database entry where the chop B images will be stored. Should be different from
+            `chop_a_out_tag`.
 
         Returns
         -------
@@ -66,24 +59,8 @@ class NearReadingModule(ReadingModule):
 
         super(NearReadingModule, self).__init__(name_in, input_dir)
 
-        out_tags = (noda_chopa_tag, noda_chopb_tag, nodb_chopa_tag, nodb_chopb_tag)
-
-        # select all unique output tag names
-        seen = set()
-        unique_tags = [tag for tag in out_tags if tag not in seen and not seen.add(tag)]
-
-        if len(unique_tags) != 4:
-            raise ValueError('Output ports should have different name tags.')
-
-        # create the 4 output ports for nod A/B and chop A/B
-        self.m_image_out_port = []
-        for tag in out_tags:
-            self.m_image_out_port.append(self.add_output_port(tag))
-
-        self.m_scheme = scheme
-
-        if self.m_scheme != 'ABBA' and self.m_scheme != 'ABAB':
-            raise ValueError('Nodding scheme argument should be set to \'ABBA\' or \'ABAB\'.')
+        self.m_chopa_out_port = self.add_output_port(chopa_out_tag)
+        self.m_chopb_out_port = self.add_output_port(chopb_out_tag)
 
     def _uncompress_file(self,
                          filename):
@@ -328,46 +305,6 @@ class NearReadingModule(ReadingModule):
 
         return chopa, chopb
 
-    def get_nod(self,
-                header,
-                first_expno):
-        """
-        Function that opens a FITS file and separates the chop A and chop B images. The primary HDU
-        contains only a general header. The subsequent HDUs contain a single image with a small
-        extra header. The last HDU is the average of all images, which will be ignored.
-
-        Parameters
-        ----------
-        astropy.io.fits.header.Header
-            Primary header, which is valid for all images.
-        first_expno : int
-            First exposure number. Should be the first position of the nodding scheme.
-
-        Returns
-        -------
-        str
-            Nod position ('A' or 'B').
-        """
-
-        # get the exposure number
-        expno = header['ESO TPL EXPNO']
-
-        # determine the nod position (A or B) for the selected nodding scheme
-        # relative to the exposure number of the first FITS file that is read
-        if self.m_scheme == 'ABBA':
-            if (expno-first_expno)%4 == 0 or (expno-first_expno)%4 == 3:
-                nod = 'A'
-            elif (expno-first_expno)%4 == 1 or (expno-first_expno)%4 == 2:
-                nod = 'B'
-
-        elif self.m_scheme == 'ABAB':
-            if (expno-first_expno)%2 == 0:
-                nod = 'A'
-            elif (expno-first_expno)%2 == 1:
-                nod = 'B'
-
-        return nod
-
     def run(self):
         """
         Run the module. The FITS files are collected from the input directory and uncompressed if
@@ -386,9 +323,10 @@ class NearReadingModule(ReadingModule):
         """
 
         # clear the output ports
-        for port in self.m_image_out_port:
-            port.del_all_data()
-            port.del_all_attributes()
+        self.m_chopa_out_port.del_all_data()
+        self.m_chopa_out_port.del_all_attributes()
+        self.m_chopb_out_port.del_all_data()
+        self.m_chopb_out_port.del_all_attributes()
 
         # uncompress the FITS files if needed
         self.uncompress()
@@ -405,10 +343,6 @@ class NearReadingModule(ReadingModule):
         # check if there are FITS files present in the input location
         assert(files), 'No FITS files found in {}.'.format(self.m_input_location)
 
-        # get the first exposure number, which should be the first position of the nodding scheme
-        header = fits.getheader(files[0], ext=0)
-        first_expno = header['ESO TPL EXPNO']
-        
         start_time = time.time()
         for i, filename in enumerate(files):
             progress(i, len(files), 'Running NearReadingModule...', start_time)
@@ -417,22 +351,15 @@ class NearReadingModule(ReadingModule):
             # and the number of images per chop position
             header, im_shape = self.read_header(filename)
             chopa, chopb = self.read_images(filename, im_shape)
-            nod = self.get_nod(header, first_expno)
-
-            # select the output ports for nod A or B
-            if nod == 'A':
-                out_ports = self.m_image_out_port[0:2]
-            elif nod == 'B':
-                out_ports = self.m_image_out_port[2:4]
 
             # append the images of chop A and B
-            out_ports[0].append(chopa, data_dim=3)
-            out_ports[1].append(chopb, data_dim=3)
+            self.m_chopa_out_port.append(chopa, data_dim=3)
+            self.m_chopb_out_port.append(chopb, data_dim=3)
 
             # starting value for the INDEX attribute
             first_index = 0
 
-            for port in out_ports:
+            for port in (self.m_chopa_out_port, self.m_chopb_out_port):
 
                 # set the static attributes
                 set_static_attr(fits_file=filename,
@@ -464,10 +391,8 @@ class NearReadingModule(ReadingModule):
         sys.stdout.flush()
 
         # add history information
-        self.m_image_out_port[0].add_history('NearReadingModule', 'Nod A, Chop A')
-        self.m_image_out_port[1].add_history('NearReadingModule', 'Nod A, Chop B')
-        self.m_image_out_port[2].add_history('NearReadingModule', 'Nod B, Chop A')
-        self.m_image_out_port[3].add_history('NearReadingModule', 'Nod B, Chop B')
+        self.m_chopa_out_port.add_history('NearReadingModule', 'Chop A')
+        self.m_chopb_out_port.add_history('NearReadingModule', 'Chop B')
 
         # close all connections to the database
-        self.m_image_out_port[0].close_port()
+        self.m_chopa_out_port.close_port()

--- a/tests/test_readwrite/test_nearreading.py
+++ b/tests/test_readwrite/test_nearreading.py
@@ -33,7 +33,7 @@ class TestNearInitModule(object):
         self.pipeline.set_attribute('config', 'PIXSCALE', 0.045, static=True)
         self.pipeline.set_attribute('config', 'MEMORY', 100, static=True)
 
-        self.positions = ('noda_chopa', 'noda_chopb', 'nodb_chopa', 'nodb_chopb')
+        self.positions = ('chopa', 'chopb')
 
     def teardown_class(self):
 
@@ -43,11 +43,8 @@ class TestNearInitModule(object):
 
         module = NearReadingModule(name_in='read1',
                                    input_dir=self.test_dir+'near',
-                                   noda_chopa_tag=self.positions[0],
-                                   noda_chopb_tag=self.positions[1],
-                                   nodb_chopa_tag=self.positions[2],
-                                   nodb_chopb_tag=self.positions[3],
-                                   scheme='ABBA')
+                                   chopa_out_tag=self.positions[0],
+                                   chopb_out_tag=self.positions[1])
 
         self.pipeline.add_module(module)
         self.pipeline.run_module('read1')
@@ -56,52 +53,7 @@ class TestNearInitModule(object):
 
             data = self.pipeline.get_data(item)
             assert np.allclose(np.mean(data), 0.060582854, rtol=limit, atol=0.)
-            assert data.shape == (10, 10, 10)
-
-    def test_near_read_scheme(self):
-
-        module = NearReadingModule(name_in='read2',
-                                   input_dir=self.test_dir+'near',
-                                   noda_chopa_tag=self.positions[0],
-                                   noda_chopb_tag=self.positions[1],
-                                   nodb_chopa_tag=self.positions[2],
-                                   nodb_chopb_tag=self.positions[3],
-                                   scheme='ABAB')
-
-        self.pipeline.add_module(module)
-        self.pipeline.run_module('read2')
-
-        for item in self.positions:
-
-            data = self.pipeline.get_data(item)
-            assert np.allclose(np.mean(data), 0.060582854, rtol=limit, atol=0.)
-            assert data.shape == (10, 10, 10)
-
-    def test_near_read_tag_check(self):
-
-        with pytest.raises(ValueError) as error:
-            NearReadingModule(name_in='read3',
-                              input_dir=self.test_dir+'near',
-                              noda_chopa_tag=self.positions[0],
-                              noda_chopb_tag=self.positions[0],
-                              nodb_chopa_tag=self.positions[2],
-                              nodb_chopb_tag=self.positions[3],
-                              scheme='ABBA')
-
-        assert str(error.value) == 'Output ports should have different name tags.'
-
-    def test_near_read_scheme_check(self):
-
-        with pytest.raises(ValueError) as error:
-            NearReadingModule(name_in='read4',
-                              input_dir=self.test_dir+'near',
-                              noda_chopa_tag=self.positions[0],
-                              noda_chopb_tag=self.positions[1],
-                              nodb_chopa_tag=self.positions[2],
-                              nodb_chopb_tag=self.positions[3],
-                              scheme='test')
-
-        assert str(error.value) == 'Nodding scheme argument should be set to \'ABBA\' or \'ABAB\'.'
+            assert data.shape == (20, 10, 10)
 
     def test_static_not_found(self):
 
@@ -109,11 +61,8 @@ class TestNearInitModule(object):
 
         module = NearReadingModule(name_in='read5',
                                    input_dir=self.test_dir+'near',
-                                   noda_chopa_tag=self.positions[0],
-                                   noda_chopb_tag=self.positions[1],
-                                   nodb_chopa_tag=self.positions[2],
-                                   nodb_chopb_tag=self.positions[3],
-                                   scheme='ABBA')
+                                   chopa_out_tag=self.positions[0],
+                                   chopb_out_tag=self.positions[1])
 
         self.pipeline.add_module(module)
 
@@ -133,11 +82,8 @@ class TestNearInitModule(object):
 
         module = NearReadingModule(name_in='read6',
                                    input_dir=self.test_dir+'near',
-                                   noda_chopa_tag=self.positions[0],
-                                   noda_chopb_tag=self.positions[1],
-                                   nodb_chopa_tag=self.positions[2],
-                                   nodb_chopb_tag=self.positions[3],
-                                   scheme='ABBA')
+                                   chopa_out_tag=self.positions[0],
+                                   chopb_out_tag=self.positions[1])
 
         self.pipeline.add_module(module)
 


### PR DESCRIPTION
VISIR will only use chopping for the NEAR experiment. The `NearReadingModule` has been adjusted accordingly. The output are simply two datasets (`chopa_out_tag` and `chopb_out_tag`).

The dedicated NEAR page in the documentation still has to be updated.