### PR TITLE
map_out_tag ignored with CPU > 1

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,4 +1,4 @@
-.. _configuration:
+r.. _configuration:
 
 Configuration
 =============
@@ -41,7 +41,7 @@ In this section, several examples are provided of the configuration content for 
 VLT/NACO
 ^^^^^^^^
 
-.. code-block::
+.. code-block:: ini
 
    [header]
 
@@ -72,7 +72,7 @@ VLT/NACO
 VLT/SPHERE
 ^^^^^^^^^^
 
-.. code-block::
+.. code-block:: ini
 
    [header]
 
@@ -103,7 +103,7 @@ VLT/SPHERE
 VLT/VISIR
 ^^^^^^^^^
 
-.. code-block::
+.. code-block:: ini
 
    [header]
 

--- a/docs/near.rst
+++ b/docs/near.rst
@@ -154,26 +154,6 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    pipeline.add_module(module)
 
-..   # Calculate detection limits between 0.8 and 2.5 arcsec
-   # The false positive fraction is fixed to 2.87e-6 (i.e. 5 sigma for Gaussian statistics)
-
-..   module = ContrastCurveModule(name_in='limits',
-                                image_in_tag='chopa_center',
-                                psf_in_tag='psf_crop',
-                                contrast_out_tag='limits',
-                                separation=(0.8, 2.5, 0.1),
-                                angle=(0., 360., 60.),
-                                threshold=('fpf', 2.87e-6),
-                                psf_scaling=1.,
-                                aperture=0.2,
-                                pca_number=10,
-                                cent_size=0.2,
-                                edge_size=3.,
-                                extra_rot=0.,
-                                residuals='median')
-
-..   pipeline.add_module(module)
-
    # Datasets can be exported to FITS files by their tag name in the database
    # Here we will export the median-combined residuals of the PSF subtraction
 
@@ -185,18 +165,6 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
                               overwrite=True)
 
    pipeline.add_module(module)
-
-..   # We also write the detection limits to a text file
-
-..   header = 'Separation [arcsec] - Contrast [mag] - Variance [mag] - FPF'
-
-..   module = TextWritingModule(name_in='write3',
-                              file_name='contrast_curve.dat',
-                              output_dir=None,
-                              data_tag='limits',
-                              header=header)
-
-..   pipeline.add_module(module)
 
    # Finally, to run all pipeline modules at once
 
@@ -214,16 +182,12 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
    pipeline.run_module('pca')
    pipeline.run_module('write')
 
-.. The VISIR datasets contain a large number of images so the PynPoint database will use a large amount of disk storage. Therefore, datasets of intermediate results can be removed from the database (together with the related attributes) by their tag name, for example::
-..
-..    pipeline.delete_data('chopa')
-
 .. _near_results:
 
 Results
 -------
 
-The images that were exported to FITS files can be visualized with a tool such as |ds9|. We can also use the :class:`~pynpoint.core.pypeline.Pypeline` functionalities to get the data from the database (without having to rerun the pipeline). For example, to get the residuals of the PSF subtraction::
+The images that were exported to a FITS file can be visualized with a tool such as |ds9|. We can also use the :class:`~pynpoint.core.pypeline.Pypeline` functionalities to get the data from the database (without having to rerun the pipeline). For example, to get the residuals of the PSF subtraction::
 
    data = pipeline.get_data('chopa_pca')
 
@@ -238,22 +202,6 @@ And to plot the residuals for 10 principal components (Python indexing starts at
    :width: 60%
    :align: center
 
-.. Or to plot the detection limits with the error bars showing the variance of the six azimuthal positions that were tested::
-..
-..    data = pipeline.get_data('limits')
-..
-..    plt.figure(figsize=(7, 4))
-..    plt.errorbar(data[:, 0], data[:, 1], data[:, 2])
-..    plt.xlim(0., 2.5)
-..    plt.ylim(18., 9.)
-..    plt.xlabel('Separation [arcsec]')
-..    plt.ylabel('Contrast [mag]')
-..    plt.show()
-
-.. .. image:: _static/near_limits.png
-..    :width: 70%
-..    :align: center
-
 .. |visir| raw:: html
 
    <a href="https://www.eso.org/sci/facilities/paranal/instruments/visir.html" target="_blank">VLT/VISIR</a>
@@ -265,10 +213,6 @@ And to plot the residuals for 10 principal components (Python indexing starts at
 .. |stolker| raw:: html
 
    <a href="http://adsabs.harvard.edu/abs/2019A%26A...621A..59S" target="_blank">Stolker et al. (2019)</a>
-
-.. |data| raw:: html
-
-   <a href="https://drive.google.com/open?id=1TPSgXjazewwBsBVe-Zu5fstf9X2nlwQX" target="_blank">here</a>
 
 .. |ds9| raw:: html
 

--- a/pynpoint/processing/badpixel.py
+++ b/pynpoint/processing/badpixel.py
@@ -4,6 +4,7 @@ Pipeline modules for the detection and interpolation of bad pixels.
 
 import sys
 import copy
+import warnings
 
 import cv2
 import numpy as np
@@ -52,7 +53,7 @@ def _calc_fast_convolution(F_roof_tmp, W, tmp_s, N_size, tmp_G, N):
 def _bad_pixel_interpolation(image_in,
                              bad_pixel_map,
                              iterations):
-    """"
+    """'
     Internal function to interpolate bad pixels.
 
     Parameters
@@ -137,7 +138,7 @@ def _bad_pixel_interpolation(image_in,
 #                      var_image,
 #                      source_image,
 #                      out_image):
-#     """"
+#     """'
 #     Internal function to create a map with ones and zeros.
 #
 #     Parameters
@@ -191,9 +192,9 @@ class BadPixelSigmaFilterModule(ProcessingModule):
                     bad_pixel_map[i][j] = 0
 
     def __init__(self,
-                 name_in="sigma_filtering",
-                 image_in_tag="im_arr",
-                 image_out_tag="im_arr_bp_clean",
+                 name_in='sigma_filtering',
+                 image_in_tag='im_arr',
+                 image_out_tag='im_arr_bp_clean',
                  map_out_tag=None,
                  box=9,
                  sigma=5,
@@ -207,9 +208,9 @@ class BadPixelSigmaFilterModule(ProcessingModule):
             Tag of the database entry that is read as input.
         image_out_tag : str
             Tag of the database entry that is written as output.
-        map_out_tag : str
+        map_out_tag : str, None
             Tag of the database entry with the bad pixel map that is written as output. No data
-            is written if set to None.
+            is written if set to None. This output port can not be used if CPU > 1.
         box : int
             Size of the sigma filter. The area of the filter is equal to the squared value of
             *box*.
@@ -291,6 +292,15 @@ class BadPixelSigmaFilterModule(ProcessingModule):
 
             return out_image
 
+        cpu = self._m_config_port.get_attribute('CPU')
+
+        if cpu > 1:
+            if self.m_map_out_port is not None:
+                warnings.warn('The map_out_port can only be used if CPU=1. No data will be '
+                              'stored to this output port.')
+
+            self.m_map_out_port = None
+
         if self.m_map_out_port is not None:
             self.m_map_out_port.del_all_data()
             self.m_map_out_port.del_all_attributes()
@@ -298,18 +308,18 @@ class BadPixelSigmaFilterModule(ProcessingModule):
         self.apply_function_to_images(_bad_pixel_sigma_filter,
                                       self.m_image_in_port,
                                       self.m_image_out_port,
-                                      "Running BadPixelSigmaFilterModule",
+                                      'Running BadPixelSigmaFilterModule',
                                       func_args=(self.m_box,
                                                  self.m_sigma,
                                                  self.m_iterate))
 
-        history = f"sigma = {self.m_sigma}"
+        history = f'sigma = {self.m_sigma}'
         self.m_image_out_port.copy_attributes(self.m_image_in_port)
-        self.m_image_out_port.add_history("BadPixelSigmaFilterModule", history)
+        self.m_image_out_port.add_history('BadPixelSigmaFilterModule', history)
 
         if self.m_map_out_port is not None:
             self.m_map_out_port.copy_attributes(self.m_image_in_port)
-            self.m_map_out_port.add_history("BadPixelSigmaFilterModule", history)
+            self.m_map_out_port.add_history('BadPixelSigmaFilterModule', history)
 
         self.m_image_out_port.close_port()
 
@@ -320,10 +330,10 @@ class BadPixelMapModule(ProcessingModule):
     """
 
     def __init__(self,
-                 name_in="bad_pixel_map",
-                 dark_in_tag="dark",
-                 flat_in_tag="flat",
-                 bp_map_out_tag="bp_map",
+                 name_in='bad_pixel_map',
+                 dark_in_tag='dark',
+                 flat_in_tag='flat',
+                 bp_map_out_tag='bp_map',
                  dark_threshold=0.2,
                  flat_threshold=0.2):
         """
@@ -391,7 +401,7 @@ class BadPixelMapModule(ProcessingModule):
 
             max_dark = np.max(dark)
 
-            sys.stdout.write(f"Threshold dark frame [counts] = {max_dark*self.m_dark_threshold}\n")
+            sys.stdout.write(f'Threshold dark frame [counts] = {max_dark*self.m_dark_threshold}\n')
             sys.stdout.flush()
 
             bpmap = np.ones(dark.shape)
@@ -405,7 +415,7 @@ class BadPixelMapModule(ProcessingModule):
 
             max_flat = np.max(flat)
 
-            sys.stdout.write(f"Threshold flat field [counts] = {max_flat*self.m_flat_threshold}\n")
+            sys.stdout.write(f'Threshold flat field [counts] = {max_flat*self.m_flat_threshold}\n')
             sys.stdout.flush()
 
             if self.m_dark_port is None:
@@ -415,7 +425,7 @@ class BadPixelMapModule(ProcessingModule):
 
         if self.m_dark_port is not None and self.m_flat_port is not None:
             if not dark.shape == flat.shape:
-                raise ValueError("Dark and flat images should have the same shape.")
+                raise ValueError('Dark and flat images should have the same shape.')
 
         self.m_bp_map_out_port.set_all(bpmap, data_dim=3)
 
@@ -424,8 +434,8 @@ class BadPixelMapModule(ProcessingModule):
         elif self.m_flat_port is not None:
             self.m_bp_map_out_port.copy_attributes(self.m_flat_port)
 
-        history = f"dark = {self.m_dark_threshold}, flat = {self.m_flat_threshold}"
-        self.m_bp_map_out_port.add_history("BadPixelMapModule", history)
+        history = f'dark = {self.m_dark_threshold}, flat = {self.m_flat_threshold}'
+        self.m_bp_map_out_port.add_history('BadPixelMapModule', history)
 
         self.m_bp_map_out_port.close_port()
 
@@ -436,10 +446,10 @@ class BadPixelInterpolationModule(ProcessingModule):
     """
 
     def __init__(self,
-                 name_in="bad_pixel_interpolation",
-                 image_in_tag="im_arr",
-                 bad_pixel_map_tag="bp_map",
-                 image_out_tag="im_arr_bp_clean",
+                 name_in='bad_pixel_interpolation',
+                 image_in_tag='im_arr',
+                 bad_pixel_map_tag='bp_map',
+                 image_out_tag='im_arr_bp_clean',
                  iterations=1000):
         """
         Parameters
@@ -483,12 +493,12 @@ class BadPixelInterpolationModule(ProcessingModule):
         im_shape = self.m_image_in_port.get_shape()
 
         if self.m_iterations > im_shape[1]*im_shape[2]:
-            raise ValueError("Maximum number of iterations needs to be smaller than the number of "
-                             "pixels in the image.")
+            raise ValueError('Maximum number of iterations needs to be smaller than the number of '
+                             'pixels in the image.')
 
         if bad_pixel_map.shape[0] != im_shape[-2] or bad_pixel_map.shape[1] != im_shape[-1]:
-            raise ValueError("The shape of the bad pixel map does not match the shape of the "
-                             "images.")
+            raise ValueError('The shape of the bad pixel map does not match the shape of the '
+                             'images.')
 
         def _image_interpolation(image_in):
             return _bad_pixel_interpolation(image_in,
@@ -498,11 +508,11 @@ class BadPixelInterpolationModule(ProcessingModule):
         self.apply_function_to_images(_image_interpolation,
                                       self.m_image_in_port,
                                       self.m_image_out_port,
-                                      "Running BadPixelInterpolationModule")
+                                      'Running BadPixelInterpolationModule')
 
-        history = f"iterations = {self.m_iterations}"
+        history = f'iterations = {self.m_iterations}'
         self.m_image_out_port.copy_attributes(self.m_image_in_port)
-        self.m_image_out_port.add_history("BadPixelInterpolationModule", history)
+        self.m_image_out_port.add_history('BadPixelInterpolationModule', history)
         self.m_image_out_port.close_port()
 
 
@@ -515,9 +525,9 @@ class BadPixelTimeFilterModule(ProcessingModule):
     """
 
     def __init__(self,
-                 name_in="bp_time",
-                 image_in_tag="im_arr",
-                 image_out_tag="im_arr_bp_time",
+                 name_in='bp_time',
+                 image_in_tag='im_arr',
+                 image_out_tag='im_arr_bp_time',
                  sigma=(5., 5.)):
         """
         Parameters
@@ -575,7 +585,7 @@ class BadPixelTimeFilterModule(ProcessingModule):
 
             return timeline
 
-        sys.stdout.write("Running BadPixelTimeFilterModule...")
+        sys.stdout.write('Running BadPixelTimeFilterModule...')
         sys.stdout.flush()
 
         self.apply_function_in_time(_time_filter,
@@ -583,12 +593,12 @@ class BadPixelTimeFilterModule(ProcessingModule):
                                     self.m_image_out_port,
                                     func_args=(self.m_sigma, ))
 
-        sys.stdout.write(" [DONE]\n")
+        sys.stdout.write(' [DONE]\n')
         sys.stdout.flush()
 
-        history = f"sigma = {self.m_sigma}"
+        history = f'sigma = {self.m_sigma}'
         self.m_image_out_port.copy_attributes(self.m_image_in_port)
-        self.m_image_out_port.add_history("BadPixelTimeFilterModule", history)
+        self.m_image_out_port.add_history('BadPixelTimeFilterModule', history)
         self.m_image_out_port.close_port()
 
 
@@ -599,12 +609,12 @@ class ReplaceBadPixelsModule(ProcessingModule):
     """
 
     def __init__(self,
-                 name_in="bp_replace",
-                 image_in_tag="im_arr",
-                 map_in_tag="bp_map",
-                 image_out_tag="im_arr_bp_replace",
+                 name_in='bp_replace',
+                 image_in_tag='im_arr',
+                 map_in_tag='bp_map',
+                 image_out_tag='im_arr_bp_replace',
                  size=2,
-                 replace="mean"):
+                 replace='mean'):
         """
         Parameters
         ----------
@@ -666,11 +676,11 @@ class ReplaceBadPixelsModule(ProcessingModule):
                 if np.size(np.where(im_tmp != np.nan)[0]) == 0:
                     im_mask[item[0], item[1]] = image[item[0], item[1]]
                 else:
-                    if self.m_replace == "mean":
+                    if self.m_replace == 'mean':
                         im_mask[item[0], item[1]] = np.nanmean(im_tmp)
-                    elif self.m_replace == "median":
+                    elif self.m_replace == 'median':
                         im_mask[item[0], item[1]] = np.nanmedian(im_tmp)
-                    elif self.m_replace == "nan":
+                    elif self.m_replace == 'nan':
                         im_mask[item[0], item[1]] = np.nan
 
             return im_mask
@@ -678,10 +688,10 @@ class ReplaceBadPixelsModule(ProcessingModule):
         self.apply_function_to_images(_replace_pixels,
                                       self.m_image_in_port,
                                       self.m_image_out_port,
-                                      "Running ReplaceBadPixelsModule",
+                                      'Running ReplaceBadPixelsModule',
                                       func_args=(index, ))
 
-        history = f"replace = {self.m_replace}"
+        history = f'replace = {self.m_replace}'
         self.m_image_out_port.copy_attributes(self.m_image_in_port)
-        self.m_image_out_port.add_history("ReplaceBadPixelsModule", history)
+        self.m_image_out_port.add_history('ReplaceBadPixelsModule', history)
         self.m_image_out_port.close_port()


### PR DESCRIPTION
- The `map_out_tag` in `BadPixelSigmaFilterModule ` can not be used with multiprocessing so it will be set to `None` (if this was not the case yet) and a warning is given.

- Updated NEAR docs.