### PR TITLE
FitCenterModule

### DIFF
--- a/docs/near.rst
+++ b/docs/near.rst
@@ -63,9 +63,9 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
    # Import the Pypeline and the modules that we will use in this example.
 
    from pynpoint import Pypeline, NearReadingModule, AngleInterpolationModule, \
-                        SubtractImagesModule, CropImagesModule, StarAlignmentModule, \
-                        StarCenteringModule, PSFpreparationModule, PcaPsfSubtractionModule, \
-                        FitsWritingModule
+                        CropImagesModule, SubtractImagesModule, FitCenterModule, \
+                        ShiftImagesModule, PSFpreparationModule, PcaPsfSubtractionModule, \
+                        ContrastCurveModule, FitsWritingModule, TextWritingModule
 
    # Create a Pypeline instance.
 
@@ -215,7 +215,7 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
    # Calculate detection limits between 0.8 and 2.0 arcsec
    # The false positive fraction is fixed to 2.87e-6 (i.e. 5 sigma for Gaussian statistics)
 
-   module = ContrastCurveModule(name_in='limits',
+   module = ContrastCurveModule(name_in='contrastcurve',
                                 image_in_tag='chopa_center',
                                 psf_in_tag='psfa_prep',
                                 contrast_out_tag='limits',

--- a/docs/near.rst
+++ b/docs/near.rst
@@ -60,20 +60,20 @@ The ``MEMORY`` and ``CPU`` setting can be adjusted. They define the number of im
 
 Pipeline modules are added sequentially to the pipeline and are executed either individually or all at once (see end of the example script). Each pipeline module requires a ``name_in`` tag which is used as identifier by the pipeline. All intermediate results (typically a stack of images) are stored in the database (`PynPoint_database.hdf5`) which allows the user to rerun particular processing steps without having to rerun the complete pipeline. The script below can now be executed as a text file from the command line, in Python interactive mode, or as a Jupyter notebook::
 
-   # Import the Pypeline and the modules that we will use in this example
+   # Import the Pypeline and the modules that we will use in this example.
 
    from pynpoint import Pypeline, NearReadingModule, AngleInterpolationModule, \
                         SubtractImagesModule, CropImagesModule, StarAlignmentModule, \
                         StarCenteringModule, PSFpreparationModule, PcaPsfSubtractionModule, \
                         FitsWritingModule
 
-   # Create a Pypeline instance
+   # Create a Pypeline instance.
 
    pipeline = Pypeline(working_place_in='working_folder/',
                        input_place_in='input_folder/',
                        output_place_in='output_folder/')
 
-   # Read the raw data and separate chop A and chop B images
+   # Read the raw data and separate the chop A and chop B images.
 
    module = NearReadingModule(name_in='read',
                               input_dir=None,
@@ -82,72 +82,122 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    pipeline.add_module(module)
 
-   # Interpolate the parallactic angles between the start and end value
+   # Interpolate the parallactic angles between the start and end value of each FITS file.
 
    module = AngleInterpolationModule(name_in='angle',
                                      data_tag='chopa')
 
    pipeline.add_module(module)
 
-   # Subtract frame-by-frame chop B from chop A
+   # Crop the chop A and chop B images around their approximate center.
 
-   module = SubtractImagesModule(name_in='subtract',
-                                 image_in_tags=('chopa', 'chopb'),
+   module = CropImagesModule(size=5.,
+                             center=(432, 287),
+                             name_in='crop1',
+                             image_in_tag='chopa',
+                             image_out_tag='chopa_crop')
+
+   pipeline.add_module(module)
+
+   module = CropImagesModule(size=5.,
+                             center=(432, 287),
+                             name_in='crop2',
+                             image_in_tag='chopb',
+                             image_out_tag='chopb_crop')
+
+   pipeline.add_module(module)
+
+   # Crop out the non-coronagraphic PSF for chop A from the chop B images.
+
+   module = CropImagesModule(size=5.,
+                             center=(430, 175),
+                             name_in='crop3',
+                             image_in_tag='chopb',
+                             image_out_tag='psfa')
+
+   pipeline.add_module(module)
+
+   # Subtract frame-by-frame chop B from chop A.
+
+   module = SubtractImagesModule(name_in='subtract1',
+                                 image_in_tags=('chopa_crop', 'chopb_crop'),
                                  image_out_tag='chopa_sub',
                                  scaling=1.)
 
    pipeline.add_module(module)
 
-   # Crop the chop A images around the approximate center to 5 x 5 arcsec
+   # Fit the center position of chop A, using the images from before the chop-subtraction.
+   # For simplicity, only the mean of the image stack is fitted.
 
-   module = CropImagesModule(size=5.,
-                             center=(432, 286),
-                             name_in='crop',
-                             image_in_tag='chopa_sub',
-                             image_out_tag='chopa_crop')
-
-   pipeline.add_module(module)
-
-   # Align the images by cross-correlating the central 1 arcsec
-
-   module = StarAlignmentModule(name_in='align',
-                                image_in_tag='chopa_crop',
-                                ref_image_in_tag=None,
-                                image_out_tag='chopa_align',
-                                interpolation='spline',
-                                accuracy=10,
-                                resize=None,
-                                num_references=10,
-                                subframe=1.)
+   module = FitCenterModule(name_in='center1',
+                            image_in_tag='chopa_crop',
+                            fit_out_tag='chopa_fit',
+                            mask_out_tag=None,
+                            method='mean',
+                            radius=1.,
+                            sign='positive',
+                            model='moffat',
+                            filter_size=None,
+                            guess=(0., 0., 10., 10., 1e4, 0., 0., 1.))
 
    pipeline.add_module(module)
 
-   # Absolute centering by fitting a 2D Moffat function to the average of all images
+   # Fit the center position of the non-coronagraphic PSF.
 
-   module = StarCenteringModule(name_in='center',
-                                image_in_tag='chopa_align',
-                                image_out_tag='chopa_center',
-                                mask_out_tag='chopa_mask',
-                                fit_out_tag='chopa_fit',
-                                method='mean',
-                                interpolation='spline',
-                                radius=2.,
-                                sign='positive',
-                                model='moffat',
-                                filter_size=0.1,
-                                guess=(0., 0., 5., 5., 100., 0., 0., 1.))
+   module = FitCenterModule(name_in='center3',
+                            image_in_tag='psfa',
+                            fit_out_tag='psfa_fit',
+                            mask_out_tag=None,
+                            method='mean',
+                            radius=1.,
+                            sign='positive',
+                            model='moffat',
+                            filter_size=None,
+                            guess=(0., 0., 10., 10., 1e4, 0., 0., 1.))
 
    pipeline.add_module(module)
 
-   # Mask the central and outer part of the images
+   # Center the chop-subtracted images by using the fitted values from the FitCenterModule.
 
-   module = PSFpreparationModule(name_in='prep',
+   module = ShiftImagesModule(shift_xy='chopa_fit',
+                              name_in='shift1',
+                              image_in_tag='chopa_sub',
+                              image_out_tag='chopa_center',
+                              interpolation='spline')
+
+   pipeline.add_module(module)
+
+   # Center the non-coronagraphic PSF.
+
+   module = ShiftImagesModule(shift_xy='psfa_fit',
+                              name_in='shift2',
+                              image_in_tag='psfa',
+                              image_out_tag='psfa_center',
+                              interpolation='spline')
+
+   pipeline.add_module(module)
+
+   # Mask the central and outer part of the chop A images.
+
+   module = PSFpreparationModule(name_in='prep1',
                                  image_in_tag='chopa_center',
                                  image_out_tag='chopa_prep',
                                  mask_out_tag=None,
                                  norm=False,
                                  cent_size=0.3,
-                                 edge_size=3.)
+                                 edge_size=2.)
+
+   pipeline.add_module(module)
+
+   # Mask the non-coronagraphic PSF beyond 1 arsec.
+
+   module = PSFpreparationModule(name_in='prep2',
+                                 image_in_tag='psfa_center',
+                                 image_out_tag='psfa_mask',
+                                 mask_out_tag=None,
+                                 norm=False,
+                                 cent_size=None,
+                                 edge_size=1.)
 
    pipeline.add_module(module)
 
@@ -162,10 +212,30 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    pipeline.add_module(module)
 
-   # Datasets can be exported to FITS files by their tag name in the database
-   # Here we will export the median-combined residuals of the PSF subtraction
+   # Calculate detection limits between 0.8 and 2.0 arcsec
+   # The false positive fraction is fixed to 2.87e-6 (i.e. 5 sigma for Gaussian statistics)
 
-   module = FitsWritingModule(name_in='write',
+   module = ContrastCurveModule(name_in='limits',
+                                image_in_tag='chopa_center',
+                                psf_in_tag='psfa_prep',
+                                contrast_out_tag='limits',
+                                separation=(0.8, 2., 0.1),
+                                angle=(0., 360., 60.),
+                                threshold=('fpf', 2.87e-6),
+                                psf_scaling=1.,
+                                aperture=0.1,
+                                pca_number=5,
+                                cent_size=0.3,
+                                edge_size=2.,
+                                extra_rot=0.,
+                                residuals='median')
+ 
+   pipeline.add_module(module)
+
+   # Datasets can be exported to FITS files by their tag name in the database.
+   # Here we will export the median-combined residuals of the PSF subtraction.
+
+   module = FitsWritingModule(name_in='write1',
                               file_name='chopa_pca.fits',
                               output_dir=None,
                               data_tag='chopa_pca',
@@ -174,21 +244,25 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    pipeline.add_module(module)
 
-   # Finally, to run all pipeline modules at once
+   # And we write the detection limits to a text file.
+
+   header = 'Separation [arcsec] - Contrast [mag] - Variance [mag] - FPF'
+
+   module = TextWritingModule(name_in='write2',
+                              file_name='contrast_curve.dat',
+                              output_dir=None,
+                              data_tag='limits',
+                              header=header)
+
+   pipeline.add_module(module)
+
+   # Finally, to run all pipeline modules at once:
 
    pipeline.run()
 
-   # Or to run the modules individually
+   # Or to run a module individually:
 
    pipeline.run_module('read')
-   pipeline.run_module('angle')
-   pipeline.run_module('subtract')
-   pipeline.run_module('crop')
-   pipeline.run_module('align')
-   pipeline.run_module('center')
-   pipeline.run_module('prep')
-   pipeline.run_module('pca')
-   pipeline.run_module('write')
 
 .. _near_results:
 

--- a/pynpoint/__init__.py
+++ b/pynpoint/__init__.py
@@ -20,7 +20,7 @@ from pynpoint.processing.basic import SubtractImagesModule, \
 from pynpoint.processing.centering import StarExtractionModule, \
                                           StarAlignmentModule, \
                                           StarCenteringModule, \
-                                          FitProfileModule, \
+                                          FitCenterModule, \
                                           ShiftImagesModule, \
                                           WaffleCenteringModule
 

--- a/pynpoint/__init__.py
+++ b/pynpoint/__init__.py
@@ -20,6 +20,7 @@ from pynpoint.processing.basic import SubtractImagesModule, \
 from pynpoint.processing.centering import StarExtractionModule, \
                                           StarAlignmentModule, \
                                           StarCenteringModule, \
+                                          FitProfileModule, \
                                           ShiftImagesModule, \
                                           WaffleCenteringModule
 

--- a/pynpoint/core/processing.py
+++ b/pynpoint/core/processing.py
@@ -46,11 +46,11 @@ class PypelineModule(metaclass=ABCMeta):
             None
         """
 
-        assert isinstance(name_in, str), "Name of the PypelineModule needs to be a string."
+        assert isinstance(name_in, str), 'Name of the PypelineModule needs to be a string.'
 
         self._m_name = name_in
         self._m_data_base = None
-        self._m_config_port = ConfigPort("config")
+        self._m_config_port = ConfigPort('config')
 
     @property
     def name(self):
@@ -156,8 +156,7 @@ class ReadingModule(PypelineModule, metaclass=ABCMeta):
         port = OutputPort(tag, activate_init=activation)
 
         if tag in self._m_output_ports:
-            warnings.warn("Tag '%s' of ReadingModule '%s' is already used."
-                          % (tag, self._m_name))
+            warnings.warn(f'Tag \'{tag}\' of ReadingModule \'{self._m_name}\' is already used.')
 
         if self._m_data_base is not None:
             port.set_database_connection(self._m_data_base)
@@ -416,8 +415,7 @@ class ProcessingModule(PypelineModule, metaclass=ABCMeta):
         port = OutputPort(tag, activate_init=activation)
 
         if tag in self._m_output_ports:
-            warnings.warn("Tag '%s' of ProcessingModule '%s' is already used."
-                          % (tag, self._m_name))
+            warnings.warn(f'Tag \'{tag}\' of ProcessingModule \'{self._m_name}\' is already used.')
 
         if self._m_data_base is not None:
             port.set_database_connection(self._m_data_base)
@@ -479,7 +477,7 @@ class ProcessingModule(PypelineModule, metaclass=ABCMeta):
             None
         """
 
-        cpu = self._m_config_port.get_attribute("CPU")
+        cpu = self._m_config_port.get_attribute('CPU')
 
         init_line = image_in_port[:, 0, 0]
 
@@ -538,8 +536,8 @@ class ProcessingModule(PypelineModule, metaclass=ABCMeta):
             None
         """
 
-        memory = self._m_config_port.get_attribute("MEMORY")
-        cpu = self._m_config_port.get_attribute("CPU")
+        memory = self._m_config_port.get_attribute('MEMORY')
+        cpu = self._m_config_port.get_attribute('CPU')
 
         nimages = image_in_port.get_shape()[0]
 
@@ -568,11 +566,14 @@ class ProcessingModule(PypelineModule, metaclass=ABCMeta):
 
                 if images.shape[-2] != result.shape[-2] or images.shape[-1] != result.shape[-1]:
 
-                    raise ValueError("Input and output port have the same tag while the input "
-                                     "function is changing the image shape. This is only possible "
-                                     "with MEMORY=None.")
+                    raise ValueError('Input and output port have the same tag while the input '
+                                     'function is changing the image shape. This is only possible '
+                                     'with MEMORY=None.')
 
             image_out_port.set_all(result, keep_attributes=True)
+
+            sys.stdout.write(message+' [DONE]\n')
+            sys.stdout.flush()
 
         elif cpu == 1:
             # process images one-by-one with a single process if CPU is set to 1
@@ -595,6 +596,9 @@ class ProcessingModule(PypelineModule, metaclass=ABCMeta):
                     image_out_port.append(result, data_dim=2)
                 elif result.ndim == 2:
                     image_out_port.append(result, data_dim=3)
+
+            sys.stdout.write(message+' [DONE]\n')
+            sys.stdout.flush()
 
         else:
             sys.stdout.write(message)
@@ -629,8 +633,8 @@ class ProcessingModule(PypelineModule, metaclass=ABCMeta):
 
             capsule.run()
 
-        sys.stdout.write(" [DONE]\n")
-        sys.stdout.flush()
+            sys.stdout.write(' [DONE]\n')
+            sys.stdout.flush()
 
     def get_all_input_tags(self):
         """

--- a/pynpoint/processing/centering.py
+++ b/pynpoint/processing/centering.py
@@ -1150,7 +1150,6 @@ class FitCenterModule(ProcessingModule):
                 im_mean += np.sum(self.m_image_in_port[frames[i]:frames[i+1], ], axis=0)
 
             best_fit = _fit_2d_function(im_mean/float(nimages))
-
             best_fit = best_fit[np.newaxis, ...]
             best_fit = np.repeat(best_fit, nimages, axis=0)
 

--- a/pynpoint/processing/centering.py
+++ b/pynpoint/processing/centering.py
@@ -430,6 +430,9 @@ class StarCenteringModule(ProcessingModule):
             None
         """
 
+        warnings.warn('The StarCenteringModule will be deprecated in a future release. Please use '
+                      'the FitCenterModule and ShiftImagesModule instead.', DeprecationWarning)
+
         if 'guess' in kwargs:
             self.m_guess = kwargs['guess']
 
@@ -1028,7 +1031,7 @@ class FitCenterModule(ProcessingModule):
             x_diff = xx_grid - x_center
             y_diff = yy_grid - y_center
 
-            if 2.**(1./beta)-1. < 0.
+            if 2.**(1./beta)-1. < 0.:
                 alpha_x = np.nan
                 alpha_y = np.nan
 
@@ -1036,7 +1039,7 @@ class FitCenterModule(ProcessingModule):
                 alpha_x = 0.5*fwhm_x/np.sqrt(2.**(1./beta)-1.)
                 alpha_y = 0.5*fwhm_y/np.sqrt(2.**(1./beta)-1.)
 
-            if alpha_x == 0. or alpha_y == 0.
+            if alpha_x == 0. or alpha_y == 0.:
                 a_moffat = np.nan
                 b_moffat = np.nan
                 c_moffat = np.nan

--- a/pynpoint/processing/centering.py
+++ b/pynpoint/processing/centering.py
@@ -1028,23 +1028,23 @@ class FitCenterModule(ProcessingModule):
             x_diff = xx_grid - x_center
             y_diff = yy_grid - y_center
 
-            try:
-                alpha_x = 0.5*fwhm_x/np.sqrt(2.**(1./beta)-1.)
-                alpha_y = 0.5*fwhm_y/np.sqrt(2.**(1./beta)-1.)
-
-            except RuntimeWarning:
+            if 2.**(1./beta)-1. < 0.
                 alpha_x = np.nan
                 alpha_y = np.nan
 
-            try:
-                a_moffat = (np.cos(theta)/alpha_x)**2. + (np.sin(theta)/alpha_y)**2.
-                b_moffat = (np.sin(theta)/alpha_x)**2. + (np.cos(theta)/alpha_y)**2.
-                c_moffat = 2.*np.sin(theta)*np.cos(theta)*(1./alpha_x**2. - 1./alpha_y**2.)
+            else:
+                alpha_x = 0.5*fwhm_x/np.sqrt(2.**(1./beta)-1.)
+                alpha_y = 0.5*fwhm_y/np.sqrt(2.**(1./beta)-1.)
 
-            except RuntimeWarning:
+            if alpha_x == 0. or alpha_y == 0.
                 a_moffat = np.nan
                 b_moffat = np.nan
                 c_moffat = np.nan
+
+            else:
+                a_moffat = (np.cos(theta)/alpha_x)**2. + (np.sin(theta)/alpha_y)**2.
+                b_moffat = (np.sin(theta)/alpha_x)**2. + (np.cos(theta)/alpha_y)**2.
+                c_moffat = 2.*np.sin(theta)*np.cos(theta)*(1./alpha_x**2. - 1./alpha_y**2.)
 
             a_term = a_moffat*x_diff**2
             b_term = b_moffat*y_diff**2
@@ -1156,7 +1156,7 @@ class FitCenterModule(ProcessingModule):
         if self.m_count > 0:
             print(f'Fit could not converge on {self.m_count} image(s). [WARNING]')
 
-        history = f'method = {self.m_method}'
+        history = f'model = {self.m_model}'
 
         self.m_fit_out_port.copy_attributes(self.m_image_in_port)
         self.m_fit_out_port.add_history('FitCenterModule', history)

--- a/pynpoint/util/module.py
+++ b/pynpoint/util/module.py
@@ -55,25 +55,24 @@ def progress(current,
         minutes = int((delta_time%3600.) / 60.)
         seconds = int(delta_time%60.)
 
-        return f"{hours:>02}:{minutes:>02}:{seconds:>02}"
+        return f'{hours:>02}:{minutes:>02}:{seconds:>02}'
 
     fraction = float(current) / float(total)
     percentage = 100.*fraction
 
     if start_time is None:
-        sys.stdout.write(f"\r{message} {percentage:4.1f}% \r")
-        sys.stdout.flush()
+        sys.stdout.write(f'\r{message} {percentage:4.1f}% \r')
 
     else:
         if fraction > 0. and current+1 != total:
             time_taken = time.time() - start_time
             time_left = time_taken / fraction * (1. - fraction)
-
-            sys.stdout.write(f"{message} {percentage:4.1f}% - Time: {time_string(time_left)}\r")
-            sys.stdout.flush()
+            sys.stdout.write(f'{message} {percentage:4.1f}% - Time: {time_string(time_left)}\r')
 
     if current+1 == total:
-        sys.stdout.write(" " * (29+len(message)) + "\r")
+        sys.stdout.write(' ' * (29+len(message)) + '\r')
+
+    sys.stdout.flush()
 
 def memory_frames(memory,
                   nimages):
@@ -96,9 +95,9 @@ def memory_frames(memory,
         frames = np.asarray([0, nimages])
 
     else:
-        frames = np.linspace(0,
-                             nimages-nimages%memory,
-                             int(float(nimages)/float(memory))+1,
+        frames = np.linspace(start=0,
+                             stop=nimages-nimages%memory,
+                             num=int(float(nimages)/float(memory))+1,
                              endpoint=True,
                              dtype=np.int)
 

--- a/tests/test_processing/test_centering.py
+++ b/tests/test_processing/test_centering.py
@@ -435,13 +435,13 @@ class TestStarAlignment:
 
         data = self.pipeline.get_data('fit_full')
         assert np.allclose(data[0, 0], 5.997834332959175, rtol=limit, atol=0.)
-        assert np.allclose(np.sum(data), 7393.3454701926685, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 13.202402625344051, rtol=1e-4, atol=0.)
         assert data.shape == (40, 14)
 
         data = self.pipeline.get_data('mask')
         assert np.allclose(data[0, 43, 45], 0.023556628129942764, rtol=limit, atol=0.)
         assert np.allclose(data[0, 43, 55], 0.0, rtol=limit, atol=0.)
-        assert np.allclose(np.sum(data), 26.349870395897373, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.00010827527282995305, rtol=limit, atol=0.)
         assert data.shape == (40, 78, 78)
 
     def test_fit_center_mean(self):
@@ -461,7 +461,7 @@ class TestStarAlignment:
 
         data = self.pipeline.get_data('fit_mean')
         assert np.allclose(data[0, 0], 5.999072568941366, rtol=limit, atol=0.)
-        assert np.allclose(np.sum(data), 9296.034957223646, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 14.525054620661948, rtol=1e-4, atol=0.)
         assert data.shape == (40, 16)
 
     def test_shift_images_tag(self):
@@ -477,5 +477,5 @@ class TestStarAlignment:
 
         data = self.pipeline.get_data('shift_tag')
         assert np.allclose(data[0, 39, 39], 0.023563080974545528, rtol=limit, atol=0.)
-        assert np.allclose(np.sum(data), 39.98557979765179, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.0001643062943690491, rtol=limit, atol=0.)
         assert data.shape == (40, 78, 78)

--- a/tests/test_processing/test_centering.py
+++ b/tests/test_processing/test_centering.py
@@ -8,7 +8,7 @@ from pynpoint.core.pypeline import Pypeline
 from pynpoint.readwrite.fitsreading import FitsReadingModule
 from pynpoint.processing.centering import StarExtractionModule, StarAlignmentModule, \
                                           ShiftImagesModule, StarCenteringModule, \
-                                          WaffleCenteringModule
+                                          WaffleCenteringModule, FitCenterModule
 from pynpoint.util.tests import create_config, create_star_data, create_waffle_data, \
                                 remove_test_data
 
@@ -250,34 +250,41 @@ class TestStarAlignment:
     def test_shift_images_fft(self):
 
         module = ShiftImagesModule(shift_xy=(6., 4.),
-                                   interpolation='spline',
+                                   interpolation='fft',
                                    name_in='shift2',
                                    image_in_tag='align',
-                                   image_out_tag='fft')
+                                   image_out_tag='shift_fft')
 
         self.pipeline.add_module(module)
         self.pipeline.run_module('shift2')
 
-        data = self.pipeline.get_data('fft')
+        data = self.pipeline.get_data('shift_fft')
         assert np.allclose(data[0, 43, 45], 0.023556628129942764, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 0.00016430682224782259, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.00016446205542266847, rtol=limit, atol=0.)
         assert data.shape == (40, 78, 78)
 
     def test_star_center_full(self):
 
-        module = StarCenteringModule(name_in='center1',
-                                     image_in_tag='shift',
-                                     image_out_tag='center',
-                                     mask_out_tag='mask',
-                                     fit_out_tag=None,
-                                     method='full',
-                                     interpolation='spline',
-                                     radius=0.05,
-                                     sign='positive',
-                                     model='gaussian',
-                                     guess=(6., 4., 3., 3., 1., 0., 0.))
+        with pytest.warns(DeprecationWarning) as warning:
+            module = StarCenteringModule(name_in='center1',
+                                         image_in_tag='shift',
+                                         image_out_tag='center',
+                                         mask_out_tag='mask',
+                                         fit_out_tag=None,
+                                         method='full',
+                                         interpolation='spline',
+                                         radius=0.05,
+                                         sign='positive',
+                                         model='gaussian',
+                                         guess=(6., 4., 3., 3., 1., 0., 0.))
 
-        self.pipeline.add_module(module)
+            self.pipeline.add_module(module)
+
+        assert len(warning) == 1
+        assert warning[0].message.args[0] == 'The StarCenteringModule will be deprecated in a ' \
+                                             'future release. Please use the FitCenterModule ' \
+                                             'and ShiftImagesModule instead.'
+
         self.pipeline.run_module('center1')
 
         data = self.pipeline.get_data('center')
@@ -293,19 +300,26 @@ class TestStarAlignment:
 
     def test_star_center_mean(self):
 
-        module = StarCenteringModule(name_in='center2',
-                                     image_in_tag='shift',
-                                     image_out_tag='center',
-                                     mask_out_tag=None,
-                                     fit_out_tag=None,
-                                     method='mean',
-                                     interpolation='bilinear',
-                                     radius=0.05,
-                                     sign='positive',
-                                     model='gaussian',
-                                     guess=(6., 4., 3., 3., 1., 0., 0.))
+        with pytest.warns(DeprecationWarning) as warning:
+            module = StarCenteringModule(name_in='center2',
+                                         image_in_tag='shift',
+                                         image_out_tag='center',
+                                         mask_out_tag=None,
+                                         fit_out_tag=None,
+                                         method='mean',
+                                         interpolation='bilinear',
+                                         radius=0.05,
+                                         sign='positive',
+                                         model='gaussian',
+                                         guess=(6., 4., 3., 3., 1., 0., 0.))
 
-        self.pipeline.add_module(module)
+            self.pipeline.add_module(module)
+
+        assert len(warning) == 1
+        assert warning[0].message.args[0] == 'The StarCenteringModule will be deprecated in a ' \
+                                             'future release. Please use the FitCenterModule ' \
+                                             'and ShiftImagesModule instead.'
+
         self.pipeline.run_module('center2')
 
         data = self.pipeline.get_data('center')
@@ -315,19 +329,25 @@ class TestStarAlignment:
 
     def test_star_center_moffat(self):
 
-        module = StarCenteringModule(name_in='center3',
-                                     image_in_tag='shift',
-                                     image_out_tag='center',
-                                     mask_out_tag=None,
-                                     fit_out_tag='center_fit',
-                                     method='mean',
-                                     interpolation='spline',
-                                     radius=0.05,
-                                     sign='positive',
-                                     model='moffat',
-                                     guess=(6., 4., 3., 3., 1., 0., 0., 1.))
+        with pytest.warns(DeprecationWarning) as warning:
+            module = StarCenteringModule(name_in='center3',
+                                         image_in_tag='shift',
+                                         image_out_tag='center',
+                                         mask_out_tag=None,
+                                         fit_out_tag='center_fit',
+                                         method='mean',
+                                         interpolation='spline',
+                                         radius=0.05,
+                                         sign='positive',
+                                         model='moffat',
+                                         guess=(6., 4., 3., 3., 1., 0., 0., 1.))
 
-        self.pipeline.add_module(module)
+            self.pipeline.add_module(module)
+
+        assert len(warning) == 1
+        assert warning[0].message.args[0] == 'The StarCenteringModule will be deprecated in a ' \
+                                             'future release. Please use the FitCenterModule ' \
+                                             'and ShiftImagesModule instead.'
 
         with pytest.warns(RuntimeWarning) as warning:
             self.pipeline.run_module('center3')
@@ -397,3 +417,65 @@ class TestStarAlignment:
 
         attribute = self.pipeline.get_attribute('center_even', 'History: WaffleCenteringModule')
         assert attribute == '[x, y] = [49.5, 49.5]'
+
+    def test_fit_center_full(self):
+
+        module = FitCenterModule(name_in='fit1',
+                                 image_in_tag='shift',
+                                 fit_out_tag='fit_full',
+                                 mask_out_tag='mask',
+                                 method='full',
+                                 radius=0.05,
+                                 sign='positive',
+                                 model='gaussian',
+                                 guess=(6., 4., 3., 3., 0.01, 0., 0.))
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('fit1')
+
+        data = self.pipeline.get_data('fit_full')
+        assert np.allclose(data[0, 0], 5.997834332959175, rtol=limit, atol=0.)
+        assert np.allclose(np.sum(data), 7393.3454701926685, rtol=limit, atol=0.)
+        assert data.shape == (40, 14)
+
+        data = self.pipeline.get_data('mask')
+        assert np.allclose(data[0, 43, 45], 0.023556628129942764, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 43, 55], 0.0, rtol=limit, atol=0.)
+        assert np.allclose(np.sum(data), 26.349870395897373, rtol=limit, atol=0.)
+        assert data.shape == (40, 78, 78)
+
+    def test_fit_center_mean(self):
+
+        module = FitCenterModule(name_in='fit2',
+                                 image_in_tag='shift',
+                                 fit_out_tag='fit_mean',
+                                 mask_out_tag=None,
+                                 method='mean',
+                                 radius=0.05,
+                                 sign='positive',
+                                 model='moffat',
+                                 guess=(6., 4., 3., 3., 0.01, 0., 0., 1.))
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('fit2')
+
+        data = self.pipeline.get_data('fit_mean')
+        assert np.allclose(data[0, 0], 5.999072568941366, rtol=limit, atol=0.)
+        assert np.allclose(np.sum(data), 9296.034957223646, rtol=limit, atol=0.)
+        assert data.shape == (40, 16)
+
+    def test_shift_images_tag(self):
+
+        module = ShiftImagesModule(shift_xy='fit_full',
+                                   interpolation='spline',
+                                   name_in='shift3',
+                                   image_in_tag='shift',
+                                   image_out_tag='shift_tag')
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('shift3')
+
+        data = self.pipeline.get_data('shift_tag')
+        assert np.allclose(data[0, 39, 39], 0.023563080974545528, rtol=limit, atol=0.)
+        assert np.allclose(np.sum(data), 39.98557979765179, rtol=limit, atol=0.)
+        assert data.shape == (40, 78, 78)


### PR DESCRIPTION
Added the `FitCenterModule` which is similar to the `StarCenteringModule` but only does the fitting part (2D Gaussian or Moffat function) and not the shifting. I think that it is better to split these two computations. This prevents unneeded computation time if only fitting is required. Furthermore, storing the fit results was not possible with multiprocessing (which only supports a single output port), while this module would benefit from the multiprocessing functionalities.

The `FitCenterModule` can run in parallel and stores the results both for a `mean` and `full` fit. These output tags can then be directly passed to the `shift_xy` argument of `ShiftImagesModule`. Potentially, `shift_xy` could take two dataset tags such that the values of `FitCenterModule` and `StarAlignmentModule` can be used at once (currently not implemented, feel free to create a PR for that).

The `StarCenteringModule` will be deprecated in a future release.

Updated the NEAR example in the docs.