### PR TITLE
RepeatImagesModule

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,8 +69,8 @@ VLT/NACO
 
 .. _config_sphere:
 
-VLT/SPHERE
-^^^^^^^^^^
+VLT/SPHERE/IRDIS
+^^^^^^^^^^^^^^^^
 
 .. code-block:: ini
 
@@ -94,7 +94,7 @@ VLT/SPHERE
 
    [settings]
 
-   PIXSCALE: 0.01227
+   PIXSCALE: 0.01226
    MEMORY: 1000
    CPU: 1
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -58,6 +58,7 @@ Basic Processing
 * :class:`~pynpoint.processing.basic.SubtractImagesModule`: Subtract two stacks of images.
 * :class:`~pynpoint.processing.basic.AddImagesModule`: Add two stacks of images
 * :class:`~pynpoint.processing.basic.RotateImagesModule`: Rotate a stack of images.
+* :class:`~pynpoint.processing.basic.RepeatImagesModule`: Repeat a stack of images.
 
 Centering
 ~~~~~~~~~

--- a/pynpoint/__init__.py
+++ b/pynpoint/__init__.py
@@ -15,7 +15,8 @@ from pynpoint.processing.badpixel import BadPixelSigmaFilterModule, \
 
 from pynpoint.processing.basic import SubtractImagesModule, \
                                       AddImagesModule, \
-                                      RotateImagesModule
+                                      RotateImagesModule, \
+                                      RepeatImagesModule
 
 from pynpoint.processing.centering import StarAlignmentModule, \
                                           StarCenteringModule, \

--- a/pynpoint/processing/basic.py
+++ b/pynpoint/processing/basic.py
@@ -5,6 +5,9 @@ Pipeline modules for basic image operations.
 import sys
 import time
 
+from typing import Tuple
+
+from typeguard import typechecked
 from scipy.ndimage import rotate
 
 from pynpoint.core.processing import ProcessingModule
@@ -16,21 +19,21 @@ class SubtractImagesModule(ProcessingModule):
     Pipeline module for subtracting two sets of images.
     """
 
+    @typechecked
     def __init__(self,
-                 image_in_tags,
-                 name_in="subtract_images",
-                 image_out_tag="im_arr_subtract",
-                 scaling=1.):
+                 name_in: str,
+                 image_in_tags: Tuple[str, str],
+                 image_out_tag: str,
+                 scaling: float = 1.) -> None:
         """
         Parameters
         ----------
-        image_in_tags : tuple(str, str)
-            Tuple with two tags of the database entry that are read as input.
         name_in : str
             Unique name of the module instance.
+        image_in_tags : tuple(str, str)
+            Tuple with two tags of the database entry that are read as input.
         image_out_tag : str
-            Tag of the database entry with the subtracted images that are written as output. Should
-            be different from *image_in_tags*.
+            Tag of the database entry with the subtracted images that are written as output.
         scaling : float
             Additional scaling factor.
 
@@ -40,7 +43,7 @@ class SubtractImagesModule(ProcessingModule):
             None
         """
 
-        super(SubtractImagesModule, self).__init__(name_in=name_in)
+        super(SubtractImagesModule, self).__init__(name_in)
 
         self.m_image_in1_port = self.add_input_port(image_in_tags[0])
         self.m_image_in2_port = self.add_input_port(image_in_tags[1])
@@ -48,7 +51,8 @@ class SubtractImagesModule(ProcessingModule):
 
         self.m_scaling = scaling
 
-    def run(self):
+    @typechecked
+    def run(self) -> None:
         """
         Run method of the module. Subtracts the images from the second database tag from the images
         of the first database tag, on a frame-by-frame basis.
@@ -63,27 +67,28 @@ class SubtractImagesModule(ProcessingModule):
         self.m_image_out_port.del_all_data()
 
         if self.m_image_in1_port.get_shape() != self.m_image_in2_port.get_shape():
-            raise ValueError("The shape of the two input tags have to be equal.")
+            raise ValueError('The shape of the two input tags has to be the same.')
 
-        memory = self._m_config_port.get_attribute("MEMORY")
+        memory = self._m_config_port.get_attribute('MEMORY')
         nimages = self.m_image_in1_port.get_shape()[0]
 
         frames = memory_frames(memory, nimages)
 
         start_time = time.time()
+
         for i, _ in enumerate(frames[:-1]):
-            progress(i, len(frames[:-1]), "Running SubtractImagesModule...", start_time)
+            progress(i, len(frames[:-1]), 'Running SubtractImagesModule...', start_time)
 
             images1 = self.m_image_in1_port[frames[i]:frames[i+1], ]
             images2 = self.m_image_in2_port[frames[i]:frames[i+1], ]
 
             self.m_image_out_port.append(self.m_scaling*(images1-images2))
 
-        sys.stdout.write("Running SubtractImagesModule... [DONE]\n")
+        sys.stdout.write('Running SubtractImagesModule... [DONE]\n')
         sys.stdout.flush()
 
-        history = "scaling = "+str(self.m_scaling)
-        self.m_image_out_port.add_history("SubtractImagesModule", history)
+        history = f'scaling = {self.m_scaling}'
+        self.m_image_out_port.add_history('SubtractImagesModule', history)
         self.m_image_out_port.copy_attributes(self.m_image_in1_port)
         self.m_image_out_port.close_port()
 
@@ -93,21 +98,21 @@ class AddImagesModule(ProcessingModule):
     Pipeline module for adding two sets of images.
     """
 
+    @typechecked
     def __init__(self,
-                 image_in_tags,
-                 name_in="add_images",
-                 image_out_tag="im_arr_add",
-                 scaling=1.):
+                 name_in: str,
+                 image_in_tags: Tuple[str, str],
+                 image_out_tag: str,
+                 scaling: float = 1.) -> None:
         """
         Parameters
         ----------
-        image_in_tags : tuple(str, str)
-            Tuple with two tags of the database entry that are read as input.
         name_in : str
             Unique name of the module instance.
+        image_in_tags : tuple(str, str)
+            Tuple with two tags of the database entry that are read as input.
         image_out_tag : str
-            Tag of the database entry with the added images that are written as output. Should
-            be different from *image_in_tags*.
+            Tag of the database entry with the added images that are written as output.
         scaling: float
             Additional scaling factor.
 
@@ -117,7 +122,7 @@ class AddImagesModule(ProcessingModule):
             None
         """
 
-        super(AddImagesModule, self).__init__(name_in=name_in)
+        super(AddImagesModule, self).__init__(name_in)
 
         self.m_image_in1_port = self.add_input_port(image_in_tags[0])
         self.m_image_in2_port = self.add_input_port(image_in_tags[1])
@@ -125,7 +130,8 @@ class AddImagesModule(ProcessingModule):
 
         self.m_scaling = scaling
 
-    def run(self):
+    @typechecked
+    def run(self) -> None:
         """
         Run method of the module. Add the images from the two database tags on a frame-by-frame
         basis.
@@ -140,27 +146,28 @@ class AddImagesModule(ProcessingModule):
         self.m_image_out_port.del_all_data()
 
         if self.m_image_in1_port.get_shape() != self.m_image_in2_port.get_shape():
-            raise ValueError("The shape of the two input tags have to be equal.")
+            raise ValueError('The shape of the two input tags has to be the same.')
 
         nimages = self.m_image_in1_port.get_shape()[0]
-        memory = self._m_config_port.get_attribute("MEMORY")
+        memory = self._m_config_port.get_attribute('MEMORY')
 
         frames = memory_frames(memory, nimages)
 
         start_time = time.time()
+
         for i, _ in enumerate(frames[:-1]):
-            progress(i, len(frames[:-1]), "Running AddImagesModule...", start_time)
+            progress(i, len(frames[:-1]), 'Running AddImagesModule...', start_time)
 
             images1 = self.m_image_in1_port[frames[i]:frames[i+1], ]
             images2 = self.m_image_in2_port[frames[i]:frames[i+1], ]
 
             self.m_image_out_port.append(self.m_scaling*(images1+images2))
 
-        sys.stdout.write("Running AddImagesModule... [DONE]\n")
+        sys.stdout.write('Running AddImagesModule... [DONE]\n')
         sys.stdout.flush()
 
-        history = "scaling = "+str(self.m_scaling)
-        self.m_image_out_port.add_history("AddImagesModule", history)
+        history = f'scaling = {self.m_scaling}'
+        self.m_image_out_port.add_history('AddImagesModule', history)
         self.m_image_out_port.copy_attributes(self.m_image_in1_port)
         self.m_image_out_port.close_port()
 
@@ -170,38 +177,37 @@ class RotateImagesModule(ProcessingModule):
     Pipeline module for rotating images.
     """
 
+    @typechecked
     def __init__(self,
-                 angle,
-                 name_in="rotate_images",
-                 image_in_tag="im_arr",
-                 image_out_tag="im_arr_rot"):
+                 name_in: str,
+                 image_in_tag: str,
+                 image_out_tag: str,
+                 angle: float) -> None:
         """
         Parameters
         ----------
-        scaling : float
-            Rotation angle (deg). Rotation is clockwise for positive values.
         name_in : str
             Unique name of the module instance.
         image_in_tag : str
             Tag of the database entry that is read as input.
         image_out_tag : str
-            Tag of the database entry that is written as output. Should be different from
-            *image_in_tags*.
-
+            Tag of the database entry that is written as output.
+        angle : float
+            Rotation angle (deg). Rotation is clockwise for positive values.
         Returns
         -------
         NoneType
             None
         """
 
-        super(RotateImagesModule, self).__init__(name_in=name_in)
+        super(RotateImagesModule, self).__init__(name_in)
 
         self.m_image_in_port = self.add_input_port(image_in_tag)
         self.m_image_out_port = self.add_output_port(image_out_tag)
 
         self.m_angle = angle
 
-    def run(self):
+    def run(self) -> None:
         """
         Run method of the module. Rotates all images by a constant angle.
 
@@ -214,10 +220,7 @@ class RotateImagesModule(ProcessingModule):
         self.m_image_out_port.del_all_attributes()
         self.m_image_out_port.del_all_data()
 
-        if self.m_image_in_port.tag == self.m_image_out_port.tag:
-            raise ValueError("Input and output port should have a different tag.")
-
-        memory = self._m_config_port.get_attribute("MEMORY")
+        memory = self._m_config_port.get_attribute('MEMORY')
 
         ndim = self.m_image_in_port.get_ndim()
         nimages = self.m_image_in_port.get_shape()[0]
@@ -225,8 +228,9 @@ class RotateImagesModule(ProcessingModule):
         frames = memory_frames(memory, nimages)
 
         start_time = time.time()
+
         for i, _ in enumerate(frames[:-1]):
-            progress(i, len(frames[:-1]), "Running RotateImagesModule...", start_time)
+            progress(i, len(frames[:-1]), 'Running RotateImagesModule...', start_time)
 
             images = self.m_image_in_port[frames[i]:frames[i+1], ]
 
@@ -238,10 +242,83 @@ class RotateImagesModule(ProcessingModule):
 
                 self.m_image_out_port.append(im_tmp, data_dim=ndim)
 
-        sys.stdout.write("Running RotateImagesModule... [DONE]\n")
+        sys.stdout.write('Running RotateImagesModule... [DONE]\n')
         sys.stdout.flush()
 
-        history = "angle [deg] = "+str(self.m_angle)
-        self.m_image_out_port.add_history("RotateImagesModule", history)
+        history = f'angle [deg] = {self.m_angle}'
+        self.m_image_out_port.add_history('RotateImagesModule', history)
+        self.m_image_out_port.copy_attributes(self.m_image_in_port)
+        self.m_image_out_port.close_port()
+
+
+class RepeatImagesModule(ProcessingModule):
+    """
+    Pipeline module for repeating the images from a dataset.
+    """
+
+    @typechecked
+    def __init__(self,
+                 name_in: str,
+                 image_in_tag: str,
+                 image_out_tag: str,
+                 repeat: int) -> None:
+        """
+        Parameters
+        ----------
+        name_in : str
+            Unique name of the module instance.
+        image_in_tag : str
+            Tag of the database entry that is read as input.
+        image_out_tag : str
+            Tag of the database entry with the added images that are written as output.
+        repeat: int
+            The number of times the input images get repeated.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        super(RepeatImagesModule, self).__init__(name_in)
+
+        self.m_image_in_port = self.add_input_port(image_in_tag)
+        self.m_image_out_port = self.add_output_port(image_out_tag)
+
+        self.m_repeat = repeat
+
+    @typechecked
+    def run(self) -> None:
+        """
+        Run method of the module. Repeats the stack of input images a specified number of times.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        self.m_image_out_port.del_all_attributes()
+        self.m_image_out_port.del_all_data()
+
+        nimages = self.m_image_in_port.get_shape()[0]
+        memory = self._m_config_port.get_attribute('MEMORY')
+
+        frames = memory_frames(memory, nimages)
+
+        start_time = time.time()
+
+        for i in range(self.m_repeat):
+            progress(i, self.m_repeat, 'Running RepeatImagesModule...', start_time)
+
+            for j, _ in enumerate(frames[:-1]):
+                images = self.m_image_in_port[frames[j]:frames[j+1], ]
+                self.m_image_out_port.append(images)
+
+        sys.stdout.write('Running RepeatImagesModule... [DONE]\n')
+        sys.stdout.flush()
+
+        history = f'repeat = {self.m_repeat}'
+        self.m_image_out_port.add_history('RepeatImagesModule', history)
         self.m_image_out_port.copy_attributes(self.m_image_in_port)
         self.m_image_out_port.close_port()

--- a/pynpoint/processing/psfpreparation.py
+++ b/pynpoint/processing/psfpreparation.py
@@ -452,22 +452,7 @@ class AngleCalculationModule(ProcessingModule):
         self.m_data_in_port = self.add_input_port(data_tag)
         self.m_data_out_port = self.add_output_port(data_tag)
 
-    def run(self):
-        """
-        Run method of the module. Calculates the parallactic angles from the position of the object
-        on the sky and the telescope location on earth. The start of the observation is used to
-        extrapolate for the observation time of each individual image of a data cube. The values
-        are written as PARANG attributes to *data_tag*.
-
-        Returns
-        -------
-        NoneType
-            None
-        """
-
-        # Load cube sizes
-        steps = self.m_data_in_port.get_attribute('NFRAMES')
-        ndit = self.m_data_in_port.get_attribute('NDIT')
+    def _attribute_check(self, ndit, steps):
 
         if not np.all(ndit == steps):
             warnings.warn('There is a mismatch between the NDIT and NFRAMES values. A frame '
@@ -492,6 +477,25 @@ class AngleCalculationModule(ProcessingModule):
                               '\'ESO INS4 DROT2 DEC\' to specify the object\'s declination. '
                               'The input will be parsed accordingly. Using the regular '
                               '\'DEC\' keyword will lead to wrong parallactic angles.')
+
+    def run(self):
+        """
+        Run method of the module. Calculates the parallactic angles from the position of the object
+        on the sky and the telescope location on earth. The start of the observation is used to
+        extrapolate for the observation time of each individual image of a data cube. The values
+        are written as PARANG attributes to *data_tag*.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        # Load cube sizes
+        steps = self.m_data_in_port.get_attribute('NFRAMES')
+        ndit = self.m_data_in_port.get_attribute('NDIT')
+
+        self._attribute_check(ndit, steps)
 
         # Load exposure time [hours]
         exptime = self.m_data_in_port.get_attribute('DIT')/3600.

--- a/pynpoint/processing/psfpreparation.py
+++ b/pynpoint/processing/psfpreparation.py
@@ -23,10 +23,10 @@ class PSFpreparationModule(ProcessingModule):
     """
 
     def __init__(self,
-                 name_in="psf_preparation",
-                 image_in_tag="im_arr",
-                 image_out_tag="im_arr",
-                 mask_out_tag="mask_arr",
+                 name_in='psf_preparation',
+                 image_in_tag='im_arr',
+                 image_out_tag='im_arr',
+                 mask_out_tag='mask_arr',
                  norm=False,
                  resize=None,
                  cent_size=None,
@@ -36,17 +36,17 @@ class PSFpreparationModule(ProcessingModule):
         ----------
         name_in : str
             Unique name of the module instance.
-            Default: "psf_preparation".
+            Default: 'psf_preparation'.
         image_in_tag : str
             Tag of the database entry that is read as input.
-            Default: "im_arr".
+            Default: 'im_arr'.
         image_out_tag : str
             Tag of the database entry with images that is written as output.
-            Default: "im_arr".
+            Default: 'im_arr'.
         mask_out_tag : str, optional
             Tag of the database entry with the mask that is written as output. If set to None, no
             mask array is saved.
-            Default: "mask_arr".
+            Default: 'mask_arr'.
         norm : bool
             Normalize each image by its Frobenius norm. Default: False.
         resize : float
@@ -84,9 +84,9 @@ class PSFpreparationModule(ProcessingModule):
 
         # Raise a DeprecationWarning if the resize argument is used
         if resize is not None:
-            warnings.warn("The 'resize' parameter has been deprecated. Its value is currently "
-                          "being ignored, and the argument will be removed in a future version "
-                          "of PynPoint.", DeprecationWarning)
+            warnings.warn('The \'resize\' parameter has been deprecated. Its value is currently '
+                          'being ignored, and the argument will be removed in a future version '
+                          'of PynPoint.', DeprecationWarning)
 
     def run(self):
         """
@@ -106,8 +106,8 @@ class PSFpreparationModule(ProcessingModule):
             self.m_mask_out_port.del_all_attributes()
 
         # Get PIXSCALE and MEMORY attributes
-        pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
-        memory = self._m_config_port.get_attribute("MEMORY")
+        pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
+        memory = self._m_config_port.get_attribute('MEMORY')
 
         # Get the number of images and split into batches to comply with memory constraints
         im_shape = self.m_image_in_port.get_shape()
@@ -133,15 +133,15 @@ class PSFpreparationModule(ProcessingModule):
         for i, _ in enumerate(frames[:-1]):
 
             # Print progress to command line
-            progress(i, len(frames[:-1]), "Running PSFpreparationModule...", start_time)
+            progress(i, len(frames[:-1]), 'Running PSFpreparationModule...', start_time)
 
             # Get the images and ensure they have the correct 3D shape with the following
             # three dimensions: (batch_size, height, width)
             images = self.m_image_in_port[frames[i]:frames[i+1], ]
 
             if images.ndim == 2:
-                warnings.warn("The input data has 2 dimensions whereas 3 dimensions are required. "
-                              "An extra dimension has been added.")
+                warnings.warn('The input data has 2 dimensions whereas 3 dimensions are required. '
+                              'An extra dimension has been added.')
 
                 images = images[np.newaxis, ...]
 
@@ -150,7 +150,7 @@ class PSFpreparationModule(ProcessingModule):
 
             # If desired, normalize the images using the Frobenius norm
             if self.m_norm:
-                im_norm = np.linalg.norm(images, ord="fro", axis=(1, 2))
+                im_norm = np.linalg.norm(images, ord='fro', axis=(1, 2))
                 images /= im_norm[:, np.newaxis, np.newaxis]
                 norms.append(im_norm)
 
@@ -168,21 +168,21 @@ class PSFpreparationModule(ProcessingModule):
         # If the norms list is not empty (i.e., if we have computed the norm for every image),
         # we can also save the corresponding norm vector as an additional attribute
         if norms:
-            self.m_image_out_port.add_attribute(name="norm",
+            self.m_image_out_port.add_attribute(name='norm',
                                                 value=np.hstack(norms),
                                                 static=False)
 
         # Save cent_size and edge_size as attributes to the output port
         if self.m_cent_size is not None:
-            self.m_image_out_port.add_attribute(name="cent_size",
+            self.m_image_out_port.add_attribute(name='cent_size',
                                                 value=self.m_cent_size * pixscale,
                                                 static=True)
         if self.m_edge_size is not None:
-            self.m_image_out_port.add_attribute(name="edge_size",
+            self.m_image_out_port.add_attribute(name='edge_size',
                                                 value=self.m_edge_size * pixscale,
                                                 static=True)
 
-        sys.stdout.write("Running PSFpreparationModule... [DONE]\n")
+        sys.stdout.write('Running PSFpreparationModule... [DONE]\n')
         sys.stdout.flush()
 
 
@@ -193,8 +193,8 @@ class AngleInterpolationModule(ProcessingModule):
     """
 
     def __init__(self,
-                 name_in="angle_interpolation",
-                 data_tag="im_arr"):
+                 name_in='angle_interpolation',
+                 data_tag='im_arr'):
         """
         Parameters
         ----------
@@ -227,25 +227,25 @@ class AngleInterpolationModule(ProcessingModule):
             None
         """
 
-        parang_start = self.m_data_in_port.get_attribute("PARANG_START")
-        parang_end = self.m_data_in_port.get_attribute("PARANG_END")
+        parang_start = self.m_data_in_port.get_attribute('PARANG_START')
+        parang_end = self.m_data_in_port.get_attribute('PARANG_END')
 
-        steps = self.m_data_in_port.get_attribute("NFRAMES")
+        steps = self.m_data_in_port.get_attribute('NFRAMES')
 
-        if "NDIT" in self.m_data_in_port.get_all_non_static_attributes():
-            ndit = self.m_data_in_port.get_attribute("NDIT")
+        if 'NDIT' in self.m_data_in_port.get_all_non_static_attributes():
+            ndit = self.m_data_in_port.get_attribute('NDIT')
 
             if not np.all(ndit == steps):
-                warnings.warn("There is a mismatch between the NDIT and NFRAMES values. The "
-                              "parallactic angles are calculated with a linear interpolation by "
-                              "using NFRAMES steps. A frame selection should be applied after "
-                              "the parallactic angles are calculated.")
+                warnings.warn('There is a mismatch between the NDIT and NFRAMES values. The '
+                              'parallactic angles are calculated with a linear interpolation by '
+                              'using NFRAMES steps. A frame selection should be applied after '
+                              'the parallactic angles are calculated.')
 
         new_angles = []
 
         start_time = time.time()
         for i, _ in enumerate(parang_start):
-            progress(i, len(parang_start), "Running AngleInterpolationModule...", start_time)
+            progress(i, len(parang_start), 'Running AngleInterpolationModule...', start_time)
 
             if parang_start[i] < -170. and parang_end[i] > 170.:
                 parang_start[i] += 360.
@@ -258,10 +258,10 @@ class AngleInterpolationModule(ProcessingModule):
                                                parang_end[i],
                                                num=steps[i]))
 
-        sys.stdout.write("Running AngleInterpolationModule... [DONE]\n")
+        sys.stdout.write('Running AngleInterpolationModule... [DONE]\n')
         sys.stdout.flush()
 
-        self.m_data_out_port.add_attribute("PARANG",
+        self.m_data_out_port.add_attribute('PARANG',
                                            new_angles,
                                            static=False)
 
@@ -272,9 +272,9 @@ class SortParangModule(ProcessingModule):
     """
 
     def __init__(self,
-                 name_in="sort",
-                 image_in_tag="im_arr",
-                 image_out_tag="im_sort"):
+                 name_in='sort',
+                 image_in_tag='im_arr',
+                 image_out_tag='im_sort'):
         """
         Parameters
         ----------
@@ -311,22 +311,22 @@ class SortParangModule(ProcessingModule):
         self.m_image_out_port.del_all_attributes()
 
         if self.m_image_in_port.tag == self.m_image_out_port.tag:
-            raise ValueError("Input and output port should have a different tag.")
+            raise ValueError('Input and output port should have a different tag.')
 
-        memory = self._m_config_port.get_attribute("MEMORY")
-        index = self.m_image_in_port.get_attribute("INDEX")
+        memory = self._m_config_port.get_attribute('MEMORY')
+        index = self.m_image_in_port.get_attribute('INDEX')
 
         index_new = np.zeros(index.shape, dtype=np.int)
 
-        if "PARANG" in self.m_image_in_port.get_all_non_static_attributes():
-            parang = self.m_image_in_port.get_attribute("PARANG")
+        if 'PARANG' in self.m_image_in_port.get_all_non_static_attributes():
+            parang = self.m_image_in_port.get_attribute('PARANG')
             parang_new = np.zeros(parang.shape)
 
         else:
             parang_new = None
 
-        if "STAR_POSITION" in self.m_image_in_port.get_all_non_static_attributes():
-            star = self.m_image_in_port.get_attribute("STAR_POSITION")
+        if 'STAR_POSITION' in self.m_image_in_port.get_all_non_static_attributes():
+            star = self.m_image_in_port.get_attribute('STAR_POSITION')
             star_new = np.zeros(star.shape)
 
         else:
@@ -340,7 +340,7 @@ class SortParangModule(ProcessingModule):
 
         start_time = time.time()
         for i, _ in enumerate(frames[:-1]):
-            progress(i, len(frames[:-1]), "Running SortParangModule...", start_time)
+            progress(i, len(frames[:-1]), 'Running SortParangModule...', start_time)
 
             index_new[frames[i]:frames[i+1]] = index[index_sort[frames[i]:frames[i+1]]]
 
@@ -354,18 +354,18 @@ class SortParangModule(ProcessingModule):
             for _, item in enumerate(index_sort[frames[i]:frames[i+1]]):
                 self.m_image_out_port.append(self.m_image_in_port[item, ], data_dim=3)
 
-        sys.stdout.write("Running SortParangModule... [DONE]\n")
+        sys.stdout.write('Running SortParangModule... [DONE]\n')
         sys.stdout.flush()
 
         self.m_image_out_port.copy_attributes(self.m_image_in_port)
-        self.m_image_out_port.add_history("SortParangModule", "sorted by INDEX")
-        self.m_image_out_port.add_attribute("INDEX", index_new, static=False)
+        self.m_image_out_port.add_history('SortParangModule', 'sorted by INDEX')
+        self.m_image_out_port.add_attribute('INDEX', index_new, static=False)
 
         if parang_new is not None:
-            self.m_image_out_port.add_attribute("PARANG", parang_new, static=False)
+            self.m_image_out_port.add_attribute('PARANG', parang_new, static=False)
 
         if star_new is not None:
-            self.m_image_out_port.add_attribute("STAR_POSITION", star_new, static=False)
+            self.m_image_out_port.add_attribute('STAR_POSITION', star_new, static=False)
 
         self.m_image_out_port.close_port()
 
@@ -377,12 +377,12 @@ class AngleCalculationModule(ProcessingModule):
     the cube. Instrument specific overheads are included.
     """
 
-    __author__ = "Alexander Bohn"
+    __author__ = 'Alexander Bohn'
 
     def __init__(self,
-                 instrument="NACO",
-                 name_in="angle_calculation",
-                 data_tag="im_arr"):
+                 instrument='NACO',
+                 name_in='angle_calculation',
+                 data_tag='im_arr'):
         """
         Parameters
         ----------
@@ -405,7 +405,7 @@ class AngleCalculationModule(ProcessingModule):
         self.m_instrument = instrument
 
         # Set parameters according to choice of instrument
-        if self.m_instrument == "NACO":
+        if self.m_instrument == 'NACO':
 
             # pupil offset in degrees
             self.m_pupil_offset = 0.            # No offset here
@@ -419,7 +419,7 @@ class AngleCalculationModule(ProcessingModule):
             # rotator offset in degrees
             self.m_rot_offset = 89.44           # According to NACO manual page 65 (v102)
 
-        elif self.m_instrument == "SPHERE/IRDIS":
+        elif self.m_instrument == 'SPHERE/IRDIS':
 
             # pupil offset in degrees
             self.m_pupil_offset = -135.99       # According to SPHERE manual page 64 (v102)
@@ -432,7 +432,7 @@ class AngleCalculationModule(ProcessingModule):
             # rotator offset in degrees
             self.m_rot_offset = 0.              # no offset here
 
-        elif self.m_instrument == "SPHERE/IFS":
+        elif self.m_instrument == 'SPHERE/IFS':
 
             # pupil offset in degrees
             self.m_pupil_offset = -135.99 - 100.48  # According to SPHERE manual page 64 (v102)
@@ -446,8 +446,8 @@ class AngleCalculationModule(ProcessingModule):
             self.m_rot_offset = 0.                  # no offset here
 
         else:
-            raise ValueError("The instrument argument should be set to either 'NACO', "
-                             "'SPHERE/IRDIS', or 'SPHERE/IFS'.")
+            raise ValueError('The instrument argument should be set to either \'NACO\', '
+                             '\'SPHERE/IRDIS\', or \'SPHERE/IFS\'.')
 
         self.m_data_in_port = self.add_input_port(data_tag)
         self.m_data_out_port = self.add_output_port(data_tag)
@@ -466,36 +466,46 @@ class AngleCalculationModule(ProcessingModule):
         """
 
         # Load cube sizes
-        steps = self.m_data_in_port.get_attribute("NFRAMES")
-        ndit = self.m_data_in_port.get_attribute("NDIT")
+        steps = self.m_data_in_port.get_attribute('NFRAMES')
+        ndit = self.m_data_in_port.get_attribute('NDIT')
 
         if not np.all(ndit == steps):
-            warnings.warn("There is a mismatch between the NDIT and NFRAMES values. A frame "
-                          "selection should be applied after the parallactic angles are "
-                          "calculated.")
+            warnings.warn('There is a mismatch between the NDIT and NFRAMES values. A frame '
+                          'selection should be applied after the parallactic angles are '
+                          'calculated.')
 
-        if self.m_instrument == "SPHERE/IFS":
-            warnings.warn("AngleCalculationModule has not been tested for SPHERE/IFS data.")
+        if self.m_instrument == 'SPHERE/IFS':
+            warnings.warn('AngleCalculationModule has not been tested for SPHERE/IFS data.')
 
-        if self.m_instrument in ("SPHERE/IRDIS", "SPHERE/IFS"):
-            warnings.warn("For SPHERE data it is recommended to use the header keywords "
-                          "\"ESO INS4 DROT2 RA/DEC\" to specify the object's position. "
-                          "The input will be parsed accordingly. Using the regular "
-                          "RA/DEC parameters will lead to wrong parallactic angles.")
+        if self.m_instrument in ('SPHERE/IRDIS', 'SPHERE/IFS'):
+
+            if self._m_config_port.get_attribute('RA') != 'ESO INS4 DROT2 RA':
+
+                warnings.warn('For SPHERE data it is recommended to use the header keyword '
+                              '\'ESO INS4 DROT2 RA\' to specify the object\'s right ascension. '
+                              'The input will be parsed accordingly. Using the regular '
+                              '\'RA\' keyword will lead to wrong parallactic angles.')
+
+            if self._m_config_port.get_attribute('DEC') != 'ESO INS4 DROT2 DEC':
+
+                warnings.warn('For SPHERE data it is recommended to use the header keyword '
+                              '\'ESO INS4 DROT2 DEC\' to specify the object\'s declination. '
+                              'The input will be parsed accordingly. Using the regular '
+                              '\'DEC\' keyword will lead to wrong parallactic angles.')
 
         # Load exposure time [hours]
-        exptime = self.m_data_in_port.get_attribute("DIT")/3600.
+        exptime = self.m_data_in_port.get_attribute('DIT')/3600.
 
         # Load telescope location
-        tel_lat = self.m_data_in_port.get_attribute("LATITUDE")
-        tel_lon = self.m_data_in_port.get_attribute("LONGITUDE")
+        tel_lat = self.m_data_in_port.get_attribute('LATITUDE')
+        tel_lon = self.m_data_in_port.get_attribute('LONGITUDE')
 
         # Load temporary target position
-        tmp_ra = self.m_data_in_port.get_attribute("RA")
-        tmp_dec = self.m_data_in_port.get_attribute("DEC")
+        tmp_ra = self.m_data_in_port.get_attribute('RA')
+        tmp_dec = self.m_data_in_port.get_attribute('DEC')
 
         # Parse to degree depending on instrument
-        if "SPHERE" in self.m_instrument:
+        if 'SPHERE' in self.m_instrument:
 
             # get sign of declination
             tmp_dec_sign = np.sign(tmp_dec)
@@ -520,16 +530,16 @@ class AngleCalculationModule(ProcessingModule):
             dec = tmp_dec
 
         # Load start times of exposures
-        obs_dates = self.m_data_in_port.get_attribute("DATE")
+        obs_dates = self.m_data_in_port.get_attribute('DATE')
 
         # Load pupil positions during observations
-        if self.m_instrument == "NACO":
-            pupil_pos = self.m_data_in_port.get_attribute("PUPIL")
+        if self.m_instrument == 'NACO':
+            pupil_pos = self.m_data_in_port.get_attribute('PUPIL')
 
-        elif self.m_instrument == "SPHERE/IRDIS":
+        elif self.m_instrument == 'SPHERE/IRDIS':
             pupil_pos = np.zeros(steps.shape)
 
-        elif self.m_instrument == "SPHERE/IFS":
+        elif self.m_instrument == 'SPHERE/IFS':
             pupil_pos = np.zeros(steps.shape)
 
         new_angles = np.array([])
@@ -540,7 +550,7 @@ class AngleCalculationModule(ProcessingModule):
             t = Time(obs_dates[i].decode('utf-8'),
                      location=EarthLocation(lat=tel_lat, lon=tel_lon))
 
-            sid_time = t.sidereal_time("apparent").value
+            sid_time = t.sidereal_time('apparent').value
 
             # Extrapolate sideral times from start time of the cube for each frame of it
             sid_time_arr = np.linspace(sid_time+self.m_O_START,
@@ -567,15 +577,15 @@ class AngleCalculationModule(ProcessingModule):
             pupil_pos_arr = np.append(pupil_pos_arr, np.ones(tmp_steps)*pupil_pos[i])
 
         # Correct for rotator (SPHERE) or pupil offset (NACO)
-        if self.m_instrument == "NACO":
+        if self.m_instrument == 'NACO':
             # See NACO manual page 65 (v102)
             new_angles_corr = new_angles - (90. + (self.m_rot_offset-pupil_pos_arr))
 
-        elif self.m_instrument == "SPHERE/IRDIS":
+        elif self.m_instrument == 'SPHERE/IRDIS':
             # See SPHERE manual page 64 (v102)
             new_angles_corr = new_angles - self.m_pupil_offset
 
-        elif self.m_instrument == "SPHERE/IFS":
+        elif self.m_instrument == 'SPHERE/IFS':
             # See SPHERE manual page 64 (v102)
             new_angles_corr = new_angles - self.m_pupil_offset
 
@@ -587,9 +597,9 @@ class AngleCalculationModule(ProcessingModule):
         if indices.size > 0:
             new_angles_corr[indices] -= 360.
 
-        self.m_data_out_port.add_attribute("PARANG", new_angles_corr, static=False)
+        self.m_data_out_port.add_attribute('PARANG', new_angles_corr, static=False)
 
-        sys.stdout.write("Running AngleCalculationModule... [DONE]\n")
+        sys.stdout.write('Running AngleCalculationModule... [DONE]\n')
         sys.stdout.flush()
 
 
@@ -598,14 +608,14 @@ class SDIpreparationModule(ProcessingModule):
     Module for preparing continuum frames for SDI subtraction.
     """
 
-    __author__ = "Gabriele Cugno"
+    __author__ = 'Gabriele Cugno'
 
     def __init__(self,
                  wavelength,
                  width,
-                 name_in="SDI_preparation",
-                 image_in_tag="im_arr",
-                 image_out_tag="im_arr_SDI"):
+                 name_in='SDI_preparation',
+                 image_in_tag='im_arr',
+                 image_out_tag='im_arr_SDI'):
         """
         Parameters
         ----------
@@ -662,13 +672,9 @@ class SDIpreparationModule(ProcessingModule):
 
         start_time = time.time()
         for i in range(nimages):
-            progress(i, nimages, "Running SDIpreparationModule...", start_time)
+            progress(i, nimages, 'Running SDIpreparationModule...', start_time)
 
-            if nimages == 1:
-                image = self.m_image_in_port.get_all()
-
-            else:
-                image = self.m_image_in_port[i, ]
+            image = self.m_image_in_port[i, ]
 
             im_scale = width_factor * scale_image(image, wvl_factor, wvl_factor)
 
@@ -686,18 +692,14 @@ class SDIpreparationModule(ProcessingModule):
             im_crop = im_scale[npix_del_a:-npix_del_b, npix_del_a:-npix_del_b]
 
             if npix_del%2 == 1:
-                im_crop = shift_image(im_crop, (-0.5, -0.5), interpolation="spline")
+                im_crop = shift_image(im_crop, (-0.5, -0.5), interpolation='spline')
 
-            if nimages == 1:
-                self.m_image_out_port.set_all(im_crop)
+            self.m_image_out_port.append(im_crop, data_dim=3)
 
-            else:
-                self.m_image_out_port.append(im_crop, data_dim=3)
-
-        sys.stdout.write("Running SDIpreparationModule... [DONE]\n")
+        sys.stdout.write('Running SDIpreparationModule... [DONE]\n')
         sys.stdout.flush()
 
-        history = "(line, continuum) = ("+str(self.m_line_wvl)+", "+str(self.m_cnt_wvl)+")"
+        history = f'(line, continuum) = ({self.m_line_wvl}, {self.m_cnt_wvl})'
         self.m_image_out_port.copy_attributes(self.m_image_in_port)
-        self.m_image_out_port.add_history("SDIpreparationModule", history)
+        self.m_image_out_port.add_history('SDIpreparationModule', history)
         self.m_image_in_port.close_port()

--- a/pynpoint/readwrite/fitsreading.py
+++ b/pynpoint/readwrite/fitsreading.py
@@ -122,7 +122,7 @@ class FitsReadingModule(ReadingModule):
 
         hdulist.close()
 
-        header_out_port = self.add_output_port('fits_header/'+fits_file)
+        header_out_port = self.add_output_port('fits_header/'+os.path.basename(fits_file))
         header_out_port.set_all(fits_header)
 
         return header, images.shape

--- a/tests/test_processing/test_basic.py
+++ b/tests/test_processing/test_basic.py
@@ -5,10 +5,11 @@ import numpy as np
 
 from pynpoint.core.pypeline import Pypeline
 from pynpoint.readwrite.fitsreading import FitsReadingModule
-from pynpoint.processing.basic import SubtractImagesModule, AddImagesModule, RotateImagesModule
+from pynpoint.processing.basic import SubtractImagesModule, AddImagesModule, RotateImagesModule, \
+                                      RepeatImagesModule
 from pynpoint.util.tests import create_config, remove_test_data, create_star_data
 
-warnings.simplefilter("always")
+warnings.simplefilter('always')
 
 limit = 1e-10
 
@@ -16,9 +17,9 @@ class TestBasic:
 
     def setup_class(self):
 
-        self.test_dir = os.path.dirname(__file__) + "/"
+        self.test_dir = os.path.dirname(__file__) + '/'
 
-        create_star_data(path=self.test_dir+"data1",
+        create_star_data(path=self.test_dir+'data1',
                          npix_x=100,
                          npix_y=100,
                          x0=[50, 50, 50, 50],
@@ -27,7 +28,7 @@ class TestBasic:
                          parang_end=[25., 50., 75., 100.],
                          exp_no=[1, 2, 3, 4])
 
-        create_star_data(path=self.test_dir+"data2",
+        create_star_data(path=self.test_dir+'data2',
                          npix_x=100,
                          npix_y=100,
                          x0=[50, 50, 50, 50],
@@ -36,7 +37,7 @@ class TestBasic:
                          parang_end=[25., 50., 75., 100.],
                          exp_no=[1, 2, 3, 4])
 
-        create_star_data(path=self.test_dir+"data3",
+        create_star_data(path=self.test_dir+'data3',
                          npix_x=100,
                          npix_y=100,
                          x0=[50, 50, 50, 50],
@@ -45,100 +46,122 @@ class TestBasic:
                          parang_end=[25., 50., 75., 100.],
                          exp_no=[1, 2, 3, 4])
 
-        create_config(self.test_dir+"PynPoint_config.ini")
+        create_config(self.test_dir+'PynPoint_config.ini')
 
         self.pipeline = Pypeline(self.test_dir, self.test_dir, self.test_dir)
 
     def teardown_class(self):
 
-        remove_test_data(self.test_dir, folders=["data1", "data2", "data3"])
+        remove_test_data(self.test_dir, folders=['data1', 'data2', 'data3'])
 
     def test_read_data(self):
 
-        read = FitsReadingModule(name_in="read1",
-                                 image_tag="data1",
-                                 input_dir=self.test_dir+"data1",
-                                 overwrite=True,
-                                 check=True)
+        module = FitsReadingModule(name_in='read1',
+                                   image_tag='data1',
+                                   input_dir=self.test_dir+'data1',
+                                   overwrite=True,
+                                   check=True)
 
-        self.pipeline.add_module(read)
+        self.pipeline.add_module(module)
 
-        read = FitsReadingModule(name_in="read2",
-                                 image_tag="data2",
-                                 input_dir=self.test_dir+"data2",
-                                 overwrite=True,
-                                 check=True)
+        module = FitsReadingModule(name_in='read2',
+                                   image_tag='data2',
+                                   input_dir=self.test_dir+'data2',
+                                   overwrite=True,
+                                   check=True)
 
-        self.pipeline.add_module(read)
+        self.pipeline.add_module(module)
 
-        read = FitsReadingModule(name_in="read3",
-                                 image_tag="data3",
-                                 input_dir=self.test_dir+"data3",
-                                 overwrite=True,
-                                 check=True)
+        module = FitsReadingModule(name_in='read3',
+                                   image_tag='data3',
+                                   input_dir=self.test_dir+'data3',
+                                   overwrite=True,
+                                   check=True)
 
-        self.pipeline.add_module(read)
+        self.pipeline.add_module(module)
 
-        self.pipeline.run_module("read1")
-        self.pipeline.run_module("read2")
-        self.pipeline.run_module("read3")
+        self.pipeline.run_module('read1')
+        self.pipeline.run_module('read2')
+        self.pipeline.run_module('read3')
 
-        data = self.pipeline.get_data("data1")
+        data = self.pipeline.get_data('data1')
         assert np.allclose(data[0, 50, 50], 0.09798413502193704, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.00010029494781738066, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)
 
-        data = self.pipeline.get_data("data2")
+        data = self.pipeline.get_data('data2')
         assert np.allclose(data[0, 50, 50], 0.09798413502193704, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.00010029494781738066, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)
 
-        data = self.pipeline.get_data("data3")
+        data = self.pipeline.get_data('data3')
         assert np.allclose(data[0, 50, 50], 0.09798413502193704, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.00010029494781738066, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)
 
     def test_subtract_images(self):
 
-        subtract = SubtractImagesModule(image_in_tags=("data1", "data2"),
-                                        name_in="subtract",
-                                        image_out_tag="subtract",
-                                        scaling=1.)
+        module = SubtractImagesModule(name_in='subtract',
+                                      image_in_tags=('data1', 'data2'),
+                                      image_out_tag='subtract',
+                                      scaling=1.)
 
-        self.pipeline.add_module(subtract)
-        self.pipeline.run_module("subtract")
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('subtract')
 
-        data = self.pipeline.get_data("subtract")
+        data = self.pipeline.get_data('subtract')
         assert np.allclose(data[0, 50, 50], 0.0, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.0, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)
 
     def test_add_images(self):
 
-        add = AddImagesModule(image_in_tags=("data1", "data2"),
-                              name_in="add",
-                              image_out_tag="add",
-                              scaling=1.)
+        module = AddImagesModule(name_in='add',
+                                 image_in_tags=('data1', 'data2'),
+                                 image_out_tag='add',
+                                 scaling=1.)
 
-        self.pipeline.add_module(add)
-        self.pipeline.run_module("add")
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('add')
 
-        data = self.pipeline.get_data("add")
+        data = self.pipeline.get_data('add')
         assert np.allclose(data[0, 50, 50], 0.19596827004387407, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.00020058989563476133, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)
 
     def test_rotate_images(self):
 
-        rotate = RotateImagesModule(angle=10.,
-                                    name_in="rotate",
-                                    image_in_tag="data1",
-                                    image_out_tag="rotate")
+        module = RotateImagesModule(name_in='rotate',
+                                    image_in_tag='data1',
+                                    image_out_tag='rotate',
+                                    angle=10.)
 
-        self.pipeline.add_module(rotate)
-        self.pipeline.run_module("rotate")
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('rotate')
 
-        data = self.pipeline.get_data("rotate")
+        data = self.pipeline.get_data('rotate')
         assert np.allclose(data[0, 50, 50], 0.09746600632363736, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.00010030089755226848, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)
+
+    def test_repeat_images(self):
+
+        module = RepeatImagesModule(name_in='repeat',
+                                    image_in_tag='data1',
+                                    image_out_tag='repeat',
+                                    repeat=5)
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('repeat')
+
+        data1 = self.pipeline.get_data('data1')
+        assert data1.shape == (40, 100, 100)
+
+        data2 = self.pipeline.get_data('repeat')
+        assert data2.shape == (200, 100, 100)
+
+        assert np.allclose(data1, data2[0:40], rtol=limit, atol=0.)
+        assert np.allclose(data1, data2[40:80], rtol=limit, atol=0.)
+        assert np.allclose(data1, data2[80:120], rtol=limit, atol=0.)
+        assert np.allclose(data1, data2[120:160], rtol=limit, atol=0.)
+        assert np.allclose(data1, data2[160:200], rtol=limit, atol=0.)

--- a/tests/test_processing/test_psfpreparation.py
+++ b/tests/test_processing/test_psfpreparation.py
@@ -10,7 +10,7 @@ from pynpoint.processing.psfpreparation import PSFpreparationModule, AngleInterp
                                                AngleCalculationModule, SDIpreparationModule
 from pynpoint.util.tests import create_config, create_star_data, remove_test_data
 
-warnings.simplefilter("always")
+warnings.simplefilter('always')
 
 limit = 1e-10
 
@@ -19,40 +19,40 @@ class TestPsfPreparation:
 
     def setup_class(self):
 
-        self.test_dir = os.path.dirname(__file__) + "/"
+        self.test_dir = os.path.dirname(__file__) + '/'
 
-        create_star_data(path=self.test_dir+"prep")
-        create_config(self.test_dir+"PynPoint_config.ini")
+        create_star_data(path=self.test_dir+'prep')
+        create_config(self.test_dir+'PynPoint_config.ini')
 
         self.pipeline = Pypeline(self.test_dir, self.test_dir, self.test_dir)
 
     def teardown_class(self):
 
-        remove_test_data(self.test_dir, folders=["prep"])
+        remove_test_data(self.test_dir, folders=['prep'])
 
     def test_read_data(self):
 
-        module = FitsReadingModule(name_in="read",
-                                   image_tag="read",
-                                   input_dir=self.test_dir+"prep")
+        module = FitsReadingModule(name_in='read',
+                                   image_tag='read',
+                                   input_dir=self.test_dir+'prep')
 
         self.pipeline.add_module(module)
-        self.pipeline.run_module("read")
+        self.pipeline.run_module('read')
 
-        data = self.pipeline.get_data("read")
+        data = self.pipeline.get_data('read')
         assert np.allclose(data[0, 25, 25], 2.0926464668090656e-05, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.00010029494781738066, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)
 
     def test_angle_interpolation(self):
 
-        module = AngleInterpolationModule(name_in="angle1",
-                                          data_tag="read")
+        module = AngleInterpolationModule(name_in='angle1',
+                                          data_tag='read')
 
         self.pipeline.add_module(module)
-        self.pipeline.run_module("angle1")
+        self.pipeline.run_module('angle1')
 
-        data = self.pipeline.get_data("header_read/PARANG")
+        data = self.pipeline.get_data('header_read/PARANG')
         assert np.allclose(data[0], 0., rtol=limit, atol=0.)
         assert np.allclose(data[15], 7.777777777777778, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 10.0, rtol=limit, atol=0.)
@@ -60,98 +60,114 @@ class TestPsfPreparation:
 
     def test_angle_calculation(self):
 
-        self.pipeline.set_attribute("read", "LATITUDE", -25.)
-        self.pipeline.set_attribute("read", "LONGITUDE", -70.)
-        self.pipeline.set_attribute("read", "DIT", 1.)
+        self.pipeline.set_attribute('read', 'LATITUDE', -25.)
+        self.pipeline.set_attribute('read', 'LONGITUDE', -70.)
+        self.pipeline.set_attribute('read', 'DIT', 1.)
 
-        self.pipeline.set_attribute("read", "RA", (90., 90., 90., 90.), static=False)
-        self.pipeline.set_attribute("read", "DEC", (-51., -51., -51., -51.), static=False)
-        self.pipeline.set_attribute("read", "PUPIL", (90., 90., 90., 90.), static=False)
+        self.pipeline.set_attribute('read', 'RA', (90., 90., 90., 90.), static=False)
+        self.pipeline.set_attribute('read', 'DEC', (-51., -51., -51., -51.), static=False)
+        self.pipeline.set_attribute('read', 'PUPIL', (90., 90., 90., 90.), static=False)
 
-        date = ("2012-12-01T07:09:00.0000", "2012-12-01T07:09:01.0000",
-                "2012-12-01T07:09:02.0000", "2012-12-01T07:09:03.0000")
+        date = ('2012-12-01T07:09:00.0000', '2012-12-01T07:09:01.0000',
+                '2012-12-01T07:09:02.0000', '2012-12-01T07:09:03.0000')
 
-        self.pipeline.set_attribute("read", "DATE", date, static=False)
+        self.pipeline.set_attribute('read', 'DATE', date, static=False)
 
-        module = AngleCalculationModule(instrument="NACO",
-                                        name_in="angle2",
-                                        data_tag="read")
+        module = AngleCalculationModule(instrument='NACO',
+                                        name_in='angle2',
+                                        data_tag='read')
 
         self.pipeline.add_module(module)
-        self.pipeline.run_module("angle2")
+        self.pipeline.run_module('angle2')
 
-        data = self.pipeline.get_data("header_read/PARANG")
+        data = self.pipeline.get_data('header_read/PARANG')
         assert np.allclose(data[0], -55.04109770947442, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), -54.99858360618869, rtol=limit, atol=0.)
         assert data.shape == (40, )
 
-        self.pipeline.set_attribute("read", "RA", (60000.0, 60000.0, 60000.0, 60000.0), static=False)
-        self.pipeline.set_attribute("read", "DEC", (-510000., -510000., -510000., -510000.), static=False)
+        self.pipeline.set_attribute('read', 'RA', (60000.0, 60000.0, 60000.0, 60000.0), static=False)
 
-        module = AngleCalculationModule(instrument="SPHERE/IRDIS",
-                                        name_in="angle3",
-                                        data_tag="read")
+        self.pipeline.set_attribute('read', 'DEC', (-510000., -510000., -510000., -510000.), static=False)
+
+        module = AngleCalculationModule(instrument='SPHERE/IRDIS',
+                                        name_in='angle3',
+                                        data_tag='read')
 
         self.pipeline.add_module(module)
 
         with pytest.warns(UserWarning) as warning:
-            self.pipeline.run_module("angle3")
+            self.pipeline.run_module('angle3')
 
-        assert len(warning) == 1
-        assert warning[0].message.args[0] == "For SPHERE data it is recommended to use the " \
-                                             "header keywords \"ESO INS4 DROT2 RA/DEC\" to " \
-                                             "specify the object's position. The input will be " \
-                                             "parsed accordingly. Using the regular RA/DEC "\
-                                             "parameters will lead to wrong parallactic angles." \
+        assert len(warning) == 2
 
-        data = self.pipeline.get_data("header_read/PARANG")
+        assert warning[0].message.args[0] == 'For SPHERE data it is recommended to use the ' \
+                                             'header keyword \'ESO INS4 DROT2 RA\' to specify ' \
+                                             'the object\'s right ascension. The input will be ' \
+                                             'parsed accordingly. Using the regular \'RA\' '\
+                                             'keyword will lead to wrong parallactic angles.' \
+
+        assert warning[1].message.args[0] == 'For SPHERE data it is recommended to use the ' \
+                                             'header keyword \'ESO INS4 DROT2 DEC\' to specify ' \
+                                             'the object\'s declination. The input will be ' \
+                                             'parsed accordingly. Using the regular \'DEC\' '\
+                                             'keyword will lead to wrong parallactic angles.' \
+
+        data = self.pipeline.get_data('header_read/PARANG')
         assert np.allclose(data[0], 170.39102715170227, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 170.46341123194824, rtol=limit, atol=0.)
         assert data.shape == (40, )
 
-        module = AngleCalculationModule(instrument="SPHERE/IFS",
-                                        name_in="angle4",
-                                        data_tag="read")
+        module = AngleCalculationModule(instrument='SPHERE/IFS',
+                                        name_in='angle4',
+                                        data_tag='read')
 
         self.pipeline.add_module(module)
 
         with pytest.warns(UserWarning) as warning:
-            self.pipeline.run_module("angle4")
+            self.pipeline.run_module('angle4')
 
-        assert len(warning) == 2
-        assert warning[0].message.args[0] == "AngleCalculationModule has not been tested for " \
-                                             "SPHERE/IFS data."
-        assert warning[1].message.args[0] == "For SPHERE data it is recommended to use the " \
-                                             "header keywords \"ESO INS4 DROT2 RA/DEC\" to " \
-                                             "specify the object's position. The input will be " \
-                                             "parsed accordingly. Using the regular RA/DEC "\
-                                             "parameters will lead to wrong parallactic angles." \
+        assert len(warning) == 3
 
-        data = self.pipeline.get_data("header_read/PARANG")
+        assert warning[0].message.args[0] == 'AngleCalculationModule has not been tested for ' \
+                                             'SPHERE/IFS data.'
+
+        assert warning[1].message.args[0] == 'For SPHERE data it is recommended to use the ' \
+                                             'header keyword \'ESO INS4 DROT2 RA\' to specify ' \
+                                             'the object\'s right ascension. The input will be ' \
+                                             'parsed accordingly. Using the regular \'RA\' '\
+                                             'keyword will lead to wrong parallactic angles.' \
+
+        assert warning[2].message.args[0] == 'For SPHERE data it is recommended to use the ' \
+                                             'header keyword \'ESO INS4 DROT2 DEC\' to specify ' \
+                                             'the object\'s declination. The input will be ' \
+                                             'parsed accordingly. Using the regular \'DEC\' '\
+                                             'keyword will lead to wrong parallactic angles.' \
+
+        data = self.pipeline.get_data('header_read/PARANG')
         assert np.allclose(data[0], -89.12897284829768, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), -89.02755918786514, rtol=limit, atol=0.)
         assert data.shape == (40, )
 
     def test_angle_interpolation_mismatch(self):
 
-        self.pipeline.set_attribute("read", "NDIT", [9, 9, 9, 9], static=False)
+        self.pipeline.set_attribute('read', 'NDIT', [9, 9, 9, 9], static=False)
 
-        module = AngleInterpolationModule(name_in="angle5",
-                                          data_tag="read")
+        module = AngleInterpolationModule(name_in='angle5',
+                                          data_tag='read')
 
         self.pipeline.add_module(module)
 
         with pytest.warns(UserWarning) as warning:
-            self.pipeline.run_module("angle5")
+            self.pipeline.run_module('angle5')
 
         assert len(warning) == 1
-        assert warning[0].message.args[0] == "There is a mismatch between the NDIT and NFRAMES " \
-                                             "values. The parallactic angles are calculated " \
-                                             "with a linear interpolation by using NFRAMES " \
-                                             "steps. A frame selection should be applied " \
-                                             "after the parallactic angles are calculated."
+        assert warning[0].message.args[0] == 'There is a mismatch between the NDIT and NFRAMES ' \
+                                             'values. The parallactic angles are calculated ' \
+                                             'with a linear interpolation by using NFRAMES ' \
+                                             'steps. A frame selection should be applied ' \
+                                             'after the parallactic angles are calculated.'
 
-        data = self.pipeline.get_data("header_read/PARANG")
+        data = self.pipeline.get_data('header_read/PARANG')
         assert np.allclose(data[0], 0., rtol=limit, atol=0.)
         assert np.allclose(data[15], 7.777777777777778, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 10.0, rtol=limit, atol=0.)
@@ -159,24 +175,24 @@ class TestPsfPreparation:
 
     def test_psf_preparation_norm_mask(self):
 
-        module = PSFpreparationModule(name_in="prep1",
-                                      image_in_tag="read",
-                                      image_out_tag="prep1",
-                                      mask_out_tag="mask1",
+        module = PSFpreparationModule(name_in='prep1',
+                                      image_in_tag='read',
+                                      image_out_tag='prep1',
+                                      mask_out_tag='mask1',
                                       norm=True,
                                       cent_size=0.1,
                                       edge_size=1.0)
 
         self.pipeline.add_module(module)
-        self.pipeline.run_module("prep1")
+        self.pipeline.run_module('prep1')
 
-        data = self.pipeline.get_data("prep1")
+        data = self.pipeline.get_data('prep1')
         assert np.allclose(data[0, 0, 0], 0., rtol=limit, atol=0.)
         assert np.allclose(data[0, 99, 99], 0., rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.0001690382058762809, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)
 
-        data = self.pipeline.get_data("mask1")
+        data = self.pipeline.get_data('mask1')
         assert np.allclose(data[0, 0], 0., rtol=limit, atol=0.)
         assert np.allclose(data[99, 99], 0., rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 0.4268, rtol=limit, atol=0.)
@@ -184,18 +200,18 @@ class TestPsfPreparation:
 
     def test_psf_preparation_none(self):
 
-        module = PSFpreparationModule(name_in="prep2",
-                                      image_in_tag="read",
-                                      image_out_tag="prep2",
-                                      mask_out_tag="mask2",
+        module = PSFpreparationModule(name_in='prep2',
+                                      image_in_tag='read',
+                                      image_out_tag='prep2',
+                                      mask_out_tag='mask2',
                                       norm=False,
                                       cent_size=None,
                                       edge_size=None)
 
         self.pipeline.add_module(module)
-        self.pipeline.run_module("prep2")
+        self.pipeline.run_module('prep2')
 
-        data = self.pipeline.get_data("prep2")
+        data = self.pipeline.get_data('prep2')
         assert np.allclose(data[0, 0, 0], 0.00032486907273264834, rtol=limit, atol=0.)
         assert np.allclose(data[0, 25, 25], 2.0926464668090656e-05, rtol=limit, atol=0.)
         assert np.allclose(data[0, 99, 99], -0.000287573978535779, rtol=limit, atol=0.)
@@ -204,18 +220,18 @@ class TestPsfPreparation:
 
     def test_psf_preparation_no_mask_out(self):
 
-        module = PSFpreparationModule(name_in="prep3",
-                                      image_in_tag="read",
-                                      image_out_tag="prep3",
+        module = PSFpreparationModule(name_in='prep3',
+                                      image_in_tag='read',
+                                      image_out_tag='prep3',
                                       mask_out_tag=None,
                                       norm=False,
                                       cent_size=None,
                                       edge_size=None)
 
         self.pipeline.add_module(module)
-        self.pipeline.run_module("prep3")
+        self.pipeline.run_module('prep3')
 
-        data = self.pipeline.get_data("prep3")
+        data = self.pipeline.get_data('prep3')
         assert np.allclose(data[0, 0, 0], 0.00032486907273264834, rtol=limit, atol=0.)
         assert np.allclose(data[0, 25, 25], 2.0926464668090656e-05, rtol=limit, atol=0.)
         assert np.allclose(data[0, 99, 99], -0.000287573978535779, rtol=limit, atol=0.)
@@ -224,19 +240,19 @@ class TestPsfPreparation:
 
     def test_sdi_preparation(self):
 
-        module = SDIpreparationModule(name_in="sdi",
+        module = SDIpreparationModule(name_in='sdi',
                                       wavelength=(0.65, 0.6),
                                       width=(0.1, 0.5),
-                                      image_in_tag="read",
-                                      image_out_tag="sdi")
+                                      image_in_tag='read',
+                                      image_out_tag='sdi')
 
         self.pipeline.add_module(module)
-        self.pipeline.run_module("sdi")
+        self.pipeline.run_module('sdi')
 
-        data = self.pipeline.get_data("sdi")
+        data = self.pipeline.get_data('sdi')
         assert np.allclose(data[0, 25, 25], -2.6648118007008814e-05, rtol=limit, atol=0.)
         assert np.allclose(np.mean(data), 2.0042892634995876e-05, rtol=limit, atol=0.)
         assert data.shape == (40, 100, 100)
 
-        attribute = self.pipeline.get_attribute("sdi", "History: SDIpreparationModule")
-        assert attribute == "(line, continuum) = (0.65, 0.6)"
+        attribute = self.pipeline.get_attribute('sdi', 'History: SDIpreparationModule')
+        assert attribute == '(line, continuum) = (0.65, 0.6)'


### PR DESCRIPTION
- `RepeatImagesModule` in `processing.basic` which simply repeats the images of a dataset a specified number of times.

- Test case for `RepeatImagesModule`.

- Type checks in the pipeline modules of `basic` and `resizing`.

- Adjusted the warning in `AngleCalculationModule` regarding using the correct RA and DEC with SPHERE data. It checks the values in the config group of the database and only prints the warning if the values are different from what is expected.

- Removed the special case of `nimages == 1` in `SDIpreparationModule` since image datasets are always stored as 3D arrays.