### PR TITLE
NEAR documentation update

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,6 +42,8 @@ PynPoint is actively being developed. To update the installation to the latest v
 
    $ pip install --upgrade PynPoint
 
+.. _installation_github:
+
 Installation from Github
 ------------------------
 

--- a/docs/near.rst
+++ b/docs/near.rst
@@ -19,7 +19,7 @@ Please also have a look at the :ref:`attribution` section when using PynPoint re
 Example
 -------
 
-In this example, we will process the images of chop A for which alpha Cen A was centered behind the AGPM coronagraph. Note that the same procedure can be applied on the images of chop B (i.e., with alpha Cen B centered behind the coronagraph).
+In this example, we will process the images of chop A (i.e., frames in which alpha Cen A was centered behind the AGPM coronagraph). Note that the same procedure can be applied on the images of chop B (i.e., with alpha Cen B centered behind the coronagraph).
 
 Setup
 ^^^^^
@@ -33,6 +33,8 @@ The results shown below are based on 1 hour of commissioning data of alpha Cen. 
 And then execute it as::
 
    $ ./near_files.sh
+
+You can also start by downloading only a few files by running a subset of the bash script lines (useful for validating the pipeline installation because analyzing the full data set takes hours).
 
 Now that we have the data, we can start the data reduction with PynPoint!
 
@@ -74,7 +76,7 @@ Running PynPoint
 
 Example code snippets for the different steps to reduce NEAR data with PynPoint are included below. These code snippets can be executed in Python interactive mode, as a Jupyter notebook.py file, or combined into a python script and executed from the command line.
 
-The first steps are to initialize the pipeline and read in the data contained in the given ``input_place_in`` directory. Data are automatically divided into the chop A and chop B data sets. Here we also use the :class:`~pynpoint.processing.psfpreparation.AngleInterpolationModule` to calculate the parallactic angle for each individual frame, which is necessary for de-rotating and stacking of the frames after PSF subtraction::
+The first steps are to initialize the pipeline and read in the data contained in the given ``input_place_in`` directory. Data are automatically divided into the chop A and chop B data sets. Here we also use the :class:`~pynpoint.processing.psfpreparation.AngleInterpolationModule` to calculate the parallactic angle for each individual frame, which is necessary for derotating and combining the frames after PSF subtraction::
 
    # Import the Pypeline and the modules that we will use in this example
 
@@ -84,7 +86,7 @@ The first steps are to initialize the pipeline and read in the data contained in
                         FakePlanetModule, PSFpreparationModule, PcaPsfSubtractionModule, \
                         ContrastCurveModule, FitsWritingModule, TextWritingModule
 
-   # Create a Pypeline instance
+   # Create a Pypeline instance (change the directories to the correct paths)
 
    pipeline = Pypeline(working_place_in='working_folder/',  # directory for database and config files
                        input_place_in='input_folder/',      # default directory for reading in input data
@@ -114,11 +116,14 @@ The first steps are to initialize the pipeline and read in the data contained in
 
    pipeline.add_module(module)
 
-   # Run each of the above modules
+   # Run each of the above modules using their 'name_in' tags
    
    pipeline.run_module('read')
    pipeline.run_module('angle1')
    pipeline.run_module('angle2')
+   
+   # Note that you can also run all the added modules using this function:
+   # pipeline.run()
    
 The next step is to reduce the chop A frames with alpha Cen A behind the corognagraph. Here we crop the chop A and chop B images around the coronagraph position, subtract chop B from chop A to remove the sky background, and center the subtracted chop A frames::
 
@@ -176,16 +181,13 @@ The next step is to reduce the chop A frames with alpha Cen A behind the corogna
 
    pipeline.add_module(module)
    
-   # Run each of the above modules using their 'name_in' tags
+   # Run each of the above modules
    
    pipeline.run_module('crop1')
    pipeline.run_module('crop2')
    pipeline.run_module('subtract_aminusb')
    pipeline.run_module('center1')
    pipeline.run_module('shift1')
-   
-   # Note that you can also run all the added modules using this function:
-   # pipeline.run()
 
 
 Next, we use the chop B frames where alpha Cen A if off of the coronagraph to extract a reference PSF. This reference PSF will later be used for calculating the detection limits::
@@ -272,7 +274,7 @@ Next, we use the chop B frames where alpha Cen A if off of the coronagraph to ex
    pipeline.run_module('shift_refpsf')
    pipeline.run_module('prep_refpsf')
 
-Finally, we use PCA to subtract the stellar PSF of alpha Cen A. For testing purposes, we first use the reference PSF created above to inject a fake planet into the chop A data. The median combination of the PSF-subtracted frames is saved in its own tag and then written out to a fits file::
+Finally, we use PCA to subtract the stellar PSF of alpha Cen A. For testing purposes, we first use the reference PSF created above to inject a fake planet into the chop A data. The median combination of the PSF-subtracted and derotated frames is saved in its own tag and then written out to a fits file::
 
    # Inject a fake planet at a separation of 1 arcsec and a contrast of 10 mag
 

--- a/docs/near.rst
+++ b/docs/near.rst
@@ -28,7 +28,7 @@ Now that we have the data, we can start the data reduction with PynPoint!
 
 The :class:`~pynpoint.core.pypeline.Pypeline` of PynPoint requires a folder for the ``working_place``, ``input_place``, and ``output_place``. These are the working folder with the database and configuration file, the default data input folder, and default output folder for results, respectively. Before we start running PynPoint, we have to put the raw NEAR data in the default input folder or the location that will provided as ``input_dir`` in the :class:`~pynpoint.readwrite.nearreading.NearReadingModule`.
 
-A basic description of the pipeline modules is given in the comments of the example script. More in-depth information of all the input parameters can be found in the :ref:`api`. In the example, we will only process the images of chop A for which alpha Cen A was centered behind the AGPM coronagraph. The same procedure can be applied on the images of chop B (i.e. alpha Cen B).
+A basic description of the pipeline modules is given in the comments of the example script. More in-depth information of all the input parameters can be found in the :ref:`api`. In the example, we will only process the images of chop A for which alpha Cen A was centered behind the AGPM coronagraph. The same procedure can be applied on the images of chop B (i.e., with alpha Cen B centered behind the coronagraph).
 
 First we create a configuration file which contains the global pipeline settings and is used to select the required FITS header keywords. Create a text file called ``PynPoint_config.ini`` in the ``working_place`` folder with the following content::
 
@@ -58,7 +58,11 @@ First we create a configuration file which contains the global pipeline settings
 
 The ``MEMORY`` and ``CPU`` setting can be adjusted. They define the number of images that is simultaneously loaded into the computer memory and the number of parallel processes that are used by some of the pipeline modules.
 
-Pipeline modules are added sequentially to the pipeline and are executed either individually or all at once (see end of the example script). Each pipeline module requires a ``name_in`` tag which is used as identifier by the pipeline. All intermediate results (typically a stack of images) are stored in the database (`PynPoint_database.hdf5`) which allows the user to rerun particular processing steps without having to rerun the complete pipeline. The script below can now be executed as a text file from the command line, in Python interactive mode, or as a Jupyter notebook::
+Pipeline modules are added sequentially to the pipeline. Each pipeline module requires a ``name_in`` tag which is used by the pipeline to identifiy the module. Once added, modules can be executed either individually using ``pipeline.run_module(name_in)``, which takes the module's ``name_in`` tag as input, or all at once using using ``pipeline.run()``. All intermediate results (typically a stack of images) are stored in the database (`PynPoint_database.hdf5`) which allows the user to rerun particular processing steps without having to rerun the complete pipeline. 
+
+Example code snippets for the different steps to reduce NEAR data are included below. These code snippets can be executed in Python interactive mode, as a Jupyter notebook.py file, or combined into a python script and executed from the command line.
+
+The first steps are to initialize the pipeline and read in the data contained in the given ``input_place_in`` directory. Data are automatically divided into the chop A and chop B data sets. Here we also use the :class:`~pynpoint.processing.psfpreparation.AngleInterpolationModule` to calculate the parallactic angle for each individual frame, which is necessary for de-rotating and stacking of the frames after PSF subtraction::
 
    # Import the Pypeline and the modules that we will use in this example
 
@@ -70,11 +74,13 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    # Create a Pypeline instance
 
-   pipeline = Pypeline(working_place_in='working_folder/',
-                       input_place_in='input_folder/',
-                       output_place_in='output_folder/')
+   pipeline = Pypeline(working_place_in='working_folder/',  # directory in which PynPoint_database.hdf5 is saved
+                       input_place_in='input_folder/',      # default directory for reading in input data
+                       output_place_in='output_folder/')    # default directory for saving output files 
+                                                            #   (i.e., with FitsWritingModule used below)
 
-   # Read the raw data and separate the chop A and chop B images
+   # Read the raw data (i.e., all the fits files contained in the input_place_in folder above) 
+   # and separate the chop A and chop B images
 
    module = NearReadingModule(name_in='read',
                               input_dir=None,
@@ -96,6 +102,14 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    pipeline.add_module(module)
 
+   # Run each of the above modules
+   
+   pipeline.run_module('read')
+   pipeline.run_module('angle1')
+   pipeline.run_module('angle2')
+   
+The next step is to reduce the chop A frames with alpha Cen A behind the corognagraph. Here we crop the chop A and chop B images around the coronagraph position, subtract chop B from chop A to remove the sky background, and center the subtracted chop A frames::
+
    # Crop the chop A and chop B images around the approximate coronagraph position
 
    module = CropImagesModule(size=5.,
@@ -114,48 +128,12 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    pipeline.add_module(module)
 
-   # Subtract chop A from chop B before extracting the non-coronagraphic PSF
-
-   module = SubtractImagesModule(name_in='subtract1',
-                                 image_in_tags=('chopb', 'chopa'),
-                                 image_out_tag='chopb_sub',
-                                 scaling=1.)
-
-   pipeline.add_module(module)
-
-   # Crop out the non-coronagraphic PSF for chop A from the chop B images
-
-   module = ExtractBinaryModule(pos_center=(432., 287.),
-                                pos_binary=(430., 175.),
-                                name_in='extract',
-                                image_in_tag='chopb_sub',
-                                image_out_tag='psfa',
-                                image_size=5.,
-                                search_size=1.,
-                                filter_size=None)
-
-   pipeline.add_module(module)
-
    # Subtract frame-by-frame chop B from chop A
 
-   module = SubtractImagesModule(name_in='subtract2',
+   module = SubtractImagesModule(name_in='subtract_aminusb',
                                  image_in_tags=('chopa_crop', 'chopb_crop'),
                                  image_out_tag='chopa_sub',
                                  scaling=1.)
-
-   pipeline.add_module(module)
-
-   # Align the non-coronagraphic PSF images
-
-   module = StarAlignmentModule(name_in='align',
-                                image_in_tag='psfa',
-                                ref_image_in_tag=None,
-                                image_out_tag='psfa_align',
-                                interpolation='spline',
-                                accuracy=10,
-                                resize=None,
-                                num_references=10,
-                                subframe=1.)
 
    pipeline.add_module(module)
 
@@ -175,9 +153,66 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    pipeline.add_module(module)
 
+
+   # Center the chop-subtracted images
+
+   module = ShiftImagesModule(shift_xy='chopa_fit',
+                              name_in='shift1',
+                              image_in_tag='chopa_sub',
+                              image_out_tag='chopa_center',
+                              interpolation='spline')
+
+   pipeline.add_module(module)
+   
+   # Run each of the above modules
+   
+   pipeline.run_module('crop1')
+   pipeline.run_module('crop2')
+   pipeline.run_module('subtract_aminusb')
+   pipeline.run_module('center1')
+   pipeline.run_module('shift1')
+
+Next, we use the chop B frames where alpha Cen A if off of the coronagraph to extract a reference PSF. This reference PSF will later be used for calculating the detection limits::
+
+   # Subtract chop A from chop B before extracting the non-coronagraphic PSF
+
+   module = SubtractImagesModule(name_in='subtract_bminusa',
+                                 image_in_tags=('chopb', 'chopa'),
+                                 image_out_tag='chopb_sub',
+                                 scaling=1.)
+
+   pipeline.add_module(module)
+
+   # Crop out the non-coronagraphic PSF for chop A from the chop B images
+
+   module = ExtractBinaryModule(pos_center=(432., 287.),
+                                pos_binary=(430., 175.),
+                                name_in='extract_refpsf',
+                                image_in_tag='chopb_sub',
+                                image_out_tag='psfa',
+                                image_size=5.,
+                                search_size=1.,
+                                filter_size=None)
+
+   pipeline.add_module(module)
+
+   # Align the non-coronagraphic PSF images
+
+   module = StarAlignmentModule(name_in='align_refpsf',
+                                image_in_tag='psfa',
+                                ref_image_in_tag=None,
+                                image_out_tag='psfa_align',
+                                interpolation='spline',
+                                accuracy=10,
+                                resize=None,
+                                num_references=10,
+                                subframe=1.)
+
+   pipeline.add_module(module)
+
    # Fit the center position of the mean, non-coronagraphic PSF
 
-   module = FitCenterModule(name_in='center2',
+   module = FitCenterModule(name_in='center_refpsf',
                             image_in_tag='psfa',
                             fit_out_tag='psfa_fit',
                             mask_out_tag=None,
@@ -190,20 +225,10 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    pipeline.add_module(module)
 
-   # Center the chop-subtracted images
-
-   module = ShiftImagesModule(shift_xy='chopa_fit',
-                              name_in='shift1',
-                              image_in_tag='chopa_sub',
-                              image_out_tag='chopa_center',
-                              interpolation='spline')
-
-   pipeline.add_module(module)
-
    # Center the non-coronagraphic PSF images
 
    module = ShiftImagesModule(shift_xy='psfa_fit',
-                              name_in='shift2',
+                              name_in='shift_refpsf',
                               image_in_tag='psfa',
                               image_out_tag='psfa_center',
                               interpolation='spline')
@@ -212,7 +237,7 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    # Mask the non-coronagraphic PSF beyond 1 arsec
 
-   module = PSFpreparationModule(name_in='prep1',
+   module = PSFpreparationModule(name_in='prep_refpsf',
                                  image_in_tag='psfa_center',
                                  image_out_tag='psfa_mask',
                                  mask_out_tag=None,
@@ -221,6 +246,17 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
                                  edge_size=1.)
 
    pipeline.add_module(module)
+   
+   # Run each of the above modules
+   
+   pipeline.run_module('subtract_bminusa')
+   pipeline.run_module('extract_refpsf')
+   pipeline.run_module('align_refpsf')
+   pipeline.run_module('center_refpsf')
+   pipeline.run_module('shift_refpsf')
+   pipeline.run_module('prep_refpsf')
+
+Finally, we use PCA to subtract the stellar PSF of alpha Cen A. For testing purposes, we first use the reference PSF created above to inject a fake planet into the chop A data. The median combination of the PSF-subtracted frames is saved in its own tag and then written out to a fits file::
 
    # Inject a fake planet at a separation of 1 arcsec and a contrast of 10 mag
 
@@ -237,7 +273,7 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    # Mask the central and outer part of the chop A images
 
-   module = PSFpreparationModule(name_in='prep2',
+   module = PSFpreparationModule(name_in='prep_data',
                                  image_in_tag='chopa_fake',
                                  image_out_tag='chopa_prep',
                                  mask_out_tag=None,
@@ -257,6 +293,27 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
                                     extra_rot=0.0)
 
    pipeline.add_module(module)
+   
+   # Datasets can be exported to FITS files by their tag name in the database
+   # Here we will export the median-combined residuals of the PSF subtraction
+
+   module = FitsWritingModule(name_in='write_result_psfsub',
+                              file_name='chopa_pca.fits',
+                              output_dir=None,
+                              data_tag='chopa_pca',
+                              data_range=None,
+                              overwrite=True)
+
+   pipeline.add_module(module)
+   
+   # Run each of the above modules
+   
+   pipeline.run_module('fake')
+   pipeline.run_module('prep_data')
+   pipeline.run_module('pca')
+   pipeline.run_module('write_result_psfsub')
+
+PynPoint also includes a module to calculate the detection limits of the final image::
 
    # Calculate detection limits between 0.8 and 2.0 arcsec
    # The false positive fraction is fixed to 2.87e-6 (i.e. 5 sigma for Gaussian statistics)
@@ -278,23 +335,11 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
  
    pipeline.add_module(module)
 
-   # Datasets can be exported to FITS files by their tag name in the database
-   # Here we will export the median-combined residuals of the PSF subtraction
-
-   module = FitsWritingModule(name_in='write1',
-                              file_name='chopa_pca.fits',
-                              output_dir=None,
-                              data_tag='chopa_pca',
-                              data_range=None,
-                              overwrite=True)
-
-   pipeline.add_module(module)
-
    # And we write the detection limits to a text file
 
    header = 'Separation [arcsec] - Contrast [mag] - Variance [mag] - FPF'
 
-   module = TextWritingModule(name_in='write2',
+   module = TextWritingModule(name_in='write_result_limits',
                               file_name='contrast_curve.dat',
                               output_dir=None,
                               data_tag='limits',
@@ -302,13 +347,10 @@ Pipeline modules are added sequentially to the pipeline and are executed either 
 
    pipeline.add_module(module)
 
-   # Finally, to run all pipeline modules at once
-
-   pipeline.run()
-
-   # Or to run a module individually
-
-   pipeline.run_module('read')
+   # Run each of the above modules
+   
+   pipeline.run_module('limits')
+   pipeline.run_module('write_result_limits')
 
 .. _near_results:
 

--- a/docs/near.rst
+++ b/docs/near.rst
@@ -9,7 +9,7 @@ Introduction
 ------------
 
 The documentation on this page contains an introduction into data reduction of the modified |visir| instrument for the |near| (New Earths in the
-Alpha Cen Region) experiment. The basic processing steps with PynPoint are described in the example below while a complete overview of all available pipeline modules can be found in the :ref:`overview` section. To get started, installation instructions are available in the :ref:`installation` section. Please have a look at the :ref:`attribution` section when using PynPoint results in a publication. Further details about the pipeline architecture and data processing are also available in |stolker|.
+Alpha Cen Region) experiment. The basic processing steps with PynPoint are described in the example below while a complete overview of all available pipeline modules can be found in the :ref:`overview` section. To get started, use the instructions available in the :ref:`installation_github` section. Please have a look at the :ref:`attribution` section when using PynPoint results in a publication. Further details about the pipeline architecture and data processing are also available in |stolker|.
 
 .. _near_example:
 
@@ -74,7 +74,7 @@ The first steps are to initialize the pipeline and read in the data contained in
 
    # Create a Pypeline instance
 
-   pipeline = Pypeline(working_place_in='working_folder/',  # directory in which PynPoint_database.hdf5 is saved
+   pipeline = Pypeline(working_place_in='working_folder/',  # directory for PynPoint_database.hdf5 file
                        input_place_in='input_folder/',      # default directory for reading in input data
                        output_place_in='output_folder/')    # default directory for saving output files 
                                                             #   (i.e., with FitsWritingModule used below)


### PR DESCRIPTION
Reorganized the NEAR documentation following testing feedback. The main change was dividing the example script into subsections, each with additional explanations, and reordering the pipeline modules for clarity. The installation instructions now also point directly to the Github instructions.