### PR TITLE
reference_in_tag in SimplexMinimizationModule, typechecks

### DIFF
--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -189,7 +189,7 @@ class SimplexMinimizationModule(ProcessingModule):
         name_in : str
             Unique name of the module instance.
         image_in_tag : str
-            Tag of the database entry with images that are read as input.
+            Tag of the database entry with the science images that are read as input.
         psf_in_tag : str
             Tag of the database entry with the reference PSF that is used as fake planet. Can be
             either a single image (2D) or a cube (3D) with the dimensions equal to *image_in_tag*.
@@ -357,16 +357,16 @@ class SimplexMinimizationModule(ProcessingModule):
             ref_reshape -= mean_ref
 
             # create the PCA basis
-            self.m_pca = PCA(n_components=self.m_pca_number, svd_solver='arpack')
-            self.m_pca.fit(ref_reshape)
+            sklearn_pca = PCA(n_components=self.m_pca_number, svd_solver='arpack')
+            sklearn_pca.fit(ref_reshape)
 
             # add mean of reference array as 1st PC and orthogonalize it to the PCA basis
             mean_ref_reshape = mean_ref.reshape((1, mean_ref.shape[0]))
 
             q_ortho, _ = np.linalg.qr(np.vstack((mean_ref_reshape,
-                                                 self.m_pca.components_[:-1, ])).T)
+                                                 sklearn_pca.components_[:-1, ])).T)
 
-            self.m_pca.components_ = q_ortho.T
+            sklearn_pca.components_ = q_ortho.T
 
         def _objective(arg):
             sys.stdout.write('.')
@@ -402,7 +402,7 @@ class SimplexMinimizationModule(ProcessingModule):
                 _, im_res = pca_psf_subtraction(images=im_reshape,
                                                 angles=-1.*parang+self.m_extra_rot,
                                                 pca_number=self.m_pca_number,
-                                                pca_sklearn=self.m_pca,
+                                                pca_sklearn=sklearn_pca,
                                                 im_shape=im_shape,
                                                 indices=None)
 

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -5,14 +5,15 @@ Pipeline modules for photometric and astrometric measurements.
 import sys
 import time
 
-from typing import Tuple
+from typing import Union, Tuple
 
 import numpy as np
 import emcee
 
+from typeguard import typechecked
 from scipy.optimize import minimize
 from photutils import aperture_photometry, CircularAperture
-from typeguard import typechecked
+from sklearn.decomposition import PCA
 
 from pynpoint.core.processing import ProcessingModule
 from pynpoint.util.analysis import fake_planet, merit_function, false_alarm
@@ -29,18 +30,29 @@ class FakePlanetModule(ProcessingModule):
     Pipeline module to inject a positive or negative artificial planet into a stack of images.
     """
 
+    @typechecked
     def __init__(self,
-                 position,
-                 magnitude,
-                 psf_scaling=1.,
-                 interpolation='spline',
-                 name_in='fake_planet',
-                 image_in_tag='im_arr',
-                 psf_in_tag='im_psf',
-                 image_out_tag='im_fake'):
+                 name_in: str,
+                 image_in_tag: str,
+                 psf_in_tag: str,
+                 image_out_tag: str,
+                 position: Tuple[float, float],
+                 magnitude: float,
+                 psf_scaling: float = 1.,
+                 interpolation: str = 'spline') -> None:
         """
         Parameters
         ----------
+        name_in : str
+            Unique name of the module instance.
+        image_in_tag : str
+            Tag of the database entry with images that are read as input.
+        psf_in_tag : str
+            Tag of the database entry that contains the reference PSF that is used as fake planet.
+            Can be either a single image (2D) or a cube (3D) with the dimensions equal to
+            *image_in_tag*.
+        image_out_tag : str
+            Tag of the database entry with images that are written as output.
         position : tuple(float, float)
             Angular separation (arcsec) and position angle (deg) of the fake planet. Angle is
             measured in counterclockwise direction with respect to the upward direction (i.e.,
@@ -52,16 +64,6 @@ class FakePlanetModule(ProcessingModule):
             filter). A negative value will inject a negative planet signal.
         interpolation : str
             Type of interpolation that is used for shifting the images (spline, bilinear, or fft).
-        name_in : str
-            Unique name of the module instance.
-        image_in_tag : str
-            Tag of the database entry with images that are read as input.
-        psf_in_tag : str
-            Tag of the database entry that contains the reference PSF that is used as fake planet.
-            Can be either a single image (2D) or a cube (3D) with the dimensions equal to
-            *image_in_tag*.
-        image_out_tag : str
-            Tag of the database entry with images that are written as output.
 
         Returns
         -------
@@ -85,7 +87,8 @@ class FakePlanetModule(ProcessingModule):
         self.m_psf_scaling = psf_scaling
         self.m_interpolation = interpolation
 
-    def run(self):
+    @typechecked
+    def run(self) -> None:
         """
         Run method of the module. Shifts the PSF template to the location of the fake planet
         with an additional correction for the parallactic angle and an optional flux scaling.
@@ -141,16 +144,13 @@ class FakePlanetModule(ProcessingModule):
                                   psf_scaling=self.m_psf_scaling,
                                   interpolation='spline')
 
-            if j == 0:
-                self.m_image_out_port.set_all(im_fake)
-            else:
-                self.m_image_out_port.append(im_fake, data_dim=3)
+            self.m_image_out_port.append(im_fake, data_dim=3)
 
         sys.stdout.write('Running FakePlanetModule... [DONE]\n')
         sys.stdout.flush()
 
-        history = '(sep, angle, mag) = ('+'{0:.2f}'.format(self.m_position[0]*pixscale)+', '+ \
-                  '{0:.2f}'.format(self.m_position[1])+', '+'{0:.2f}'.format(self.m_magnitude)+')'
+        history = f'(sep, angle, mag) = ({self.m_position[0]*pixscale:.2f}, ' \
+                  f'{self.m_position[1]:.2f}, {self.m_magnitude:.2f})'
 
         self.m_image_out_port.copy_attributes(self.m_image_in_port)
         self.m_image_out_port.add_history('FakePlanetModule', history)
@@ -163,35 +163,29 @@ class SimplexMinimizationModule(ProcessingModule):
     and minimizing a function of merit.
     """
 
+    @typechecked
     def __init__(self,
-                 position,
-                 magnitude,
-                 psf_scaling=-1.,
-                 name_in='simplex',
-                 image_in_tag='im_arr',
-                 psf_in_tag='im_psf',
-                 res_out_tag='simplex_res',
-                 flux_position_tag='flux_position',
-                 merit='hessian',
-                 aperture=0.1,
-                 sigma=0.027,
-                 tolerance=0.1,
-                 pca_number=20,
-                 cent_size=None,
-                 edge_size=None,
-                 extra_rot=0.,
-                 residuals='mean'):
+                 name_in: str,
+                 image_in_tag: str,
+                 psf_in_tag: str,
+                 res_out_tag: str,
+                 flux_position_tag: str,
+                 position: Tuple[float, float],
+                 magnitude: float,
+                 psf_scaling: float = -1.,
+                 merit: str = 'hessian',
+                 aperture: float = 0.1,
+                 sigma: float = 0.027,
+                 tolerance: float = 0.1,
+                 pca_number: int = 20,
+                 cent_size: float = None,
+                 edge_size: float = None,
+                 extra_rot: float = 0.,
+                 residuals: str = 'mean',
+                 reference_in_tag: str = None) -> None:
         """
         Parameters
         ----------
-        position : tuple(float, float)
-            Approximate position (x, y) of the planet (pix). This is also the location where the
-            function of merit is calculated with an aperture of radius *aperture*.
-        magnitude : float
-            Approximate magnitude of the planet relative to the star.
-        psf_scaling : float
-            Additional scaling factor of the planet flux (e.g., to correct for a neutral density
-            filter). Should be negative in order to inject negative fake planets.
         name_in : str
             Unique name of the module instance.
         image_in_tag : str
@@ -208,6 +202,14 @@ class SimplexMinimizationModule(ProcessingModule):
             Each step of the minimization saves the x position (pix), y position (pix), separation
             (arcsec), angle (deg), contrast (mag), and the function of merit. The last row of
             values contain the best-fit results.
+        position : tuple(float, float)
+            Approximate position (x, y) of the planet (pix). This is also the location where the
+            function of merit is calculated with an aperture of radius *aperture*.
+        magnitude : float
+            Approximate magnitude of the planet relative to the star.
+        psf_scaling : float
+            Additional scaling factor of the planet flux (e.g., to correct for a neutral density
+            filter). Should be negative in order to inject negative fake planets.
         merit : str
             Function of merit for the minimization. Can be either *hessian*, to minimize the sum of
             the absolute values of the determinant of the Hessian matrix, or *sum*, to minimize the
@@ -238,6 +240,12 @@ class SimplexMinimizationModule(ProcessingModule):
             Additional rotation angle of the images in clockwise direction (deg).
         residuals : str
             Method used for combining the residuals ('mean', 'median', 'weighted', or 'clipped').
+        reference_in_tag : str, None
+            Tag of the database entry with the reference images that are read as input. The data of
+            the ``image_in_tag`` itself is used as reference data for the PSF subtraction if set to
+            None. Note that the mean is not subtracted from the data of ``image_in_tag`` and
+            ``reference_in_tag`` in case the ``reference_in_tag`` is used, to allow for flux and
+            position measurements in the context of RDI.
 
         Returns
         -------
@@ -253,6 +261,11 @@ class SimplexMinimizationModule(ProcessingModule):
             self.m_psf_in_port = self.m_image_in_port
         else:
             self.m_psf_in_port = self.add_input_port(psf_in_tag)
+
+        if reference_in_tag is None:
+            self.m_reference_in_port = None
+        else:
+            self.m_reference_in_port = self.add_input_port(reference_in_tag)
 
         self.m_res_out_port = self.add_output_port(res_out_tag)
         self.m_flux_position_port = self.add_output_port(flux_position_tag)
@@ -270,7 +283,8 @@ class SimplexMinimizationModule(ProcessingModule):
         self.m_extra_rot = extra_rot
         self.m_residuals = residuals
 
-    def run(self):
+    @typechecked
+    def run(self) -> None:
         """
         Run method of the module. The position and flux of a planet are measured by injecting
         negative fake companions and applying a simplex method (Nelder-Mead) for minimization
@@ -318,13 +332,41 @@ class SimplexMinimizationModule(ProcessingModule):
         psf = self.m_psf_in_port.get_all()
         images = self.m_image_in_port.get_all()
 
-        center = center_subpixel(psf)
-
         if psf.shape[0] != 1 and psf.shape[0] != images.shape[0]:
             raise ValueError('The number of frames in psf_in_tag does not match with the number '
                              'of frames in image_in_tag. The DerotateAndStackModule can be '
                              'used to average the PSF frames (without derotating) before applying '
                              'the SimplexMinimizationModule.')
+
+        center = center_subpixel(psf)
+
+        if self.m_reference_in_port is not None:
+            ref_data = self.m_reference_in_port.get_all()
+
+            im_shape = images.shape
+            ref_shape = ref_data.shape
+
+            if ref_shape[1:] != im_shape[1:]:
+                raise ValueError('The image size of the science data and the reference data '
+                                 'should be identical.')
+
+            # reshape reference data and select the unmasked pixels
+            ref_reshape = ref_data.reshape(ref_shape[0], ref_shape[1]*ref_shape[2])
+
+            mean_ref = np.mean(ref_reshape, axis=0)
+            ref_reshape -= mean_ref
+
+            # create the PCA basis
+            self.m_pca = PCA(n_components=self.m_pca_number, svd_solver='arpack')
+            self.m_pca.fit(ref_reshape)
+
+            # add mean of reference array as 1st PC and orthogonalize it to the PCA basis
+            mean_ref_reshape = mean_ref.reshape((1, mean_ref.shape[0]))
+
+            q_ortho, _ = np.linalg.qr(np.vstack((mean_ref_reshape,
+                                                 self.m_pca.components_[:-1, ])).T)
+
+            self.m_pca.components_ = q_ortho.T
 
         def _objective(arg):
             sys.stdout.write('.')
@@ -343,13 +385,26 @@ class SimplexMinimizationModule(ProcessingModule):
                                magnitude=mag,
                                psf_scaling=self.m_psf_scaling)
 
-            im_shape = (fake.shape[-2], fake.shape[-1])
+            mask_shape = (fake.shape[-2], fake.shape[-1])
+            mask = create_mask(mask_shape, [self.m_cent_size, self.m_edge_size])
 
-            mask = create_mask(im_shape, [self.m_cent_size, self.m_edge_size])
+            if self.m_reference_in_port is None:
+                _, im_res = pca_psf_subtraction(images=fake*mask,
+                                                angles=-1.*parang+self.m_extra_rot,
+                                                pca_number=self.m_pca_number,
+                                                pca_sklearn=None,
+                                                im_shape=None,
+                                                indices=None)
 
-            _, im_res = pca_psf_subtraction(images=fake*mask,
-                                            angles=-1.*parang+self.m_extra_rot,
-                                            pca_number=self.m_pca_number)
+            else:
+                im_reshape = np.reshape(fake*mask, (im_shape[0], im_shape[1]*im_shape[2]))
+
+                _, im_res = pca_psf_subtraction(images=im_reshape,
+                                                angles=-1.*parang+self.m_extra_rot,
+                                                pca_number=self.m_pca_number,
+                                                pca_sklearn=self.m_pca,
+                                                im_shape=im_shape,
+                                                indices=None)
 
             stack = combine_residuals(method=self.m_residuals, res_rot=im_res)
 
@@ -393,7 +448,7 @@ class SimplexMinimizationModule(ProcessingModule):
         sys.stdout.write(' [DONE]\n')
         sys.stdout.flush()
 
-        history = 'merit = '+str(self.m_merit)
+        history = f'merit = {self.m_merit}'
         self.m_flux_position_port.copy_attributes(self.m_image_in_port)
         self.m_flux_position_port.add_history('SimplexMinimizationModule', history)
 
@@ -409,27 +464,19 @@ class FalsePositiveModule(ProcessingModule):
     Optionally, the SNR can be optimized with the aperture position as free parameter.
     """
 
+    @typechecked
     def __init__(self,
-                 position,
-                 aperture=0.1,
-                 ignore=False,
-                 name_in='snr',
-                 image_in_tag='im_arr',
-                 snr_out_tag='snr_fpf',
-                 optimize=False,
-                 **kwargs):
+                 name_in: str,
+                 image_in_tag: str,
+                 snr_out_tag: str,
+                 position: Tuple[float, float],
+                 aperture: float = 0.1,
+                 ignore: bool = False,
+                 optimize: bool = False,
+                 **kwargs: float) -> None:
         """
         Parameters
         ----------
-        position : tuple(float, float)
-            The x and y position (pix) where the SNR and FPF is calculated. Note that the bottom
-            left of the image is defined as (-0.5, -0.5) so there is a -1.0 offset with respect
-            to the DS9 coordinate system. Aperture photometry corrects for the partial inclusion
-            of pixels at the boundary.
-        aperture : float
-            Aperture radius (arcsec).
-        ignore : bool
-            Ignore the two neighboring apertures that may contain self-subtraction from the planet.
         name_in: str
             Unique name of the module instance.
         image_in_tag : str
@@ -439,6 +486,15 @@ class FalsePositiveModule(ProcessingModule):
             (pix), y position (pix), separation (arcsec), position angle (deg), SNR, FPF). The
             position angle is measured in counterclockwise direction with respect to the upward
             direction (i.e., East of North).
+        position : tuple(float, float)
+            The x and y position (pix) where the SNR and FPF is calculated. Note that the bottom
+            left of the image is defined as (-0.5, -0.5) so there is a -1.0 offset with respect
+            to the DS9 coordinate system. Aperture photometry corrects for the partial inclusion
+            of pixels at the boundary.
+        aperture : float
+            Aperture radius (arcsec).
+        ignore : bool
+            Ignore the two neighboring apertures that may contain self-subtraction from the planet.
         optimize : bool
             Optimize the SNR. The aperture position is written in the history. The size of the
             aperture is kept fixed.
@@ -470,7 +526,8 @@ class FalsePositiveModule(ProcessingModule):
         self.m_ignore = ignore
         self.m_optimize = optimize
 
-    def run(self):
+    @typechecked
+    def run(self) -> None:
         """
         Run method of the module. Calculates the SNR and FPF for a specified position in a post-
         processed image with the Student's t-test (Mawet et al. 2014). This approach assumes
@@ -557,27 +614,38 @@ class MCMCsamplingModule(ProcessingModule):
     emcee, an affine invariant Markov chain Monte Carlo (MCMC) ensemble sampler.
     """
 
+    @typechecked
     def __init__(self,
-                 param,
-                 bounds,
-                 name_in='mcmc_sampling',
-                 image_in_tag='im_arr',
-                 psf_in_tag='im_arr',
-                 chain_out_tag='samples',
-                 nwalkers=100,
-                 nsteps=200,
-                 psf_scaling=-1.,
-                 pca_number=20,
-                 aperture=0.1,
-                 mask=None,
-                 extra_rot=0.,
-                 prior='flat',
-                 variance='poisson',
-                 residuals='mean',
-                 **kwargs):
+                 name_in: str,
+                 image_in_tag: str,
+                 psf_in_tag: str,
+                 chain_out_tag: str,
+                 param: Tuple[float, float, float],
+                 bounds: Tuple[Tuple[float, float], Tuple[float, float], Tuple[float, float]],
+                 nwalkers: int = 100,
+                 nsteps: int = 200,
+                 psf_scaling: float = -1.,
+                 pca_number: int = 20,
+                 aperture: Union[float, dict] = 0.1,
+                 mask: Tuple[float, float] = None,
+                 extra_rot: float = 0.,
+                 prior: str = 'flat',
+                 variance: str = 'poisson',
+                 residuals: str = 'mean',
+                 **kwargs: Union[float, Tuple[float, float, float]]) -> None:
         """
         Parameters
         ----------
+        name_in : str
+            Unique name of the module instance.
+        image_in_tag : str
+            Tag of the database entry with images that are read as input.
+        psf_in_tag : str
+            Tag of the database entry with the reference PSF that is used as fake planet. Can be
+            either a single image (2D) or a cube (3D) with the dimensions equal to *image_in_tag*.
+        chain_out_tag : str
+            Tag of the database entry with the Markov chain that is written as output. The shape
+            of the array is (nwalkers*nsteps, 3).
         param : tuple(float, float, float)
             The approximate separation (arcsec), angle (deg), and contrast (mag), for example
             obtained with the :class:`~pynpoint.processing.fluxposition.SimplexMinimizationModule`.
@@ -590,16 +658,6 @@ class MCMCsamplingModule(ProcessingModule):
         bounds : tuple(tuple(float, float), tuple(float, float), tuple(float, float))
             The boundaries of the separation (arcsec), angle (deg), and contrast (mag). Each set
             of boundaries is specified as a tuple.
-        name_in : str
-            Unique name of the module instance.
-        image_in_tag : str
-            Tag of the database entry with images that are read as input.
-        psf_in_tag : str
-            Tag of the database entry with the reference PSF that is used as fake planet. Can be
-            either a single image (2D) or a cube (3D) with the dimensions equal to *image_in_tag*.
-        chain_out_tag : str
-            Tag of the database entry with the Markov chain that is written as output. The shape
-            of the array is (nwalkers*nsteps, 3).
         nwalkers : int
             Number of ensemble members (i.e. chains).
         nsteps : int
@@ -682,8 +740,9 @@ class MCMCsamplingModule(ProcessingModule):
         else:
             self.m_mask = np.array(mask)
 
+    @typechecked
     def aperture_dict(self,
-                      images):
+                      images: np.ndarray) -> None:
         """
         Function to create or update the dictionary with aperture properties.
 
@@ -720,11 +779,12 @@ class MCMCsamplingModule(ProcessingModule):
             raise ValueError('Gaussian variance can only be used in combination with a'
                              'circular aperture.')
 
+    @typechecked
     def gaussian_noise(self,
-                       images,
-                       psf,
-                       parang,
-                       aperture):
+                       images: np.ndarray,
+                       psf: np.ndarray,
+                       parang: np.ndarray,
+                       aperture: dict) -> float:
         """
         Function to compute the (constant) variance for the likelihood function when the
         variance parameter is set to gaussian (see Mawet et al. 2014). The planet is first removed
@@ -771,7 +831,8 @@ class MCMCsamplingModule(ProcessingModule):
 
         return noise**2
 
-    def run(self):
+    @typechecked
+    def run(self) -> None:
         """
         Run method of the module. The posterior distributions of the separation, position angle,
         and flux contrast are sampled with the affine invariant Markov chain Monte Carlo (MCMC)

--- a/pynpoint/processing/limits.py
+++ b/pynpoint/processing/limits.py
@@ -29,20 +29,20 @@ class ContrastCurveModule(ProcessingModule):
     """
 
     def __init__(self,
-                 name_in="contrast",
-                 image_in_tag="im_arr",
-                 psf_in_tag="im_psf",
-                 contrast_out_tag="contrast_limits",
+                 name_in='contrast',
+                 image_in_tag='im_arr',
+                 psf_in_tag='im_psf',
+                 contrast_out_tag='contrast_limits',
                  separation=(0.1, 1., 0.01),
                  angle=(0., 360., 60.),
-                 threshold=("sigma", 5.),
+                 threshold=('sigma', 5.),
                  psf_scaling=1.,
                  aperture=0.05,
                  pca_number=20,
                  cent_size=None,
                  edge_size=None,
                  extra_rot=0.,
-                 residuals="median",
+                 residuals='median',
                  snr_inject=100.,
                  **kwargs):
         """
@@ -68,9 +68,9 @@ class ContrastCurveModule(ProcessingModule):
             (lower limit, upper limit, step size), measured counterclockwise with respect to the
             vertical image axis, i.e. East of North.
         threshold : tuple(str, float)
-            Detection threshold for the contrast curve, either in terms of "sigma" or the false
-            positive fraction (FPF). The value is a tuple, for example provided as ("sigma", 5.)
-            or ("fpf", 1e-6). Note that when sigma is fixed, the false positive fraction will
+            Detection threshold for the contrast curve, either in terms of 'sigma' or the false
+            positive fraction (FPF). The value is a tuple, for example provided as ('sigma', 5.)
+            or ('fpf', 1e-6). Note that when sigma is fixed, the false positive fraction will
             change with separation. Also, sigma only corresponds to the standard deviation of a
             normal distribution at large separations (i.e., large number of samples).
         psf_scaling : float
@@ -89,7 +89,7 @@ class ContrastCurveModule(ProcessingModule):
         extra_rot : float
             Additional rotation angle of the images in clockwise direction (deg).
         residuals : str
-            Method used for combining the residuals ("mean", "median", "weighted", or "clipped").
+            Method used for combining the residuals ('mean', 'median', 'weighted', or 'clipped').
         snr_inject : float
             Signal-to-noise ratio of the injected planet signal that is used to measure the amount
             of self-subtraction.
@@ -102,25 +102,25 @@ class ContrastCurveModule(ProcessingModule):
 
         super(ContrastCurveModule, self).__init__(name_in)
 
-        if "sigma" in kwargs:
-            warnings.warn("The 'sigma' parameter has been deprecated. Please use the 'threshold' "
-                          "parameter instead.", DeprecationWarning)
+        if 'sigma' in kwargs:
+            warnings.warn('The \'sigma\' parameter has been deprecated. Please use the '
+                          '\'threshold\' parameter instead.', DeprecationWarning)
 
-        if "norm" in kwargs:
-            warnings.warn("The 'norm' parameter has been deprecated. It is not recommended to "
-                          "normalize the images before PSF subtraction.", DeprecationWarning)
+        if 'norm' in kwargs:
+            warnings.warn('The \'norm\' parameter has been deprecated. It is not recommended to '
+                          'normalize the images before PSF subtraction.', DeprecationWarning)
 
-        if "accuracy" in kwargs:
-            warnings.warn("The 'accuracy' parameter has been deprecated. The parameter is no "
-                          "longer required.", DeprecationWarning)
+        if 'accuracy' in kwargs:
+            warnings.warn('The \'accuracy\' parameter has been deprecated. The parameter is no '
+                          'longer required.', DeprecationWarning)
 
-        if "magnitude" in kwargs:
-            warnings.warn("The 'magnitude' parameter has been deprecated. The parameter is no "
-                          "longer required.", DeprecationWarning)
+        if 'magnitude' in kwargs:
+            warnings.warn('The \'magnitude\' parameter has been deprecated. The parameter is no '
+                          'longer required.', DeprecationWarning)
 
-        if "ignore" in kwargs:
-            warnings.warn("The 'ignore' parameter has been deprecated. The parameter is no "
-                          "longer required.", DeprecationWarning)
+        if 'ignore' in kwargs:
+            warnings.warn('The \'ignore\' parameter has been deprecated. The parameter is no '
+                          'longer required.', DeprecationWarning)
 
         self.m_image_in_port = self.add_input_port(image_in_tag)
 
@@ -146,8 +146,8 @@ class ContrastCurveModule(ProcessingModule):
         if self.m_angle[0] < 0. or self.m_angle[0] > 360. or self.m_angle[1] < 0. or \
            self.m_angle[1] > 360. or self.m_angle[2] < 0. or self.m_angle[2] > 360.:
 
-            raise ValueError("The angular positions of the fake planets should lie between "
-                             "0 deg and 360 deg.")
+            raise ValueError('The angular positions of the fake planets should lie between '
+                             '0 deg and 360 deg.')
 
     def run(self):
         """
@@ -167,14 +167,14 @@ class ContrastCurveModule(ProcessingModule):
         psf = self.m_psf_in_port.get_all()
 
         if psf.shape[0] != 1 and psf.shape[0] != images.shape[0]:
-            raise ValueError('The number of frames in psf_in_tag {0} does not match with the '
-                             'number of frames in image_in_tag {1}. The DerotateAndStackModule can '
-                             'be used to average the PSF frames (without derotating) before '
-                             'applying the ContrastCurveModule.'.format(psf.shape, images.shape))
+            raise ValueError(f'The number of frames in psf_in_tag {psf.shape} does not match with '
+                             f'the number of frames in image_in_tag {images.shape}. The '
+                             f'DerotateAndStackModule can be used to average the PSF frames '
+                             f'(without derotating) before applying the ContrastCurveModule.')
 
-        cpu = self._m_config_port.get_attribute("CPU")
-        parang = self.m_image_in_port.get_attribute("PARANG")
-        pixscale = self.m_image_in_port.get_attribute("PIXSCALE")
+        cpu = self._m_config_port.get_attribute('CPU')
+        parang = self.m_image_in_port.get_attribute('PARANG')
+        pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
 
         if self.m_cent_size is not None:
             self.m_cent_size /= pixscale
@@ -214,11 +214,11 @@ class ContrastCurveModule(ProcessingModule):
         result = []
         async_results = []
 
-        working_place = self._m_config_port.get_attribute("WORKING_PLACE")
+        working_place = self._m_config_port.get_attribute('WORKING_PLACE')
 
         # Create temporary files
-        tmp_im_str = os.path.join(working_place, "tmp_images.npy")
-        tmp_psf_str = os.path.join(working_place, "tmp_psf.npy")
+        tmp_im_str = os.path.join(working_place, 'tmp_images.npy')
+        tmp_psf_str = os.path.join(working_place, 'tmp_psf.npy')
 
         np.save(tmp_im_str, images)
         np.save(tmp_psf_str, psf)
@@ -256,7 +256,7 @@ class ContrastCurveModule(ProcessingModule):
             # number of finished processes
             nfinished = sum([i.ready() for i in async_results])
 
-            progress(nfinished/len(positions), 1, "Running ContrastCurveModule...")
+            progress(nfinished/len(positions), 1, 'Running ContrastCurveModule...')
 
             # check if new processes have finished every 5 seconds
             time.sleep(5)
@@ -286,11 +286,11 @@ class ContrastCurveModule(ProcessingModule):
 
         self.m_contrast_out_port.set_all(limits, data_dim=2)
 
-        sys.stdout.write("\rRunning ContrastCurveModule... [DONE]\n")
+        sys.stdout.write('\rRunning ContrastCurveModule... [DONE]\n')
         sys.stdout.flush()
 
-        history = f"{self.m_threshold[0]} = {self.m_threshold[1]}"
-        self.m_contrast_out_port.add_history("ContrastCurveModule", history)
+        history = f'{self.m_threshold[0]} = {self.m_threshold[1]}'
+        self.m_contrast_out_port.add_history('ContrastCurveModule', history)
         self.m_contrast_out_port.copy_attributes(self.m_image_in_port)
         self.m_contrast_out_port.close_port()
 
@@ -301,15 +301,15 @@ class MassLimitsModule(ProcessingModule):
     downloaded from https://phoenix.ens-lyon.fr/Grids/.
     """
 
-    __author__ = "Benedikt Schmidhuber, Tomas Stolker"
+    __author__ = 'Benedikt Schmidhuber, Tomas Stolker'
 
     def __init__(self,
                  model_file,
                  star_prop,
-                 name_in="mass",
-                 contrast_in_tag="contrast_limits",
-                 mass_out_tag="mass_limits",
-                 instr_filter="L\'"):
+                 name_in='mass',
+                 contrast_in_tag='contrast_limits',
+                 mass_out_tag='mass_limits',
+                 instr_filter='L\''):
 
         """
         Parameters
@@ -471,13 +471,13 @@ class MassLimitsModule(ProcessingModule):
             None
         """
 
-        sys.stdout.write("Running MassLimitsModule...")
+        sys.stdout.write('Running MassLimitsModule...')
         sys.stdout.flush()
 
         model_age, model_data, model_header = self.read_model()
 
-        assert self.m_instr_filter in model_header, "The selected filter was not found in the " \
-                                                    "list of available filters from the model."
+        assert self.m_instr_filter in model_header, 'The selected filter was not found in the ' \
+                                                    'list of available filters from the model.'
 
         # find the correct filter
         # simple argwhere gives empty list?!
@@ -513,10 +513,10 @@ class MassLimitsModule(ProcessingModule):
         mass_limits = np.column_stack((separation, mass, mass_upper, mass_lower))
         self.m_mass_out_port.set_all(mass_limits, data_dim=2)
 
-        sys.stdout.write(" [DONE]\n")
+        sys.stdout.write(' [DONE]\n')
         sys.stdout.flush()
 
-        history = f"filter = {self.m_instr_filter}"
-        self.m_mass_out_port.add_history("MassLimitsModule", history)
+        history = f'filter = {self.m_instr_filter}'
+        self.m_mass_out_port.add_history('MassLimitsModule', history)
         self.m_mass_out_port.copy_attributes(self.m_contrast_in_port)
         self.m_mass_out_port.close_port()

--- a/pynpoint/util/psf.py
+++ b/pynpoint/util/psf.py
@@ -27,13 +27,12 @@ def pca_psf_subtraction(images,
         Derotation angles (deg).
     pca_number : int
         Number of principal components used for the PSF model.
-    pca_sklearn : sklearn.decomposition.pca.PCA
+    pca_sklearn : sklearn.decomposition.pca.PCA, None
         PCA object with the basis if not set to None.
-    im_shape : tuple(int, int, int)
+    im_shape : tuple(int, int, int), None
         Original shape of the stack with images. Required if `pca_sklearn` is not set to None.
-    indices : numpy.ndarray
-        Non-masked image indices, required if `pca_sklearn` is not set to None. Optional if
-        `pca_sklearn` is set to None.
+    indices : numpy.ndarray, None
+        Non-masked image indices. All pixels are used if set to None.
 
     Returns
     -------
@@ -78,6 +77,9 @@ def pca_psf_subtraction(images,
     residuals = np.zeros((im_shape[0], im_shape[1]*im_shape[2]))
 
     # subtract the psf model
+    if indices is None:
+        indices = np.arange(0, im_reshape.shape[1], 1)
+
     residuals[:, indices] = im_reshape - psf_model
 
     # reshape to the original image size


### PR DESCRIPTION
- `reference_in_tag` argument added in `SimplexMinimizationModule` such that the module can also be used for RDI datasets. Note that the mean is not subtracted from either the science or the reference data in case `reference_in_tag` is used. The default is set to None, that is, the science data itself is used for the PSF subtraction.

- type checks added for all pipeline modules in `processing.fluxposition`.