### PR TITLE
changed ShiftImages, now uses SubtractImages like style for iteration

### DIFF
--- a/pynpoint/processing/centering.py
+++ b/pynpoint/processing/centering.py
@@ -1098,7 +1098,7 @@ class ShiftImagesModule(ProcessingModule):
             # if the offset is constant, grab the first element of the shift for the second part
             # of the function
             if constant:
-                self.m_shift = self.m_shift[0, ]
+                self.m_shift = tuple(self.m_shift[0, ])
 
             # if the offset is not constant, then the apply the shifts to each frame individually
             # since each frame is shifted individually, it can not be easily applied to
@@ -1106,7 +1106,7 @@ class ShiftImagesModule(ProcessingModule):
             else:
                 for i, shift in enumerate(self.m_shift):
                     shifted_image = shift_image(self.m_image_in_port[i, ],
-                                                shift,
+                                                tuple(shift),
                                                 self.m_interpolation)
                     # append the shifted images to the selt.m_image_out_port database entry
                     self.m_image_out_port.append([shifted_image])

--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -185,13 +185,13 @@ def fake_planet(images: np.ndarray,
     for i in range(images.shape[0]):
         if psf.shape[0] == 1:
             im_shift[i, ] = shift_image(psf[0, ],
-                                        (y_shift[i], x_shift[i]),
+                                        [y_shift[i], x_shift[i]],
                                         interpolation,
                                         mode='reflect')
 
         else:
             im_shift[i, ] = shift_image(psf[i, ],
-                                        (y_shift[i], x_shift[i]),
+                                        [y_shift[i], x_shift[i]],
                                         interpolation,
                                         mode='reflect')
 

--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -185,13 +185,13 @@ def fake_planet(images: np.ndarray,
     for i in range(images.shape[0]):
         if psf.shape[0] == 1:
             im_shift[i, ] = shift_image(psf[0, ],
-                                        [y_shift[i], x_shift[i]],
+                                        (y_shift[i], x_shift[i]),
                                         interpolation,
                                         mode='reflect')
 
         else:
             im_shift[i, ] = shift_image(psf[i, ],
-                                        [y_shift[i], x_shift[i]],
+                                        (y_shift[i], x_shift[i]),
                                         interpolation,
                                         mode='reflect')
 

--- a/pynpoint/util/image.py
+++ b/pynpoint/util/image.py
@@ -189,7 +189,7 @@ def shift_image(image,
     Parameters
     ----------
     image : numpy.ndarray
-        Input image (2D).
+        Input image (2D or 3D). If 3D the image is not shifted along the 0th axis.
     shift_yx : tuple(float, float)
         Shift (y, x) to be applied (pix).
     interpolation : str
@@ -201,14 +201,19 @@ def shift_image(image,
         Shifted image.
     """
 
+    if image.ndim == 3:
+        shift_zyx = np.stack((np.zeros_like(shift_yx[0]), shift_yx[0], shift_yx[1])).T
+    else:
+        shift_zyx = shift_yx
+
     if interpolation == "spline":
-        im_center = shift(image, shift_yx, order=5, mode=mode)
+        im_center = shift(image, shift_zyx, order=5, mode=mode)
 
     elif interpolation == "bilinear":
-        im_center = shift(image, shift_yx, order=1, mode=mode)
+        im_center = shift(image, shift_zyx, order=1, mode=mode)
 
     elif interpolation == "fft":
-        fft_shift = fourier_shift(np.fft.fftn(image), shift_yx)
+        fft_shift = fourier_shift(np.fft.fftn(image), shift_zyx)
         im_center = np.fft.ifftn(fft_shift).real
 
     return im_center

--- a/pynpoint/util/image.py
+++ b/pynpoint/util/image.py
@@ -202,7 +202,7 @@ def shift_image(image,
     """
 
     if image.ndim == 3:
-        shift_zyx = np.stack((np.zeros_like(shift_yx[0]), shift_yx[0], shift_yx[1])).T
+        shift_zyx = [0, shift_yx[0], shift_yx[1]]
     else:
         shift_zyx = shift_yx
 

--- a/tests/test_processing/test_centering.py
+++ b/tests/test_processing/test_centering.py
@@ -445,12 +445,27 @@ class TestCentering:
                                    interpolation='spline',
                                    name_in='shift3',
                                    image_in_tag='shift',
-                                   image_out_tag='shift_tag')
+                                   image_out_tag='shift_tag_1')
 
         self.pipeline.add_module(module)
         self.pipeline.run_module('shift3')
 
-        data = self.pipeline.get_data('shift_tag')
+        data = self.pipeline.get_data('shift_tag_1')
         assert np.allclose(data[0, 39, 39], 0.023563080974545528, rtol=1e-8, atol=0.)
         assert np.allclose(np.mean(data), 0.0001643062943690491, rtol=limit, atol=0.)
+        assert data.shape == (40, 78, 78)
+
+    def test_shift_images_tag_mean(self):
+
+        module = ShiftImagesModule(shift_xy='fit_mean',
+                                   interpolation='spline',
+                                   name_in='shift4',
+                                   image_in_tag='shift',
+                                   image_out_tag='shift_tag_2')
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('shift4')
+        data = self.pipeline.get_data('shift_tag_2')
+        assert np.allclose(data[0, 20, 31], 5.348337712000518e-05, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.00016430318227546225, rtol=limit, atol=0.)
         assert data.shape == (40, 78, 78)

--- a/tests/test_processing/test_centering.py
+++ b/tests/test_processing/test_centering.py
@@ -451,8 +451,8 @@ class TestCentering:
         self.pipeline.run_module('shift3')
 
         data = self.pipeline.get_data('shift_tag_1')
-        assert np.allclose(data[0, 39, 39], 0.023563080974545528, rtol=1e-8, atol=0.)
-        assert np.allclose(np.mean(data), 0.0001643062943690491, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 39, 39], 0.023563080974545528, rtol=1e-6, atol=0.)
+        assert np.allclose(np.mean(data), 0.0001643062943690491, rtol=1e-6, atol=0.)
         assert data.shape == (40, 78, 78)
 
     def test_shift_images_tag_mean(self):
@@ -466,6 +466,6 @@ class TestCentering:
         self.pipeline.add_module(module)
         self.pipeline.run_module('shift4')
         data = self.pipeline.get_data('shift_tag_2')
-        assert np.allclose(data[0, 20, 31], 5.348337712000518e-05, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 0.00016430318227546225, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 20, 31], 5.348337712000518e-05, rtol=1e-6, atol=0.)
+        assert np.allclose(np.mean(data), 0.00016430318227546225, rtol=1e-6, atol=0.)
         assert data.shape == (40, 78, 78)


### PR DESCRIPTION
As discussed yesterday, I've implemented the `ShiftImagesModule` into a `SubtractImagesModule.run` type iteration. Additionally I  modified the `util.image.shift_image` function in such a way that it can take 3D stacks of images. 

 - When a input_port with individual shifts is provided, the iteration can't loop over stacks of images, as `scipy.ndimage.interpolation.shift` does not support different shifts within an axis.

- The tests for `test_fit_center_full` and `test_fit_center_mean` fail, but the final `test_shift_images_tag` which relies on these tags passes. Interestingly, for me they also fail on the master branch.