### PR TITLE
Memory intensive hotfix for issue #356

### DIFF
--- a/pynpoint/util/multistack.py
+++ b/pynpoint/util/multistack.py
@@ -61,15 +61,15 @@ class StackReader(TaskCreator):
         """
 
         nimages = self.m_data_in_port.get_shape()[0]
-
+        images = self.m_data_in_port.get_all()
         i = 0
         while i < nimages:
             j = min((i + self.m_stack_size), nimages)
 
             # lock mutex and read data
-            with self.m_data_mutex:
-                # read images from i to j
-                tmp_data = self.m_data_in_port[i:j, ]
+            # with self.m_data_mutex:
+            # read images from i to j
+            tmp_data = images[i:j, ]
 
             # first dimension (start, stop, step)
             stack_slice = [(i, j, None)]
@@ -82,7 +82,7 @@ class StackReader(TaskCreator):
             self.m_task_queue.put(TaskInput(tmp_data, param))
 
             i = j
-
+        del images  # for space
         self.create_poison_pills()
 
 

--- a/tests/test_processing/test_resizing.py
+++ b/tests/test_processing/test_resizing.py
@@ -154,6 +154,8 @@ class TestResizing:
         self.pipeline.add_module(module)
         self.pipeline.run_module('repeat')
 
+        with h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a') as hdf_file:
+            hdf_file['config'].attrs['CPU'] = 1
 
         module = RemoveLinesModule(lines=(2, 5, 0, 9),
                                    name_in='remove_slow',
@@ -174,9 +176,9 @@ class TestResizing:
         data_multi = self.pipeline.get_data('remove_slow')
         bad_frames = np.argwhere(data - data_multi)
 
-        for i in np.unique(bad_frames[:, 0]):
-            fits.writeto(f'../../image1_{i}.fits', data[i, ], overwrite=True)
-            fits.writeto(f'../../image2_{i}.fits', data_multi[i, ], overwrite=True)
+        # for i in np.unique(bad_frames[:, 0]):
+        #     fits.writeto(f'../../image1_{i}.fits', data[i, ], overwrite=True)
+        #     fits.writeto(f'../../image2_{i}.fits', data_multi[i, ], overwrite=True)
 
         assert np.allclose(data, data_multi, rtol=limit, atol=0.)
         assert data.shape == data_multi.shape


### PR DESCRIPTION
TaskReader: 
 * instead of accessing the port each time and running into the issue #356, the data is read in once. This obviously is not very feasible for large chunks of data.