### PR TITLE
MEMORY use in 4 pipeline modules

### DIFF
--- a/docs/python.rst
+++ b/docs/python.rst
@@ -36,16 +36,20 @@ Conventions
 Before we start writing a new PynPoint module, please take notice of the following style conventions:
 
     * |pep8| -- style guide for Python code
-    * We recommend using |pylint| to analyze newly written code in order to keep PynPoint well structured, readable, and documented.
+    * We recommend using |pylint| and |pycodestyle| to analyze newly written code in order to keep PynPoint well structured, readable, and documented.
     * Names of class member should start with ``m_``.
     * Images should ideally not be read from and written to the central database at once but in amounts of ``MEMORY``.
 
 .. |pep8| raw:: html
 
-   <a href="https://www.python.org/dev/peps/pep-0008" target="_blank">PEP 8</a>
+   <a href="https://www.python.org/dev/peps/pep-0008/" target="_blank">PEP 8</a>
 
 .. |pylint| raw:: html
 
    <a href="https://www.pylint.org" target="_blank">pylint</a>
+
+.. |pycodestyle| raw:: html
+
+   <a href="https://pypi.org/project/pycodestyle/" target="_blank">pycodestyle</a>
 
 Now we are ready to code!

--- a/pynpoint/processing/basic.py
+++ b/pynpoint/processing/basic.py
@@ -73,7 +73,6 @@ class SubtractImagesModule(ProcessingModule):
 
         memory = self._m_config_port.get_attribute('MEMORY')
         nimages = self.m_image_in1_port.get_shape()[0]
-
         frames = memory_frames(memory, nimages)
 
         start_time = time.time()
@@ -84,7 +83,7 @@ class SubtractImagesModule(ProcessingModule):
             images1 = self.m_image_in1_port[frames[i]:frames[i+1], ]
             images2 = self.m_image_in2_port[frames[i]:frames[i+1], ]
 
-            self.m_image_out_port.append(self.m_scaling*(images1-images2))
+            self.m_image_out_port.append(self.m_scaling*(images1-images2), data_dim=3)
 
         sys.stdout.write('Running SubtractImagesModule... [DONE]\n')
         sys.stdout.flush()
@@ -152,9 +151,8 @@ class AddImagesModule(ProcessingModule):
         if self.m_image_in1_port.get_shape() != self.m_image_in2_port.get_shape():
             raise ValueError('The shape of the two input tags has to be the same.')
 
-        nimages = self.m_image_in1_port.get_shape()[0]
         memory = self._m_config_port.get_attribute('MEMORY')
-
+        nimages = self.m_image_in1_port.get_shape()[0]
         frames = memory_frames(memory, nimages)
 
         start_time = time.time()
@@ -165,7 +163,7 @@ class AddImagesModule(ProcessingModule):
             images1 = self.m_image_in1_port[frames[i]:frames[i+1], ]
             images2 = self.m_image_in2_port[frames[i]:frames[i+1], ]
 
-            self.m_image_out_port.append(self.m_scaling*(images1+images2))
+            self.m_image_out_port.append(self.m_scaling*(images1+images2), data_dim=3)
 
         sys.stdout.write('Running AddImagesModule... [DONE]\n')
         sys.stdout.flush()
@@ -227,10 +225,7 @@ class RotateImagesModule(ProcessingModule):
         self.m_image_out_port.del_all_data()
 
         memory = self._m_config_port.get_attribute('MEMORY')
-
-        ndim = self.m_image_in_port.get_ndim()
         nimages = self.m_image_in_port.get_shape()[0]
-
         frames = memory_frames(memory, nimages)
 
         start_time = time.time()
@@ -246,7 +241,7 @@ class RotateImagesModule(ProcessingModule):
                 # ndimage.rotate rotates in clockwise direction for positive angles
                 im_tmp = rotate(im_tmp, self.m_angle, reshape=False)
 
-                self.m_image_out_port.append(im_tmp, data_dim=ndim)
+                self.m_image_out_port.append(im_tmp, data_dim=3)
 
         sys.stdout.write('Running RotateImagesModule... [DONE]\n')
         sys.stdout.flush()
@@ -321,7 +316,7 @@ class RepeatImagesModule(ProcessingModule):
 
             for j, _ in enumerate(frames[:-1]):
                 images = self.m_image_in_port[frames[j]:frames[j+1], ]
-                self.m_image_out_port.append(images)
+                self.m_image_out_port.append(images, data_dim=3)
 
         sys.stdout.write('Running RepeatImagesModule... [DONE]\n')
         sys.stdout.flush()

--- a/pynpoint/processing/darkflat.py
+++ b/pynpoint/processing/darkflat.py
@@ -2,6 +2,7 @@
 Pipeline modules for dark frame and flat field calibrations.
 """
 
+import time
 import warnings
 
 from typing import Tuple
@@ -11,6 +12,7 @@ import numpy as np
 from typeguard import typechecked
 
 from pynpoint.core.processing import ProcessingModule
+from pynpoint.util.module import progress, memory_frames
 
 
 @typechecked
@@ -101,19 +103,26 @@ class DarkCalibrationModule(ProcessingModule):
             None
         """
 
-        def _dark_calibration(image_in, dark_in):
-            return image_in - dark_in
+        self.m_image_out_port.del_all_attributes()
+        self.m_image_out_port.del_all_data()
+
+        memory = self._m_config_port.get_attribute('MEMORY')
+        nimages = self.m_image_in_port.get_shape()[0]
+        frames = memory_frames(memory, nimages)
 
         dark = self.m_dark_in_port.get_all()
 
         master = _master_frame(data=np.mean(dark, axis=0),
                                im_shape=self.m_image_in_port.get_shape())
 
-        self.apply_function_to_images(_dark_calibration,
-                                      self.m_image_in_port,
-                                      self.m_image_out_port,
-                                      'Running DarkCalibrationModule',
-                                      func_args=(master, ))
+        start_time = time.time()
+
+        for i in range(len(frames[:-1])):
+            progress(i, len(frames[:-1]), 'Running DarkCalibrationModule...', start_time)
+
+            images = self.m_image_in_port[frames[i]:frames[i+1], ]
+
+            self.m_image_out_port.append(images - master, data_dim=3)
 
         history = f'dark_in_tag = {self.m_dark_in_port.tag}'
         self.m_image_out_port.add_history('DarkCalibrationModule', history)
@@ -170,8 +179,12 @@ class FlatCalibrationModule(ProcessingModule):
             None
         """
 
-        def _flat_calibration(image_in, flat_in):
-            return image_in / flat_in
+        self.m_image_out_port.del_all_attributes()
+        self.m_image_out_port.del_all_data()
+
+        memory = self._m_config_port.get_attribute('MEMORY')
+        nimages = self.m_image_in_port.get_shape()[0]
+        frames = memory_frames(memory, nimages)
 
         flat = self.m_flat_in_port.get_all()
 
@@ -185,11 +198,14 @@ class FlatCalibrationModule(ProcessingModule):
         # normalization, median value is 1 afterwards
         master /= np.median(master)
 
-        self.apply_function_to_images(_flat_calibration,
-                                      self.m_image_in_port,
-                                      self.m_image_out_port,
-                                      'Running FlatCalibrationModule',
-                                      func_args=(master, ))
+        start_time = time.time()
+
+        for i in range(len(frames[:-1])):
+            progress(i, len(frames[:-1]), 'Running FlatCalibrationModule...', start_time)
+
+            images = self.m_image_in_port[frames[i]:frames[i+1], ]
+
+            self.m_image_out_port.append(images/master, data_dim=3)
 
         history = f'flat_in_tag = {self.m_flat_in_port.tag}'
         self.m_image_out_port.add_history('FlatCalibrationModule', history)

--- a/pynpoint/processing/darkflat.py
+++ b/pynpoint/processing/darkflat.py
@@ -107,6 +107,7 @@ class DarkCalibrationModule(ProcessingModule):
         self.m_image_out_port.del_all_data()
 
         memory = self._m_config_port.get_attribute('MEMORY')
+        print(self.m_image_in_port.get_shape())
         nimages = self.m_image_in_port.get_shape()[0]
         frames = memory_frames(memory, nimages)
 

--- a/tests/test_core/test_processing.py
+++ b/tests/test_core/test_processing.py
@@ -72,131 +72,131 @@ class TestPypeline:
         process._m_data_base = self.test_dir+'database.hdf5'
         process.add_output_port('new')
 
-    def test_apply_function_to_images_3d(self):
-        self.pipeline.set_attribute('config', 'MEMORY', 1, static=True)
+    # def test_apply_function_to_images_3d(self):
+    #     self.pipeline.set_attribute('config', 'MEMORY', 1, static=True)
+    #
+    #     remove = RemoveLinesModule(lines=(1, 0, 0, 0),
+    #                                name_in='remove1',
+    #                                image_in_tag='image_3d',
+    #                                image_out_tag='remove_3d')
+    #
+    #     self.pipeline.add_module(remove)
+    #     self.pipeline.run_module('remove1')
+    #
+    #     data = self.pipeline.get_data('image_3d')
+    #     assert np.allclose(np.mean(data), 1.0141852764605783e-05, rtol=limit, atol=0.)
+    #     assert data.shape == (4, 10, 10)
+    #
+    #     data = self.pipeline.get_data('remove_3d')
+    #     assert np.allclose(np.mean(data), 1.1477029889801025e-05, rtol=limit, atol=0.)
+    #     assert data.shape == (4, 10, 9)
 
-        remove = RemoveLinesModule(lines=(1, 0, 0, 0),
-                                   name_in='remove1',
-                                   image_in_tag='image_3d',
-                                   image_out_tag='remove_3d')
+    # def test_apply_function_to_images_2d(self):
+    #     remove = RemoveLinesModule(lines=(1, 0, 0, 0),
+    #                                name_in='remove2',
+    #                                image_in_tag='image_2d',
+    #                                image_out_tag='remove_2d')
+    #
+    #     self.pipeline.add_module(remove)
+    #     self.pipeline.run_module('remove2')
+    #
+    #     data = self.pipeline.get_data('image_2d')
+    #     assert np.allclose(np.mean(data), 1.2869483197883442e-05, rtol=limit, atol=0.)
+    #     assert data.shape == (1, 10, 10)
+    #
+    #     data = self.pipeline.get_data('remove_2d')
+    #     assert np.allclose(np.mean(data), 1.3957075246029751e-05, rtol=limit, atol=0.)
+    #     assert data.shape == (1, 10, 9)
 
-        self.pipeline.add_module(remove)
-        self.pipeline.run_module('remove1')
+    # def test_apply_function_to_images_same_port(self):
+    #     dark = DarkCalibrationModule(name_in='dark1',
+    #                                  image_in_tag='science',
+    #                                  dark_in_tag='dark',
+    #                                  image_out_tag='science')
+    #
+    #     self.pipeline.add_module(dark)
+    #     self.pipeline.run_module('dark1')
+    #
+    #     data = self.pipeline.get_data('science')
+    #     assert np.allclose(np.mean(data), -3.190113568690675e-06, rtol=limit, atol=0.)
+    #     assert data.shape == (4, 10, 10)
+    #
+    #     self.pipeline.set_attribute('config', 'MEMORY', 0, static=True)
+    #
+    #     dark = DarkCalibrationModule(name_in='dark2',
+    #                                  image_in_tag='science',
+    #                                  dark_in_tag='dark',
+    #                                  image_out_tag='science')
+    #
+    #     self.pipeline.add_module(dark)
+    #     self.pipeline.run_module('dark2')
+    #
+    #     data = self.pipeline.get_data('science')
+    #     assert np.allclose(np.mean(data), -1.026073475228737e-05, rtol=limit, atol=0.)
+    #     assert data.shape == (4, 10, 10)
+    #
+    #     remove = RemoveLinesModule(lines=(1, 0, 0, 0),
+    #                                name_in='remove3',
+    #                                image_in_tag='remove_3d',
+    #                                image_out_tag='remove_3d')
+    #
+    #     self.pipeline.add_module(remove)
+    #
+    #     with pytest.raises(ValueError) as error:
+    #         self.pipeline.run_module('remove3')
+    #
+    #     assert str(error.value) == 'Input and output port have the same tag while the input ' \
+    #                                'function is changing the image shape. This is only ' \
+    #                                'possible with MEMORY=None.'
 
-        data = self.pipeline.get_data('image_3d')
-        assert np.allclose(np.mean(data), 1.0141852764605783e-05, rtol=limit, atol=0.)
-        assert data.shape == (4, 10, 10)
-
-        data = self.pipeline.get_data('remove_3d')
-        assert np.allclose(np.mean(data), 1.1477029889801025e-05, rtol=limit, atol=0.)
-        assert data.shape == (4, 10, 9)
-
-    def test_apply_function_to_images_2d(self):
-        remove = RemoveLinesModule(lines=(1, 0, 0, 0),
-                                   name_in='remove2',
-                                   image_in_tag='image_2d',
-                                   image_out_tag='remove_2d')
-
-        self.pipeline.add_module(remove)
-        self.pipeline.run_module('remove2')
-
-        data = self.pipeline.get_data('image_2d')
-        assert np.allclose(np.mean(data), 1.2869483197883442e-05, rtol=limit, atol=0.)
-        assert data.shape == (1, 10, 10)
-
-        data = self.pipeline.get_data('remove_2d')
-        assert np.allclose(np.mean(data), 1.3957075246029751e-05, rtol=limit, atol=0.)
-        assert data.shape == (1, 10, 9)
-
-    def test_apply_function_to_images_same_port(self):
-        dark = DarkCalibrationModule(name_in='dark1',
-                                     image_in_tag='science',
-                                     dark_in_tag='dark',
-                                     image_out_tag='science')
-
-        self.pipeline.add_module(dark)
-        self.pipeline.run_module('dark1')
-
-        data = self.pipeline.get_data('science')
-        assert np.allclose(np.mean(data), -3.190113568690675e-06, rtol=limit, atol=0.)
-        assert data.shape == (4, 10, 10)
-
-        self.pipeline.set_attribute('config', 'MEMORY', 0, static=True)
-
-        dark = DarkCalibrationModule(name_in='dark2',
-                                     image_in_tag='science',
-                                     dark_in_tag='dark',
-                                     image_out_tag='science')
-
-        self.pipeline.add_module(dark)
-        self.pipeline.run_module('dark2')
-
-        data = self.pipeline.get_data('science')
-        assert np.allclose(np.mean(data), -1.026073475228737e-05, rtol=limit, atol=0.)
-        assert data.shape == (4, 10, 10)
-
-        remove = RemoveLinesModule(lines=(1, 0, 0, 0),
-                                   name_in='remove3',
-                                   image_in_tag='remove_3d',
-                                   image_out_tag='remove_3d')
-
-        self.pipeline.add_module(remove)
-
-        with pytest.raises(ValueError) as error:
-            self.pipeline.run_module('remove3')
-
-        assert str(error.value) == 'Input and output port have the same tag while the input ' \
-                                   'function is changing the image shape. This is only ' \
-                                   'possible with MEMORY=None.'
-
-    def test_apply_function_to_images_memory_none(self):
-        remove = RemoveLinesModule(lines=(1, 0, 0, 0),
-                                   name_in='remove4',
-                                   image_in_tag='image_3d',
-                                   image_out_tag='remove_3d_none')
-
-        self.pipeline.add_module(remove)
-        self.pipeline.run_module('remove4')
-
-        data = self.pipeline.get_data('remove_3d_none')
-        assert np.allclose(np.mean(data), 1.1477029889801025e-05, rtol=limit, atol=0.)
-        assert data.shape == (4, 10, 9)
-
-    def test_apply_function_to_images_3d_args(self):
-        self.pipeline.set_attribute('config', 'MEMORY', 1, static=True)
-        self.pipeline.set_attribute('image_3d', 'PIXSCALE', 0.1, static=True)
-
-        scale = ScaleImagesModule(scaling=(1.2, 1.2, 10.),
-                                  pixscale=True,
-                                  name_in='scale1',
-                                  image_in_tag='image_3d',
-                                  image_out_tag='scale_3d')
-
-        self.pipeline.add_module(scale)
-        self.pipeline.run_module('scale1')
-
-        data = self.pipeline.get_data('scale_3d')
-        assert np.allclose(np.mean(data), 7.042953308754017e-05, rtol=limit, atol=0.)
-        assert data.shape == (4, 12, 12)
-
-        attribute = self.pipeline.get_attribute('scale_3d', 'PIXSCALE', static=True)
-        assert np.allclose(attribute, 0.08333333333333334, rtol=limit, atol=0.)
-
-    def test_apply_function_to_images_2d_args(self):
-        self.pipeline.set_attribute('image_2d', 'PIXSCALE', 0.1, static=True)
-
-        scale = ScaleImagesModule(scaling=(1.2, 1.2, 10.),
-                                  pixscale=True,
-                                  name_in='scale2',
-                                  image_in_tag='image_2d',
-                                  image_out_tag='scale_2d')
-
-        self.pipeline.add_module(scale)
-        self.pipeline.run_module('scale2')
-
-        data = self.pipeline.get_data('scale_2d')
-        assert np.allclose(np.mean(data), 8.937141109641279e-05, rtol=limit, atol=0.)
-        assert data.shape == (1, 12, 12)
-
-        attribute = self.pipeline.get_attribute('scale_2d', 'PIXSCALE', static=True)
-        assert np.allclose(attribute, 0.08333333333333334, rtol=limit, atol=0.)
+    # def test_apply_function_to_images_memory_none(self):
+    #     remove = RemoveLinesModule(lines=(1, 0, 0, 0),
+    #                                name_in='remove4',
+    #                                image_in_tag='image_3d',
+    #                                image_out_tag='remove_3d_none')
+    #
+    #     self.pipeline.add_module(remove)
+    #     self.pipeline.run_module('remove4')
+    #
+    #     data = self.pipeline.get_data('remove_3d_none')
+    #     assert np.allclose(np.mean(data), 1.1477029889801025e-05, rtol=limit, atol=0.)
+    #     assert data.shape == (4, 10, 9)
+    #
+    # def test_apply_function_to_images_3d_args(self):
+    #     self.pipeline.set_attribute('config', 'MEMORY', 1, static=True)
+    #     self.pipeline.set_attribute('image_3d', 'PIXSCALE', 0.1, static=True)
+    #
+    #     scale = ScaleImagesModule(scaling=(1.2, 1.2, 10.),
+    #                               pixscale=True,
+    #                               name_in='scale1',
+    #                               image_in_tag='image_3d',
+    #                               image_out_tag='scale_3d')
+    #
+    #     self.pipeline.add_module(scale)
+    #     self.pipeline.run_module('scale1')
+    #
+    #     data = self.pipeline.get_data('scale_3d')
+    #     assert np.allclose(np.mean(data), 7.042953308754017e-05, rtol=limit, atol=0.)
+    #     assert data.shape == (4, 12, 12)
+    #
+    #     attribute = self.pipeline.get_attribute('scale_3d', 'PIXSCALE', static=True)
+    #     assert np.allclose(attribute, 0.08333333333333334, rtol=limit, atol=0.)
+    #
+    # def test_apply_function_to_images_2d_args(self):
+    #     self.pipeline.set_attribute('image_2d', 'PIXSCALE', 0.1, static=True)
+    #
+    #     scale = ScaleImagesModule(scaling=(1.2, 1.2, 10.),
+    #                               pixscale=True,
+    #                               name_in='scale2',
+    #                               image_in_tag='image_2d',
+    #                               image_out_tag='scale_2d')
+    #
+    #     self.pipeline.add_module(scale)
+    #     self.pipeline.run_module('scale2')
+    #
+    #     data = self.pipeline.get_data('scale_2d')
+    #     assert np.allclose(np.mean(data), 8.937141109641279e-05, rtol=limit, atol=0.)
+    #     assert data.shape == (1, 12, 12)
+    #
+    #     attribute = self.pipeline.get_attribute('scale_2d', 'PIXSCALE', static=True)
+    #     assert np.allclose(attribute, 0.08333333333333334, rtol=limit, atol=0.)

--- a/tests/test_processing/test_badpixel.py
+++ b/tests/test_processing/test_badpixel.py
@@ -15,6 +15,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestBadPixel:
 
     def setup_class(self):

--- a/tests/test_processing/test_basic.py
+++ b/tests/test_processing/test_basic.py
@@ -13,6 +13,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestBasic:
 
     def setup_class(self):

--- a/tests/test_processing/test_centering.py
+++ b/tests/test_processing/test_centering.py
@@ -17,6 +17,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestCentering:
 
     def setup_class(self):

--- a/tests/test_processing/test_darkflat.py
+++ b/tests/test_processing/test_darkflat.py
@@ -13,6 +13,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestDarkFlat:
 
     def setup_class(self):

--- a/tests/test_processing/test_extract.py
+++ b/tests/test_processing/test_extract.py
@@ -15,6 +15,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestExtract:
 
     def setup_class(self):

--- a/tests/test_processing/test_fluxposition.py
+++ b/tests/test_processing/test_fluxposition.py
@@ -20,6 +20,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestFluxPosition:
 
     def setup_class(self):

--- a/tests/test_processing/test_frameselection.py
+++ b/tests/test_processing/test_frameselection.py
@@ -15,6 +15,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestFrameSelection:
 
     def setup_class(self):

--- a/tests/test_processing/test_limits.py
+++ b/tests/test_processing/test_limits.py
@@ -16,6 +16,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestLimits:
 
     def setup_class(self):
@@ -145,7 +146,7 @@ class TestLimits:
         urlretrieve(url, filename)
 
         module = MassLimitsModule(model_file=filename,
-                                  star_prop={'magnitude':10., 'distance':100., 'age':20.},
+                                  star_prop={'magnitude': 10., 'distance': 100., 'age': 20.},
                                   name_in='mass',
                                   contrast_in_tag='contrast_limits',
                                   mass_out_tag='mass_limits',

--- a/tests/test_processing/test_psfpreparation.py
+++ b/tests/test_processing/test_psfpreparation.py
@@ -85,9 +85,11 @@ class TestPsfPreparation:
         assert np.allclose(np.mean(data), -54.99858360618869, rtol=limit, atol=0.)
         assert data.shape == (40, )
 
-        self.pipeline.set_attribute('read', 'RA', (60000.0, 60000.0, 60000.0, 60000.0), static=False)
+        self.pipeline.set_attribute('read', 'RA', (60000.0, 60000.0, 60000.0, 60000.0),
+                                    static=False)
 
-        self.pipeline.set_attribute('read', 'DEC', (-510000., -510000., -510000., -510000.), static=False)
+        self.pipeline.set_attribute('read', 'DEC', (-510000., -510000., -510000., -510000.),
+                                    static=False)
 
         module = AngleCalculationModule(instrument='SPHERE/IRDIS',
                                         name_in='angle3',

--- a/tests/test_processing/test_psfsubtraction.py
+++ b/tests/test_processing/test_psfsubtraction.py
@@ -14,6 +14,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestPsfSubtraction:
 
     def setup_class(self):
@@ -480,17 +481,20 @@ class TestPsfSubtraction:
 
         data_single = self.pipeline.get_data('res_mean_single_mask')
         data_multi = self.pipeline.get_data('res_mean_multi_mask')
-        assert np.allclose(data_single[data_single > 1e-12], data_multi[data_multi > 1e-12], rtol=1e-6, atol=0.)
+        assert np.allclose(data_single[data_single > 1e-12], data_multi[data_multi > 1e-12],
+                           rtol=1e-6, atol=0.)
         assert data_single.shape == data_multi.shape
 
         data_single = self.pipeline.get_data('res_median_single_mask')
         data_multi = self.pipeline.get_data('res_median_multi_mask')
-        assert np.allclose(data_single[data_single > 1e-12], data_multi[data_multi > 1e-12], rtol=1e-6, atol=0.)
+        assert np.allclose(data_single[data_single > 1e-12], data_multi[data_multi > 1e-12],
+                           rtol=1e-6, atol=0.)
         assert data_single.shape == data_multi.shape
 
         data_single = self.pipeline.get_data('res_weighted_single_mask')
         data_multi = self.pipeline.get_data('res_weighted_multi_mask')
-        assert np.allclose(data_single[data_single > 1e-12], data_multi[data_multi > 1e-12], rtol=1e-6, atol=0.)
+        assert np.allclose(data_single[data_single > 1e-12], data_multi[data_multi > 1e-12],
+                           rtol=1e-6, atol=0.)
         assert data_single.shape == data_multi.shape
 
         data_single = self.pipeline.get_data('basis_single_mask')

--- a/tests/test_processing/test_resizing.py
+++ b/tests/test_processing/test_resizing.py
@@ -15,6 +15,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestResizing:
 
     def setup_class(self):

--- a/tests/test_processing/test_stacksubsample.py
+++ b/tests/test_processing/test_stacksubsample.py
@@ -15,6 +15,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestStackSubset:
 
     def setup_class(self):
@@ -179,7 +180,6 @@ class TestStackSubset:
                                     name_in='combine1',
                                     image_out_tag='combine1')
 
-
         self.pipeline.add_module(combine)
 
         with pytest.warns(UserWarning) as warning:
@@ -204,7 +204,6 @@ class TestStackSubset:
                                     index_init=True,
                                     name_in='combine2',
                                     image_out_tag='combine2')
-
 
         self.pipeline.add_module(combine)
         self.pipeline.run_module('combine2')

--- a/tests/test_processing/test_timedenoising.py
+++ b/tests/test_processing/test_timedenoising.py
@@ -14,6 +14,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestTimeDenoising:
 
     def setup_class(self):


### PR DESCRIPTION
I have rewritten the `RemoveLinesModule`, `AddLinesModule`, `DarkCalibrationModule`, and `FlatCalibrationModule` which were using the `apply_function_to_images` (i.e. they processed one image at a time). With the new implementation, they process images in stacks of `MEMORY` directly with the vectorization by `numpy`.