### PR TITLE
Add chop subtraction and cropping options to NEARReadingModule

### DIFF
--- a/pynpoint/processing/psfpreparation.py
+++ b/pynpoint/processing/psfpreparation.py
@@ -237,9 +237,6 @@ class AngleInterpolationModule(ProcessingModule):
 
         steps = self.m_data_in_port.get_attribute('NFRAMES')
 
-        print(self.m_data_in_port.tag)
-        print(parang_start,parang_end,steps)
-
         if 'NDIT' in self.m_data_in_port.get_all_non_static_attributes():
             ndit = self.m_data_in_port.get_attribute('NDIT')
 

--- a/pynpoint/processing/psfpreparation.py
+++ b/pynpoint/processing/psfpreparation.py
@@ -237,6 +237,9 @@ class AngleInterpolationModule(ProcessingModule):
 
         steps = self.m_data_in_port.get_attribute('NFRAMES')
 
+        print(self.m_data_in_port.tag)
+        print(parang_start,parang_end,steps)
+
         if 'NDIT' in self.m_data_in_port.get_all_non_static_attributes():
             ndit = self.m_data_in_port.get_attribute('NDIT')
 
@@ -258,10 +261,14 @@ class AngleInterpolationModule(ProcessingModule):
             elif parang_end[i] < -170. and parang_start[i] > 170.:
                 parang_end[i] += 360.
 
-            new_angles = np.append(new_angles,
-                                   np.linspace(parang_start[i],
-                                               parang_end[i],
-                                               num=steps[i]))
+            if steps[i] == 1:
+                new_angles = np.append(new_angles,
+                                      [(parang_start[i] + parang_end[i])/2.])
+            elif steps[i] != 1:
+                new_angles = np.append(new_angles,
+                                       np.linspace(parang_start[i],
+                                                   parang_end[i],
+                                                   num=steps[i]))
 
         sys.stdout.write('Running AngleInterpolationModule... [DONE]\n')
         sys.stdout.flush()

--- a/pynpoint/readwrite/nearreading.py
+++ b/pynpoint/readwrite/nearreading.py
@@ -10,9 +10,10 @@ import subprocess
 import threading
 import warnings
 
-from typing import Tuple
+from typing import Union, Tuple
 
 import numpy as np
+import math
 
 from astropy.io import fits
 from typeguard import typechecked
@@ -20,6 +21,7 @@ from typeguard import typechecked
 from pynpoint.core.processing import ReadingModule
 from pynpoint.util.attributes import set_static_attr, set_nonstatic_attr, set_extra_attr
 from pynpoint.util.module import progress, memory_frames
+from pynpoint.util.image import crop_image
 
 
 class NearReadingModule(ReadingModule):
@@ -32,14 +34,18 @@ class NearReadingModule(ReadingModule):
     contains the average of all images.
     """
 
-    __author__ = 'Jasper Jonker, Tomas Stolker'
+    __author__ = 'Jasper Jonker, Tomas Stolker, Anna Boehle'
 
     @typechecked
     def __init__(self,
                  name_in: str,
                  input_dir: str = None,
                  chopa_out_tag: str = 'chopa',
-                 chopb_out_tag: str = 'chopb'):
+                 chopb_out_tag: str = 'chopb',
+                 do_chop_sub: bool = False,
+                 do_chopa_crop: bool = False,
+                 crop_size: float = 5.,
+                 crop_center: Union[tuple, None] = (432, 287)):
         """
         Parameters
         ----------
@@ -54,6 +60,16 @@ class NearReadingModule(ReadingModule):
         chopb_out_tag : str
             Database entry where the chop B images will be stored. Should be different from
             ``chop_a_out_tag``.
+        do_chop_sub : bool
+            If True, the other chop position is subtracted before saving out chop A and chop B images.
+        do_chopa_crop: bool
+            If True, the chop A images are cropped around the location given by crop_center
+            and with the image size given by crop_size before saving them out.
+        crop_size : float
+            Cropped chop A image size (arcsec). The same size will be used for both image dimensions.
+        crop_center : tuple(int, int), None
+            Tuple (x0, y0) with the cropped chop A image center. As all chop A images are cropped around
+            the same location, the crop_center location should be roughly the coronagraph position.
 
         Returns
         -------
@@ -65,6 +81,12 @@ class NearReadingModule(ReadingModule):
 
         self.m_chopa_out_port = self.add_output_port(chopa_out_tag)
         self.m_chopb_out_port = self.add_output_port(chopb_out_tag)
+
+        self.m_do_chop_sub = do_chop_sub
+        self.m_do_chopa_crop = do_chopa_crop
+
+        self.m_crop_size = crop_size
+        self.m_crop_center = crop_center
 
     @typechecked
     def _uncompress_file(self,
@@ -355,6 +377,11 @@ class NearReadingModule(ReadingModule):
         # check if there are FITS files present in the input location
         assert(files), f'No FITS files found in {self.m_input_location}.'
 
+        # if cropping chop A, get pixscale and convert crop_size to pixels and swap x/y
+        if self.m_do_chopa_crop:
+            self.m_crop_size = int(math.ceil(self.m_crop_size / self._m_config_port.get_attribute('PIXSCALE')))
+            self.m_crop_center = (self.m_crop_center[1], self.m_crop_center[0])
+
         start_time = time.time()
         for i, filename in enumerate(files):
             progress(i, len(files), 'Running NearReadingModule...', start_time)
@@ -364,6 +391,16 @@ class NearReadingModule(ReadingModule):
 
             # get the images of chop A and chop B
             chopa, chopb = self.read_images(filename, im_shape)
+
+            if self.m_do_chop_sub:
+                chopa = chopa - chopb
+                chopb = -chopa
+
+            if self.m_do_chopa_crop:
+                chopa = crop_image(chopa,
+                                   center=self.m_crop_center,
+                                   size=self.m_crop_size,
+                                   copy=False)
 
             # append the images of chop A and B
             self.m_chopa_out_port.append(chopa, data_dim=3)

--- a/tests/test_readwrite/test_fitsreading.py
+++ b/tests/test_readwrite/test_fitsreading.py
@@ -14,6 +14,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestFitsReadingModule:
 
     def setup_class(self):
@@ -255,8 +256,8 @@ class TestFitsReadingModule:
         with pytest.raises(ValueError) as error:
             self.pipeline.run_module('read9')
 
-        assert str(error.value) == f'The file fits/image00.fits does not exist. '\
-        'Please check that the path is correct.'
+        assert str(error.value) == 'The file fits/image00.fits does not exist. ' \
+                                   'Please check that the path is correct.'
 
     def test_fits_read_textfile_exists(self):
 
@@ -276,5 +277,5 @@ class TestFitsReadingModule:
         with pytest.raises(ValueError) as error:
             self.pipeline.run_module('read10')
 
-        assert str(error.value) == f'The file fits/image00.fits does not exist. '\
-        'Please check that the path is correct.'
+        assert str(error.value) == 'The file fits/image00.fits does not exist. ' \
+                                   'Please check that the path is correct.'

--- a/tests/test_readwrite/test_fitswriting.py
+++ b/tests/test_readwrite/test_fitswriting.py
@@ -13,6 +13,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestFitsWritingModule:
 
     def setup_class(self):

--- a/tests/test_readwrite/test_hdf5reading.py
+++ b/tests/test_readwrite/test_hdf5reading.py
@@ -13,6 +13,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestHdf5ReadingModule:
 
     def setup_class(self):
@@ -32,14 +33,14 @@ class TestHdf5ReadingModule:
 
         data = np.random.normal(loc=0, scale=2e-4, size=(4, 10, 10))
 
-        with  h5py.File(self.test_dir+'data/PynPoint_database.hdf5', 'a') as hdf_file:
+        with h5py.File(self.test_dir+'data/PynPoint_database.hdf5', 'a') as hdf_file:
             hdf_file.create_dataset('extra', data=data)
             hdf_file.create_dataset('header_extra/PARANG', data=[1., 2., 3., 4.])
 
         read = Hdf5ReadingModule(name_in='read1',
                                  input_filename='PynPoint_database.hdf5',
                                  input_dir=self.test_dir+'data',
-                                 tag_dictionary={'images':'images'})
+                                 tag_dictionary={'images': 'images'})
 
         self.pipeline.add_module(read)
         self.pipeline.run_module('read1')
@@ -69,7 +70,7 @@ class TestHdf5ReadingModule:
         read = Hdf5ReadingModule(name_in='read3',
                                  input_filename='PynPoint_database.hdf5',
                                  input_dir=self.test_dir+'data',
-                                 tag_dictionary={'test':'test'})
+                                 tag_dictionary={'test': 'test'})
 
         self.pipeline.add_module(read)
 

--- a/tests/test_readwrite/test_hdf5writing.py
+++ b/tests/test_readwrite/test_hdf5writing.py
@@ -13,6 +13,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestHdf5WritingModule:
 
     def setup_class(self):
@@ -33,7 +34,7 @@ class TestHdf5WritingModule:
         write = Hdf5WritingModule(file_name='test.hdf5',
                                   name_in='write1',
                                   output_dir=None,
-                                  tag_dictionary={'images':'data1'},
+                                  tag_dictionary={'images': 'data1'},
                                   keep_attributes=True,
                                   overwrite=True)
 
@@ -45,7 +46,7 @@ class TestHdf5WritingModule:
         write = Hdf5WritingModule(file_name='test.hdf5',
                                   name_in='write2',
                                   output_dir=None,
-                                  tag_dictionary={'empty':'empty'},
+                                  tag_dictionary={'empty': 'empty'},
                                   keep_attributes=True,
                                   overwrite=False)
 
@@ -63,7 +64,7 @@ class TestHdf5WritingModule:
         write = Hdf5WritingModule(file_name='test.hdf5',
                                   name_in='write3',
                                   output_dir=None,
-                                  tag_dictionary={'images':'data2'},
+                                  tag_dictionary={'images': 'data2'},
                                   keep_attributes=True,
                                   overwrite=False)
 
@@ -87,7 +88,7 @@ class TestHdf5WritingModule:
         read = Hdf5ReadingModule(name_in='read',
                                  input_filename='test.hdf5',
                                  input_dir=self.test_dir,
-                                 tag_dictionary={'data1':'data1', 'data2':'data2'})
+                                 tag_dictionary={'data1': 'data1', 'data2': 'data2'})
 
         self.pipeline.add_module(read)
         self.pipeline.run_module('read')

--- a/tests/test_readwrite/test_nearreading.py
+++ b/tests/test_readwrite/test_nearreading.py
@@ -14,6 +14,7 @@ warnings.simplefilter('always')
 
 limit = 1e-6
 
+
 class TestNearInitModule(object):
 
     def setup_class(self):
@@ -44,19 +45,40 @@ class TestNearInitModule(object):
 
     def test_near_read(self):
 
-        module = NearReadingModule(name_in='read1',
+        module = NearReadingModule(name_in='read1a',
                                    input_dir=self.test_dir+'near',
                                    chopa_out_tag=self.positions[0],
                                    chopb_out_tag=self.positions[1])
 
         self.pipeline.add_module(module)
-        self.pipeline.run_module('read1')
+        self.pipeline.run_module('read1a')
 
         for item in self.positions:
 
             data = self.pipeline.get_data(item)
             assert np.allclose(np.mean(data), 0.060582854, rtol=limit, atol=0.)
             assert data.shape == (20, 10, 10)
+
+    def test_near_subtract_crop_combine(self):
+
+        module = NearReadingModule(name_in='read1b',
+                                   input_dir=self.test_dir+'near',
+                                   chopa_out_tag=self.positions[0],
+                                   chopb_out_tag=self.positions[1],
+                                   subtract=True,
+                                   crop=(None, None, 0.3),
+                                   combine='mean')
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('read1b')
+
+        data = self.pipeline.get_data(self.positions[0])
+        assert np.allclose(np.mean(data), 0.0, rtol=limit, atol=0.)
+        assert data.shape == (4, 7, 7)
+
+        data = self.pipeline.get_data(self.positions[1])
+        assert np.allclose(np.mean(data), 0.0, rtol=limit, atol=0.)
+        assert data.shape == (4, 7, 7)
 
     def test_static_not_found(self):
 

--- a/tests/test_readwrite/test_textreading.py
+++ b/tests/test_readwrite/test_textreading.py
@@ -12,6 +12,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestTextReading:
 
     def setup_class(self):

--- a/tests/test_readwrite/test_textwriting.py
+++ b/tests/test_readwrite/test_textwriting.py
@@ -14,6 +14,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestTextReading:
 
     def setup_class(self):


### PR DESCRIPTION
Added options to the NEARReadingModule to perform the chop subtraction (chop A - chop B and vice versa) and/or the image cropping (cropping images around a fixed location, i.e., the coronagraph position) prior to writing out the chopA and chopB data sets to the database. The goal with this change is to skip saving some of the intermediate steps of the data reduction. Note that with the default cropping size you do remove the region with the non-coronagraphic PSF.