### PR TITLE
weighted residuals for SimplexMinimization and MCMC

### DIFF
--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -401,7 +401,9 @@ class SimplexMinimizationModule(ProcessingModule):
                                                                indices=None)
 
             res_stack = combine_residuals(method=self.m_residuals,
-                                          res_rot=im_res_derot, residuals=im_res_rot, angles=parang)
+                                          res_rot=im_res_derot,
+                                          residuals=im_res_rot,
+                                          angles=parang)
 
             self.m_res_out_port.append(res_stack, data_dim=3)
 
@@ -746,64 +748,6 @@ class MCMCsamplingModule(ProcessingModule):
         else:
             self.m_mask = mask
 
-    # @typechecked
-    # def gaussian_variance(self,
-    #                       images: np.ndarray,
-    #                       psf: np.ndarray,
-    #                       parang: np.ndarray,
-    #                       aperture: Tuple[int, int, float]) -> float:
-    #     """
-    #     Function to compute the (constant) variance for the likelihood function when the
-    #     merit parameter is set to 'gaussian'. The planet is first removed from the dataset
-    #     with the `param` values.
-    #
-    #     Parameters
-    #     ----------
-    #     images : numpy.ndarray
-    #         Masked input images.
-    #     psf : numpy.ndarray
-    #         PSF template.
-    #     parang : numpy.ndarray
-    #         Parallactic angles (deg).
-    #     aperture : tuple(int, int, float)
-    #         Properties of the circular aperture. The radius is recommended to be larger than or
-    #         equal to 0.5*lambda/D.
-    #
-    #     Returns
-    #     -------
-    #     float
-    #         Variance (counts).
-    #     """
-    #
-    #     pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
-    #
-    #     fake = fake_planet(images=images,
-    #                        psf=psf,
-    #                        parang=parang,
-    #                        position=(self.m_param[0]/pixscale, self.m_param[1]),
-    #                        magnitude=self.m_param[2],
-    #                        psf_scaling=self.m_psf_scaling)
-    #
-    #     im_res_rot, im_res_derot = pca_psf_subtraction(images=fake,
-    #                                                    angles=-1.*parang+self.m_extra_rot,
-    #                                                    pca_number=self.m_pca_number)
-    #
-    #     res_stack = combine_residuals(method=self.m_residuals,
-    #                                   res_rot=im_res_derot, residuals=im_res_rot, angles=parang)
-    #
-    #     # separation (pix) and position angle (deg)
-    #     sep_ang = cartesian_to_polar(center=center_subpixel(res_stack),
-    #                                  y_pos=aperture[0],
-    #                                  x_pos=aperture[1])
-    #
-    #     selected = select_annulus(image_in=res_stack[0, ],
-    #                               radius_in=sep_ang[0]-aperture[2],
-    #                               radius_out=sep_ang[0]+aperture[2],
-    #                               mask_position=aperture[0:2],
-    #                               mask_radius=aperture[2])
-    #
-    #     return np.var(selected)
-
     @typechecked
     def run(self) -> None:
         """
@@ -859,11 +803,6 @@ class MCMCsamplingModule(ProcessingModule):
         initial[:, 0] = self.m_param[0] + np.random.normal(0, self.m_sigma[0], self.m_nwalkers)
         initial[:, 1] = self.m_param[1] + np.random.normal(0, self.m_sigma[1], self.m_nwalkers)
         initial[:, 2] = self.m_param[2] + np.random.normal(0, self.m_sigma[2], self.m_nwalkers)
-
-        # if self.m_merit == 'gaussian':
-        #     variance = self.gaussian_variance(images*mask, psf, parang, aperture)
-        # else:
-        #     variance = None
 
         sampler = emcee.EnsembleSampler(nwalkers=self.m_nwalkers,
                                         dim=ndim,

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -383,24 +383,25 @@ class SimplexMinimizationModule(ProcessingModule):
             mask = create_mask(fake.shape[-2:], (self.m_cent_size, self.m_edge_size))
 
             if self.m_reference_in_port is None:
-                _, im_res = pca_psf_subtraction(images=fake*mask,
-                                                angles=-1.*parang+self.m_extra_rot,
-                                                pca_number=self.m_pca_number,
-                                                pca_sklearn=None,
-                                                im_shape=None,
-                                                indices=None)
+                im_res_rot, im_res_derot = pca_psf_subtraction(images=fake*mask,
+                                                               angles=-1.*parang+self.m_extra_rot,
+                                                               pca_number=self.m_pca_number,
+                                                               pca_sklearn=None,
+                                                               im_shape=None,
+                                                               indices=None)
 
             else:
                 im_reshape = np.reshape(fake*mask, (im_shape[0], im_shape[1]*im_shape[2]))
 
-                _, im_res = pca_psf_subtraction(images=im_reshape,
-                                                angles=-1.*parang+self.m_extra_rot,
-                                                pca_number=self.m_pca_number,
-                                                pca_sklearn=sklearn_pca,
-                                                im_shape=im_shape,
-                                                indices=None)
+                im_res_rot, im_res_derot = pca_psf_subtraction(images=im_reshape,
+                                                               angles=-1.*parang+self.m_extra_rot,
+                                                               pca_number=self.m_pca_number,
+                                                               pca_sklearn=sklearn_pca,
+                                                               im_shape=im_shape,
+                                                               indices=None)
 
-            res_stack = combine_residuals(method=self.m_residuals, res_rot=im_res)
+            res_stack = combine_residuals(method=self.m_residuals,
+                                          res_rot=im_res_derot, residuals=im_res_rot, angles=parang)
 
             self.m_res_out_port.append(res_stack, data_dim=3)
 
@@ -783,11 +784,12 @@ class MCMCsamplingModule(ProcessingModule):
     #                        magnitude=self.m_param[2],
     #                        psf_scaling=self.m_psf_scaling)
     #
-    #     _, res_arr = pca_psf_subtraction(images=fake,
-    #                                      angles=-1.*parang+self.m_extra_rot,
-    #                                      pca_number=self.m_pca_number)
+    #     im_res_rot, im_res_derot = pca_psf_subtraction(images=fake,
+    #                                                    angles=-1.*parang+self.m_extra_rot,
+    #                                                    pca_number=self.m_pca_number)
     #
-    #     res_stack = combine_residuals(method=self.m_residuals, res_rot=res_arr)
+    #     res_stack = combine_residuals(method=self.m_residuals,
+    #                                   res_rot=im_res_derot, residuals=im_res_rot, angles=parang)
     #
     #     # separation (pix) and position angle (deg)
     #     sep_ang = cartesian_to_polar(center=center_subpixel(res_stack),

--- a/pynpoint/util/mcmc.py
+++ b/pynpoint/util/mcmc.py
@@ -122,12 +122,13 @@ def lnprob(param: np.ndarray,
                            magnitude=mag,
                            psf_scaling=psf_scaling)
 
-        _, im_res = pca_psf_subtraction(images=fake*mask,
-                                        angles=-1.*parang+extra_rot,
-                                        pca_number=pca_number,
-                                        indices=indices)
+        im_res_rot, im_res_derot = pca_psf_subtraction(images=fake*mask,
+                                                       angles=-1.*parang+extra_rot,
+                                                       pca_number=pca_number,
+                                                       indices=indices)
 
-        res_stack = combine_residuals(method=residuals, res_rot=im_res)
+        res_stack = combine_residuals(
+            method=residuals, res_rot=im_res_derot, residuals=im_res_rot, angles=parang)
 
         chi_square = merit_function(residuals=res_stack[0, ],
                                     merit=merit,

--- a/pynpoint/util/mcmc.py
+++ b/pynpoint/util/mcmc.py
@@ -127,8 +127,10 @@ def lnprob(param: np.ndarray,
                                                        pca_number=pca_number,
                                                        indices=indices)
 
-        res_stack = combine_residuals(
-            method=residuals, res_rot=im_res_derot, residuals=im_res_rot, angles=parang)
+        res_stack = combine_residuals(method=residuals,
+                                      res_rot=im_res_derot,
+                                      residuals=im_res_rot,
+                                      angles=parang)
 
         chi_square = merit_function(residuals=res_stack[0, ],
                                     merit=merit,


### PR DESCRIPTION
As requested in #374 the `SimplexMinimizationModule` and the `MCMCsamplingModule` now support the `residuals=weighted` input.
Note: The `MCMCsampingModule` has the function `gaussian_variance` function commented, therefore the change has currently no effect. I don't know whether or not you want to uncomment this.