### PR TITLE
RemoveLinesModule, bug fix NearReadingModule, test cases

### DIFF
--- a/pynpoint/core/processing.py
+++ b/pynpoint/core/processing.py
@@ -564,17 +564,7 @@ class ProcessingModule(PypelineModule, metaclass=ABCMeta):
                 else:
                     result.append(func(images[i, ], *args))
 
-            result = np.asarray(result)
-
-            if image_out_port.tag == image_in_port.tag:
-
-                if images.shape[-2] != result.shape[-2] or images.shape[-1] != result.shape[-1]:
-
-                    raise ValueError('Input and output port have the same tag while the input '
-                                     'function is changing the image shape. This is only possible '
-                                     'with MEMORY=None.')
-
-            image_out_port.set_all(result, keep_attributes=True)
+            image_out_port.set_all(np.asarray(result), keep_attributes=True)
 
             sys.stdout.write(message+' [DONE]\n')
             sys.stdout.flush()

--- a/pynpoint/processing/limits.py
+++ b/pynpoint/processing/limits.py
@@ -181,8 +181,12 @@ class ContrastCurveModule(ProcessingModule):
                              f'(without derotating) before applying the ContrastCurveModule.')
 
         cpu = self._m_config_port.get_attribute('CPU')
+        working_place = self._m_config_port.get_attribute('WORKING_PLACE')
+
         parang = self.m_image_in_port.get_attribute('PARANG')
         pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
+
+        self.m_image_in_port.close_port()
 
         if self.m_cent_size is not None:
             self.m_cent_size /= pixscale
@@ -221,8 +225,6 @@ class ContrastCurveModule(ProcessingModule):
 
         result = []
         async_results = []
-
-        working_place = self._m_config_port.get_attribute('WORKING_PLACE')
 
         # Create temporary files
         tmp_im_str = os.path.join(working_place, 'tmp_images.npy')
@@ -292,6 +294,7 @@ class ContrastCurveModule(ProcessingModule):
 
         limits = np.column_stack((pos_r*pixscale, mag_mean, mag_var, res_fpf))
 
+        self.m_contrast_out_port._check_status_and_activate()
         self.m_contrast_out_port.set_all(limits, data_dim=2)
 
         sys.stdout.write('\rRunning ContrastCurveModule... [DONE]\n')

--- a/pynpoint/processing/psfpreparation.py
+++ b/pynpoint/processing/psfpreparation.py
@@ -260,7 +260,8 @@ class AngleInterpolationModule(ProcessingModule):
 
             if steps[i] == 1:
                 new_angles = np.append(new_angles,
-                                      [(parang_start[i] + parang_end[i])/2.])
+                                       [(parang_start[i] + parang_end[i])/2.])
+
             elif steps[i] != 1:
                 new_angles = np.append(new_angles,
                                        np.linspace(parang_start[i],

--- a/pynpoint/processing/resizing.py
+++ b/pynpoint/processing/resizing.py
@@ -347,96 +347,30 @@ class RemoveLinesModule(ProcessingModule):
             None
         """
 
-        def _remove_lines(image_in, lines):
-            shape_in = image_in.shape
+        self.m_image_out_port.del_all_attributes()
+        self.m_image_out_port.del_all_data()
 
-            return image_in[int(lines[2]):shape_in[0]-int(lines[3]),
-                            int(lines[0]):shape_in[1]-int(lines[1])]
+        memory = self._m_config_port.get_attribute('MEMORY')
+        nimages = self.m_image_in_port.get_shape()[0]
+        frames = memory_frames(memory, nimages)
 
-        self.apply_function_to_images(_remove_lines,
-                                      self.m_image_in_port,
-                                      self.m_image_out_port,
-                                      'Running RemoveLinesModule',
-                                      func_args=(self.m_lines, ))
+        start_time = time.time()
+
+        for i in range(len(frames[:-1])):
+            progress(i, len(frames[:-1]), 'Running RemoveLinesModule...', start_time)
+
+            image_in = self.m_image_in_port[frames[i]:frames[i+1], ]
+
+            image_out = image_in[:,
+                                 int(self.m_lines[2]):image_in.shape[1]-int(self.m_lines[3]),
+                                 int(self.m_lines[0]):image_in.shape[2]-int(self.m_lines[1])]
+
+            self.m_image_out_port.append(image_out, data_dim=3)
+
+        sys.stdout.write('Running RemoveLinesModule... [DONE]\n')
+        sys.stdout.flush()
 
         history = f'number of lines = {self.m_lines}'
         self.m_image_out_port.add_history('RemoveLinesModule', history)
         self.m_image_out_port.copy_attributes(self.m_image_in_port)
         self.m_image_out_port.close_port()
-
-
-# class RemoveLinesModule(ProcessingModule):
-#     """
-#     Module to decrease the dimensions of an image by removing lines of pixels.
-#     """
-#
-#     @typechecked
-#     def __init__(self,
-#                  name_in: str,
-#                  image_in_tag: str,
-#                  image_out_tag: str,
-#                  lines: Tuple[int, int, int, int]) -> None:
-#         """
-#         Parameters
-#         ----------
-#         name_in : str
-#             Unique name of the module instance.
-#         image_in_tag : str
-#             Tag of the database entry that is read as input.
-#         image_out_tag : str
-#             Tag of the database entry that is written as output, including the images with
-#             decreased size. Should be different from *image_in_tag*.
-#         lines : tuple(int, int, int, int)
-#             The number of lines that are removed in left, right, bottom, and top direction.
-#
-#         Returns
-#         -------
-#         NoneType
-#             None
-#         """
-#
-#         super(RemoveLinesModule, self).__init__(name_in)
-#
-#         self.m_image_in_port = self.add_input_port(image_in_tag)
-#         self.m_image_out_port = self.add_output_port(image_out_tag)
-#
-#         self.m_lines = lines
-#
-#     @typechecked
-#     def run(self) -> None:
-#         """
-#         Run method of the module. Removes the lines given by *lines* from each frame.
-#
-#         Returns
-#         -------
-#         NoneType
-#             None
-#         """
-#
-#         self.m_image_out_port.del_all_attributes()
-#         self.m_image_out_port.del_all_data()
-#
-#         memory = self._m_config_port.get_attribute('MEMORY')
-#         nimages = self.m_image_in_port.get_shape()[0]
-#         frames = memory_frames(memory, nimages)
-#
-#         start_time = time.time()
-#
-#         for i in range(len(frames[:-1])):
-#             progress(i, len(frames[:-1]), 'Running RemoveLinesModule...', start_time)
-#
-#             image_in = self.m_image_in_port[frames[i]:frames[i+1], ]
-#
-#             image_out = image_in[:,
-#                                  int(self.m_lines[2]):image_in.shape[1]-int(self.m_lines[3]),
-#                                  int(self.m_lines[0]):image_in.shape[2]-int(self.m_lines[1])]
-#
-#             self.m_image_out_port.append(image_out, data_dim=3)
-#
-#         sys.stdout.write('Running RemoveLinesModule... [DONE]\n')
-#         sys.stdout.flush()
-#
-#         history = f'number of lines = {self.m_lines}'
-#         self.m_image_out_port.add_history('RemoveLinesModule', history)
-#         self.m_image_out_port.copy_attributes(self.m_image_in_port)
-#         self.m_image_out_port.close_port()

--- a/pynpoint/readwrite/nearreading.py
+++ b/pynpoint/readwrite/nearreading.py
@@ -408,12 +408,12 @@ class NearReadingModule(ReadingModule):
             if self.m_combine is not None:
 
                 if self.m_combine == 'mean':
-                    chopa = chopa.mean(axis=0)
-                    chopb = chopb.mean(axis=0)
+                    chopa = np.mean(chopa, axis=0)
+                    chopb = np.mean(chopb, axis=0)
 
                 elif self.m_combine == 'median':
-                    chopa = chopa.median(axis=0)
-                    chopb = chopb.median(axis=0)
+                    chopa = np.median(chopa, axis=0)
+                    chopb = np.median(chopb, axis=0)
 
                 header[self._m_config_port.get_attribute('NFRAMES')] = 1
 

--- a/pynpoint/util/module.py
+++ b/pynpoint/util/module.py
@@ -68,7 +68,7 @@ def progress(current: int,
         if fraction > 0. and current+1 != total:
             time_taken = time.time() - start_time
             time_left = time_taken / fraction * (1. - fraction)
-            sys.stdout.write(f'{message} {percentage:4.1f}% - Time: {time_string(time_left)}\r')
+            sys.stdout.write(f'{message} {percentage:4.1f}% - ETA: {time_string(time_left)}\r')
 
     if current+1 == total:
         sys.stdout.write(' ' * (29+len(message)) + '\r')

--- a/pynpoint/util/multipca.py
+++ b/pynpoint/util/multipca.py
@@ -412,6 +412,7 @@ class PcaMultiprocessingCapsule(MultiprocessingCapsule):
         processors = []
 
         for _ in range(self.m_num_proc):
+
             processors.append(PcaTaskProcessor(self.m_tasks_queue,
                                                self.m_result_queue,
                                                self.m_star_reshape,

--- a/pynpoint/util/multiproc.py
+++ b/pynpoint/util/multiproc.py
@@ -419,11 +419,9 @@ class MultiprocessingCapsule(metaclass=ABCMeta):
 
         Returns
         -------
-        list
-            Empty list.
+        NoneType
+            None
         """
-
-        return []
 
     @abstractmethod
     @typechecked

--- a/tests/test_core/test_configport.py
+++ b/tests/test_core/test_configport.py
@@ -12,6 +12,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestConfigPort:
 
     def setup_class(self):

--- a/tests/test_core/test_datastorage.py
+++ b/tests/test_core/test_datastorage.py
@@ -11,6 +11,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestDataStorage:
 
     def setup(self):

--- a/tests/test_core/test_inputport.py
+++ b/tests/test_core/test_inputport.py
@@ -11,6 +11,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestInputPort:
 
     def setup_class(self):

--- a/tests/test_core/test_outputport.py
+++ b/tests/test_core/test_outputport.py
@@ -11,16 +11,17 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
-def setup_module():
-    create_random(os.path.dirname(__file__))
-
-def teardown_module():
-    os.remove(os.path.dirname(__file__) + '/PynPoint_database.hdf5')
 
 class TestOutputPort:
 
     def setup(self):
         self.storage = DataStorage(os.path.dirname(__file__) + '/PynPoint_database.hdf5')
+
+    def setup_class(self):
+        create_random(os.path.dirname(__file__))
+
+    def teardown_class(self):
+        os.remove(os.path.dirname(__file__) + '/PynPoint_database.hdf5')
 
     def create_input_port(self, tag_name):
         inport = InputPort(tag_name, self.storage)
@@ -544,8 +545,8 @@ class TestOutputPort:
         # check that only one warning was raised
         assert len(warning) == 1
         # check that the message matches
-        assert warning[0].message.args[0] == 'Attribute \'not_existing\' does not exist and could ' \
-                                             'not be deleted.'
+        assert warning[0].message.args[0] == 'Attribute \'not_existing\' does not exist and ' \
+                                             'could not be deleted.'
 
         out_port.del_all_attributes()
         out_port.del_all_data()

--- a/tests/test_core/test_processing.py
+++ b/tests/test_core/test_processing.py
@@ -186,10 +186,7 @@ class TestProcessing:
         self.pipeline.add_module(module)
         self.pipeline.run_module('subtract_multi')
 
-        data = self.pipeline.get_data('im_sub_single')
-        assert np.allclose(np.mean(data), -7.5026790335996905e-25, rtol=limit, atol=0.)
-        assert data.shape == (10000, 100, 100)
-
+        data_single = self.pipeline.get_data('im_sub_single')
         data_multi = self.pipeline.get_data('im_sub_multi')
-        assert np.allclose(data, data_multi, rtol=limit, atol=0.)
-        assert data.shape == data_multi.shape
+        assert np.allclose(data_single, data_multi, rtol=limit, atol=0.)
+        assert data_single.shape == data_multi.shape

--- a/tests/test_core/test_processing.py
+++ b/tests/test_core/test_processing.py
@@ -7,61 +7,68 @@ import numpy as np
 
 from pynpoint.core.pypeline import Pypeline
 from pynpoint.readwrite.fitsreading import FitsReadingModule
+from pynpoint.processing.background import LineSubtractionModule
 from pynpoint.processing.badpixel import BadPixelSigmaFilterModule
-from pynpoint.processing.darkflat import DarkCalibrationModule
-from pynpoint.processing.resizing import RemoveLinesModule, ScaleImagesModule
+from pynpoint.processing.basic import RepeatImagesModule
+from pynpoint.processing.extract import StarExtractionModule
+from pynpoint.processing.timedenoising import TimeNormalizationModule
 from pynpoint.util.tests import create_config, create_star_data, remove_test_data
 
 warnings.simplefilter('always')
 
 limit = 1e-10
 
-class TestPypeline:
+
+class TestProcessing:
 
     def setup_class(self):
+
         self.test_dir = os.path.dirname(__file__) + '/'
 
         np.random.seed(1)
 
-        image_3d = np.random.normal(loc=0, scale=2e-4, size=(4, 10, 10))
-        image_2d = np.random.normal(loc=0, scale=2e-4, size=(1, 10, 10))
-        science = np.random.normal(loc=0, scale=2e-4, size=(4, 10, 10))
-        dark = np.random.normal(loc=0, scale=2e-4, size=(4, 10, 10))
+        images = np.random.normal(loc=0, scale=2e-4, size=(100, 10, 10))
+        large_data = np.random.normal(loc=0, scale=2e-4, size=(10000, 100, 100))
 
         with h5py.File(self.test_dir+'PynPoint_database.hdf5', 'w') as hdf_file:
-            hdf_file.create_dataset('image_3d', data=image_3d)
-            hdf_file.create_dataset('image_2d', data=image_2d)
-            hdf_file.create_dataset('science', data=science)
-            hdf_file.create_dataset('dark', data=dark)
+            hdf_file.create_dataset('images', data=images)
+            hdf_file.create_dataset('large_data', data=large_data)
 
         create_star_data(path=self.test_dir+'images')
         create_config(self.test_dir+'PynPoint_config.ini')
 
         self.pipeline = Pypeline(self.test_dir, self.test_dir, self.test_dir)
 
+        self.pipeline.set_attribute('images', 'PIXSCALE', 0.1, static=True)
+        self.pipeline.set_attribute('large_data', 'PIXSCALE', 0.1, static=True)
+
     def teardown_class(self):
+
         remove_test_data(self.test_dir, folders=['images'])
 
     def test_output_port_name(self):
-        read = FitsReadingModule(name_in='read', input_dir=self.test_dir+'images',
-                                 image_tag='images')
-        read.add_output_port('test')
+
+        module = FitsReadingModule(name_in='read',
+                                   image_tag='images',
+                                   input_dir=self.test_dir+'images')
+
+        module.add_output_port('test')
 
         with pytest.warns(UserWarning) as warning:
-            read.add_output_port('test')
+            module.add_output_port('test')
 
         assert len(warning) == 1
         assert warning[0].message.args[0] == 'Tag \'test\' of ReadingModule \'read\' is already ' \
                                              'used.'
 
-        process = BadPixelSigmaFilterModule(name_in='badpixel',
-                                            image_in_tag='images',
-                                            image_out_tag='im_out')
+        module = BadPixelSigmaFilterModule(name_in='badpixel',
+                                           image_in_tag='images',
+                                           image_out_tag='im_out')
 
-        process.add_output_port('test')
+        module.add_output_port('test')
 
         with pytest.warns(UserWarning) as warning:
-            process.add_output_port('test')
+            module.add_output_port('test')
 
         assert len(warning) == 1
         assert warning[0].message.args[0] == 'Tag \'test\' of ProcessingModule \'badpixel\' is ' \
@@ -69,134 +76,120 @@ class TestPypeline:
 
         self.pipeline.m_data_storage.close_connection()
 
-        process._m_data_base = self.test_dir+'database.hdf5'
-        process.add_output_port('new')
+        module._m_data_base = self.test_dir+'database.hdf5'
+        module.add_output_port('new')
 
-    # def test_apply_function_to_images_3d(self):
-    #     self.pipeline.set_attribute('config', 'MEMORY', 1, static=True)
-    #
-    #     remove = RemoveLinesModule(lines=(1, 0, 0, 0),
-    #                                name_in='remove1',
-    #                                image_in_tag='image_3d',
-    #                                image_out_tag='remove_3d')
-    #
-    #     self.pipeline.add_module(remove)
-    #     self.pipeline.run_module('remove1')
-    #
-    #     data = self.pipeline.get_data('image_3d')
-    #     assert np.allclose(np.mean(data), 1.0141852764605783e-05, rtol=limit, atol=0.)
-    #     assert data.shape == (4, 10, 10)
-    #
-    #     data = self.pipeline.get_data('remove_3d')
-    #     assert np.allclose(np.mean(data), 1.1477029889801025e-05, rtol=limit, atol=0.)
-    #     assert data.shape == (4, 10, 9)
+    def test_apply_function_to_images(self):
 
-    # def test_apply_function_to_images_2d(self):
-    #     remove = RemoveLinesModule(lines=(1, 0, 0, 0),
-    #                                name_in='remove2',
-    #                                image_in_tag='image_2d',
-    #                                image_out_tag='remove_2d')
-    #
-    #     self.pipeline.add_module(remove)
-    #     self.pipeline.run_module('remove2')
-    #
-    #     data = self.pipeline.get_data('image_2d')
-    #     assert np.allclose(np.mean(data), 1.2869483197883442e-05, rtol=limit, atol=0.)
-    #     assert data.shape == (1, 10, 10)
-    #
-    #     data = self.pipeline.get_data('remove_2d')
-    #     assert np.allclose(np.mean(data), 1.3957075246029751e-05, rtol=limit, atol=0.)
-    #     assert data.shape == (1, 10, 9)
+        self.pipeline.set_attribute('config', 'MEMORY', 20, static=True)
+        self.pipeline.set_attribute('config', 'CPU', 4, static=True)
 
-    # def test_apply_function_to_images_same_port(self):
-    #     dark = DarkCalibrationModule(name_in='dark1',
-    #                                  image_in_tag='science',
-    #                                  dark_in_tag='dark',
-    #                                  image_out_tag='science')
-    #
-    #     self.pipeline.add_module(dark)
-    #     self.pipeline.run_module('dark1')
-    #
-    #     data = self.pipeline.get_data('science')
-    #     assert np.allclose(np.mean(data), -3.190113568690675e-06, rtol=limit, atol=0.)
-    #     assert data.shape == (4, 10, 10)
-    #
-    #     self.pipeline.set_attribute('config', 'MEMORY', 0, static=True)
-    #
-    #     dark = DarkCalibrationModule(name_in='dark2',
-    #                                  image_in_tag='science',
-    #                                  dark_in_tag='dark',
-    #                                  image_out_tag='science')
-    #
-    #     self.pipeline.add_module(dark)
-    #     self.pipeline.run_module('dark2')
-    #
-    #     data = self.pipeline.get_data('science')
-    #     assert np.allclose(np.mean(data), -1.026073475228737e-05, rtol=limit, atol=0.)
-    #     assert data.shape == (4, 10, 10)
-    #
-    #     remove = RemoveLinesModule(lines=(1, 0, 0, 0),
-    #                                name_in='remove3',
-    #                                image_in_tag='remove_3d',
-    #                                image_out_tag='remove_3d')
-    #
-    #     self.pipeline.add_module(remove)
-    #
-    #     with pytest.raises(ValueError) as error:
-    #         self.pipeline.run_module('remove3')
-    #
-    #     assert str(error.value) == 'Input and output port have the same tag while the input ' \
-    #                                'function is changing the image shape. This is only ' \
-    #                                'possible with MEMORY=None.'
+        module = LineSubtractionModule(name_in='subtract',
+                                       image_in_tag='images',
+                                       image_out_tag='im_subtract',
+                                       combine='mean',
+                                       mask=None)
 
-    # def test_apply_function_to_images_memory_none(self):
-    #     remove = RemoveLinesModule(lines=(1, 0, 0, 0),
-    #                                name_in='remove4',
-    #                                image_in_tag='image_3d',
-    #                                image_out_tag='remove_3d_none')
-    #
-    #     self.pipeline.add_module(remove)
-    #     self.pipeline.run_module('remove4')
-    #
-    #     data = self.pipeline.get_data('remove_3d_none')
-    #     assert np.allclose(np.mean(data), 1.1477029889801025e-05, rtol=limit, atol=0.)
-    #     assert data.shape == (4, 10, 9)
-    #
-    # def test_apply_function_to_images_3d_args(self):
-    #     self.pipeline.set_attribute('config', 'MEMORY', 1, static=True)
-    #     self.pipeline.set_attribute('image_3d', 'PIXSCALE', 0.1, static=True)
-    #
-    #     scale = ScaleImagesModule(scaling=(1.2, 1.2, 10.),
-    #                               pixscale=True,
-    #                               name_in='scale1',
-    #                               image_in_tag='image_3d',
-    #                               image_out_tag='scale_3d')
-    #
-    #     self.pipeline.add_module(scale)
-    #     self.pipeline.run_module('scale1')
-    #
-    #     data = self.pipeline.get_data('scale_3d')
-    #     assert np.allclose(np.mean(data), 7.042953308754017e-05, rtol=limit, atol=0.)
-    #     assert data.shape == (4, 12, 12)
-    #
-    #     attribute = self.pipeline.get_attribute('scale_3d', 'PIXSCALE', static=True)
-    #     assert np.allclose(attribute, 0.08333333333333334, rtol=limit, atol=0.)
-    #
-    # def test_apply_function_to_images_2d_args(self):
-    #     self.pipeline.set_attribute('image_2d', 'PIXSCALE', 0.1, static=True)
-    #
-    #     scale = ScaleImagesModule(scaling=(1.2, 1.2, 10.),
-    #                               pixscale=True,
-    #                               name_in='scale2',
-    #                               image_in_tag='image_2d',
-    #                               image_out_tag='scale_2d')
-    #
-    #     self.pipeline.add_module(scale)
-    #     self.pipeline.run_module('scale2')
-    #
-    #     data = self.pipeline.get_data('scale_2d')
-    #     assert np.allclose(np.mean(data), 8.937141109641279e-05, rtol=limit, atol=0.)
-    #     assert data.shape == (1, 12, 12)
-    #
-    #     attribute = self.pipeline.get_attribute('scale_2d', 'PIXSCALE', static=True)
-    #     assert np.allclose(attribute, 0.08333333333333334, rtol=limit, atol=0.)
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('subtract')
+
+        data = self.pipeline.get_data('images')
+        assert np.allclose(np.mean(data), 1.9545313398209947e-06, rtol=limit, atol=0.)
+        assert data.shape == (100, 10, 10)
+
+        data = self.pipeline.get_data('im_subtract')
+        assert np.allclose(np.mean(data), 5.529431079676073e-22, rtol=limit, atol=0.)
+        assert data.shape == (100, 10, 10)
+
+    def test_apply_function_to_images_args_none(self):
+
+        module = TimeNormalizationModule(name_in='norm',
+                                         image_in_tag='images',
+                                         image_out_tag='im_norm')
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('norm')
+
+        data = self.pipeline.get_data('im_norm')
+        assert np.allclose(np.mean(data), -3.3117684144801347e-07, rtol=limit, atol=0.)
+        assert data.shape == (100, 10, 10)
+
+    def test_apply_function_to_images_args_none_memory_none(self):
+
+        self.pipeline.set_attribute('config', 'MEMORY', 0, static=True)
+
+        module = TimeNormalizationModule(name_in='norm_none',
+                                         image_in_tag='images',
+                                         image_out_tag='im_norm')
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('norm_none')
+
+        data = self.pipeline.get_data('im_norm')
+        assert np.allclose(np.mean(data), -3.3117684144801347e-07, rtol=limit, atol=0.)
+        assert data.shape == (100, 10, 10)
+
+    def test_apply_function_to_images_same_port(self):
+
+        module = LineSubtractionModule(name_in='subtract_same',
+                                       image_in_tag='im_subtract',
+                                       image_out_tag='im_subtract',
+                                       combine='mean',
+                                       mask=None)
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('subtract_same')
+
+        data = self.pipeline.get_data('im_subtract')
+        assert np.allclose(np.mean(data), 7.318364664277155e-22, rtol=limit, atol=0.)
+        assert data.shape == (100, 10, 10)
+
+    def test_apply_function_to_images_memory_none(self):
+
+        module = StarExtractionModule(name_in='extract',
+                                      image_in_tag='im_subtract',
+                                      image_out_tag='extract',
+                                      index_out_tag=None,
+                                      image_size=0.5,
+                                      fwhm_star=0.1,
+                                      position=(None, None, 0.1))
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('extract')
+
+        data = self.pipeline.get_data('extract')
+        assert np.allclose(np.mean(data), 1.5591859111937413e-07, rtol=limit, atol=0.)
+        assert data.shape == (100, 5, 5)
+
+    def test_multiproc_large_data(self):
+
+        self.pipeline.set_attribute('config', 'MEMORY', 1000, static=True)
+        self.pipeline.set_attribute('config', 'CPU', 1, static=True)
+
+        module = LineSubtractionModule(name_in='subtract_single',
+                                       image_in_tag='large_data',
+                                       image_out_tag='im_sub_single',
+                                       combine='mean',
+                                       mask=None)
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('subtract_single')
+
+        self.pipeline.set_attribute('config', 'CPU', 4, static=True)
+
+        module = LineSubtractionModule(name_in='subtract_multi',
+                                       image_in_tag='large_data',
+                                       image_out_tag='im_sub_multi',
+                                       combine='mean',
+                                       mask=None)
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('subtract_multi')
+
+        data = self.pipeline.get_data('im_sub_single')
+        assert np.allclose(np.mean(data), -7.5026790335996905e-25, rtol=limit, atol=0.)
+        assert data.shape == (10000, 100, 100)
+
+        data_multi = self.pipeline.get_data('im_sub_multi')
+        assert np.allclose(data, data_multi, rtol=limit, atol=0.)
+        assert data.shape == data_multi.shape

--- a/tests/test_core/test_pypeline.py
+++ b/tests/test_core/test_pypeline.py
@@ -17,6 +17,7 @@ warnings.simplefilter('always')
 
 limit = 1e-10
 
+
 class TestPypeline:
 
     def setup_class(self):
@@ -45,7 +46,7 @@ class TestPypeline:
         with pytest.warns(UserWarning) as warning:
             Pypeline(self.test_dir, self.test_dir, self.test_dir)
 
-        # assert len(warning) == 2
+        assert len(warning) == 1
         assert warning[0].message.args[0] == 'Configuration file not found. Creating ' \
                                              'PynPoint_config.ini with default values ' \
                                              'in the working place.'

--- a/tests/test_readwrite/test_nearreading.py
+++ b/tests/test_readwrite/test_nearreading.py
@@ -59,7 +59,7 @@ class TestNearInitModule(object):
             assert np.allclose(np.mean(data), 0.060582854, rtol=limit, atol=0.)
             assert data.shape == (20, 10, 10)
 
-    def test_near_subtract_crop_combine(self):
+    def test_near_subtract_crop_mean(self):
 
         module = NearReadingModule(name_in='read1b',
                                    input_dir=self.test_dir+'near',
@@ -79,6 +79,25 @@ class TestNearInitModule(object):
         data = self.pipeline.get_data(self.positions[1])
         assert np.allclose(np.mean(data), 0.0, rtol=limit, atol=0.)
         assert data.shape == (4, 7, 7)
+
+    def test_near_median(self):
+
+        module = NearReadingModule(name_in='read1c',
+                                   input_dir=self.test_dir+'near',
+                                   chopa_out_tag=self.positions[0],
+                                   chopb_out_tag=self.positions[1],
+                                   combine='median')
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('read1c')
+
+        data = self.pipeline.get_data(self.positions[0])
+        assert np.allclose(np.mean(data), 0.060582854, rtol=limit, atol=0.)
+        assert data.shape == (4, 10, 10)
+
+        data = self.pipeline.get_data(self.positions[1])
+        assert np.allclose(np.mean(data), 0.060582854, rtol=limit, atol=0.)
+        assert data.shape == (4, 10, 10)
 
     def test_static_not_found(self):
 


### PR DESCRIPTION
- Closing database before the multiprocessing starts in `ContrastCurveModule`.

- Vectorized version of `RemoveLinesModule` reactivated.

- Bug fix in `NearReadingModule`. `numpy` arrays do not have a `median` method.

- New test cases for `apply_function_to_images` and `NearReadingModule`.