### PR TITLE
time-display fix

### DIFF
--- a/pynpoint/util/module.py
+++ b/pynpoint/util/module.py
@@ -70,8 +70,8 @@ def progress(current: int,
             time_left = time_taken / fraction * (1. - fraction)
             sys.stdout.write(f'{message} {percentage:4.1f}% - ETA: {time_string(time_left)}\r')
 
-    if current+1 == total:
-        sys.stdout.write(' ' * (29+len(message)) + '\r')
+    if current+1 >= total:
+        sys.stdout.write(' ' * (29+len(message)) + '\r' + message + '\r')
 
     sys.stdout.flush()
 


### PR DESCRIPTION
This is a pull request for issue #386 

The problem consists of two parts:

1. we are inconsistent throughout the package how we count measure the progress. Sometimes we start at 0, other times at 1. Sometimes we go to N, sometimes to N-1... depending on the configuration, we sometimes have the case where `current +1 > total` which was not covered by the if-clause in util.progress in line 73.. 
The new `>=` may lead to the time not beeing displayed for the very last iteration. We can revert this once we go through all loops where the `progress` function is called and standardize them.
I ran a couple of tests, the lack of the time display on the last iteration is only really noticable for very slow iterations.

2. As the contrast curve runs in parallel and we check every 5 seconds whether or not any progress has been made, it sometimes occurs that all the last tasks finish within the same 5 second window in which case we again go past the `current + 1 == total` if-clause.
I fixed this by using a callback function which gets called everytime a task finishes and increases the count of finished tasks. see lines 250-260 in `processing/limits.py`