### PR TITLE
subset_size argument added to the FitsWritingModule

### DIFF
--- a/pynpoint/readwrite/fitswriting.py
+++ b/pynpoint/readwrite/fitswriting.py
@@ -1,5 +1,5 @@
 """
-Module for writing data as FITS file.
+Module for exporting a dataset from the HDF5 database to a FITS file.
 """
 
 import os
@@ -12,17 +12,16 @@ from astropy.io import fits
 from typeguard import typechecked
 
 from pynpoint.core.processing import WritingModule
+from pynpoint.util.module import memory_frames
 
 
 class FitsWritingModule(WritingModule):
     """
-    Module for writing a data set of the central HDF5 database as FITS file. The data and all
-    attached attributes will be saved. Besides typical image stacks it is possible to export for
-    example non-static header information. To choose the data set from the database its tag
-    / key has to be specified. FitsWritingModule is a Writing Module and supports to use the
-    Pypeline default output directory as well as a own location. See
-    :class:`pynpoint.core.processing.WritingModule` for more information. Note that per default
-    this module will overwrite an existing FITS file with the same filename.
+    Module for writing a dataset from the central HDF5 database to a FITS file. The static
+    attributes will be stored as header information. The dataset is selected from the database
+    by its tag name. :class:`~pynpoint.readwrite.fitswriting.FitsWritingModule` is a
+    :class:`~pynpoint.core.processing.WritingModule` and uses either the default output directory
+    of a :class:`~pynpoint.core.pypeline.Pypeline` or a specified location to store the FITS data.
     """
 
     @typechecked
@@ -32,14 +31,15 @@ class FitsWritingModule(WritingModule):
                  file_name: str,
                  output_dir: str = None,
                  data_range: Tuple[int, int] = None,
-                 overwrite: bool = True) -> None:
+                 overwrite: bool = True,
+                 subset_size: int = None) -> None:
         """
         Parameters
         ----------
         name_in : str
             Unique name of the module instance.
         data_tag : str
-            Tag of the database entry the module has to export as FITS file.
+            Tag of the database entry that has to be exported to a FITS file.
         file_name : str
             Name of the FITS output file. Requires the FITS extension.
         output_dir : str, None
@@ -47,9 +47,14 @@ class FitsWritingModule(WritingModule):
             Pypeline default is chosen.
         data_range : tuple, None
             A two element tuple which specifies a begin and end frame of the export. This can be
-            used to save a subsets of huge dataset. If None the whole dataset will be exported.
-        overwrite : bool
-            Overwrite existing FITS file with identical filename.
+            used to save a subsets of a large dataset. The whole dataset will be exported if set
+            to None.
+        overwrite : bool, None
+            Overwrite an existing FITS file with an identical filename.
+        subset_size : int, None
+            Size of the subsets that are created when storing the data. This can be useful if the
+            dataset contains a large number of images. An increasing index value is appended to
+            the FITS file names. All images are written to a single FITS file if set to None.
 
         Returns
         -------
@@ -66,12 +71,13 @@ class FitsWritingModule(WritingModule):
         self.m_data_port = self.add_input_port(data_tag)
         self.m_range = data_range
         self.m_overwrite = overwrite
+        self.m_subset_size = subset_size
 
     @typechecked
     def run(self) -> None:
         """
-        Run method of the module. Creates a FITS file and saves the data as well as the
-        corresponding attributes.
+        Run method of the module. Creates a FITS file and stores the data and the corresponding
+        static attributes.
 
         Returns
         -------
@@ -89,7 +95,7 @@ class FitsWritingModule(WritingModule):
                           'FITS file.')
 
         else:
-            prihdr = fits.Header()
+            header = fits.Header()
             attributes = self.m_data_port.get_all_static_attributes()
 
             for attr in attributes:
@@ -108,20 +114,36 @@ class FitsWritingModule(WritingModule):
                                       f'the FITS format. To avoid an error, the value was '
                                       f'truncated to \'{value[:max_val_len]}\'.')
 
-                    prihdr[key] = value[:max_val_len]
+                    header[key] = value[:max_val_len]
 
                 else:
-                    prihdr[attr] = attributes[attr]
+                    header[attr] = attributes[attr]
 
-            if self.m_range is None:
-                hdu = fits.PrimaryHDU(self.m_data_port.get_all(),
-                                      header=prihdr)
+            if self.m_subset_size is None:
+                if self.m_range is None:
+                    frames = [0, self.m_data_port.get_shape()[0]]
+
+                else:
+                    frames = [self.m_range[0], self.m_range[1]]
+
             else:
-                hdu = fits.PrimaryHDU(self.m_data_port[self.m_range[0]:self.m_range[1], ],
-                                      header=prihdr)
+                if self.m_range is None:
+                    nimages = self.m_data_port.get_shape()[0]
 
-            hdulist = fits.HDUList([hdu])
-            hdulist.writeto(out_name, overwrite=self.m_overwrite)
+                else:
+                    nimages = self.m_range[1] - self.m_range[0]
+
+                frames = memory_frames(self.m_subset_size, nimages)
+
+            for i, item in enumerate(frames[:-1]):
+                data_select = self.m_data_port[frames[i]:frames[i+1], ]
+
+                if len(frames) == 2:
+                    fits.writeto(out_name, data_select, header, overwrite=self.m_overwrite)
+
+                else:
+                    filename = f'{out_name[:-5]}{i:03d}.fits'
+                    fits.writeto(filename, data_select, header, overwrite=self.m_overwrite)
 
             sys.stdout.write(' [DONE]\n')
             sys.stdout.flush()

--- a/pynpoint/readwrite/fitswriting.py
+++ b/pynpoint/readwrite/fitswriting.py
@@ -11,6 +11,8 @@ from typing import Tuple
 from astropy.io import fits
 from typeguard import typechecked
 
+import numpy as np
+
 from pynpoint.core.processing import WritingModule
 from pynpoint.util.module import memory_frames
 
@@ -129,11 +131,12 @@ class FitsWritingModule(WritingModule):
             else:
                 if self.m_range is None:
                     nimages = self.m_data_port.get_shape()[0]
+                    frames = memory_frames(self.m_subset_size, nimages)
 
                 else:
                     nimages = self.m_range[1] - self.m_range[0]
-
-                frames = memory_frames(self.m_subset_size, nimages)
+                    frames = memory_frames(self.m_subset_size, nimages)
+                    frames = np.asarray(frames) + self.m_range[0]
 
             for i, item in enumerate(frames[:-1]):
                 data_select = self.m_data_port[frames[i]:frames[i+1], ]

--- a/tests/test_readwrite/test_fitswriting.py
+++ b/tests/test_readwrite/test_fitswriting.py
@@ -26,18 +26,18 @@ class TestFitsWritingModule:
         self.pipeline = Pypeline(self.test_dir, self.test_dir, self.test_dir)
 
     def teardown_class(self):
-
-        remove_test_data(self.test_dir, folders=['fits'], files=['test.fits'])
+        files = ['test.fits', 'test000.fits', 'test001.fits', 'test002.fits', 'test003.fits']
+        remove_test_data(self.test_dir, folders=['fits'], files=files)
 
     def test_fits_reading(self):
 
-        read = FitsReadingModule(name_in='read',
-                                 input_dir=self.test_dir+'fits',
-                                 image_tag='images',
-                                 overwrite=True,
-                                 check=True)
+        module = FitsReadingModule(name_in='read',
+                                   input_dir=self.test_dir+'fits',
+                                   image_tag='images',
+                                   overwrite=True,
+                                   check=True)
 
-        self.pipeline.add_module(read)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('read')
 
         data = self.pipeline.get_data('images')
@@ -47,14 +47,14 @@ class TestFitsWritingModule:
 
     def test_fits_writing(self):
 
-        write = FitsWritingModule(file_name='test.fits',
-                                  name_in='write1',
-                                  output_dir=None,
-                                  data_tag='images',
-                                  data_range=None,
-                                  overwrite=True)
+        module = FitsWritingModule(file_name='test.fits',
+                                   name_in='write1',
+                                   output_dir=None,
+                                   data_tag='images',
+                                   data_range=None,
+                                   overwrite=True)
 
-        self.pipeline.add_module(write)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('write1')
 
     def test_filename_extension(self):
@@ -65,32 +65,35 @@ class TestFitsWritingModule:
                               output_dir=None,
                               data_tag='images',
                               data_range=None,
-                              overwrite=True)
+                              overwrite=True,
+                              subset_size=None)
 
         assert str(error.value) == 'Output \'file_name\' requires the FITS extension.'
 
     def test_data_range(self):
 
-        write = FitsWritingModule(file_name='test.fits',
-                                  name_in='write4',
-                                  output_dir=None,
-                                  data_tag='images',
-                                  data_range=(0, 10),
-                                  overwrite=True)
+        module = FitsWritingModule(file_name='test.fits',
+                                   name_in='write4',
+                                   output_dir=None,
+                                   data_tag='images',
+                                   data_range=(0, 10),
+                                   overwrite=True,
+                                   subset_size=None)
 
-        self.pipeline.add_module(write)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('write4')
 
     def test_not_overwritten(self):
 
-        write = FitsWritingModule(file_name='test.fits',
-                                  name_in='write5',
-                                  output_dir=None,
-                                  data_tag='images',
-                                  data_range=None,
-                                  overwrite=False)
+        module = FitsWritingModule(file_name='test.fits',
+                                   name_in='write5',
+                                   output_dir=None,
+                                   data_tag='images',
+                                   data_range=None,
+                                   overwrite=False,
+                                   subset_size=None)
 
-        self.pipeline.add_module(write)
+        self.pipeline.add_module(module)
 
         with pytest.warns(UserWarning) as warning:
             self.pipeline.run_module('write5')
@@ -98,6 +101,19 @@ class TestFitsWritingModule:
         assert len(warning) == 1
         assert warning[0].message.args[0] == 'Filename already present. Use overwrite=True ' \
                                              'to overwrite an existing FITS file.'
+
+    def test_data_range(self):
+
+        module = FitsWritingModule(file_name='test.fits',
+                                   name_in='write6',
+                                   output_dir=None,
+                                   data_tag='images',
+                                   data_range=None,
+                                   overwrite=True,
+                                   subset_size=10)
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('write6')
 
     def test_attribute_length(self):
 
@@ -107,17 +123,18 @@ class TestFitsWritingModule:
         self.pipeline.set_attribute('images', 'longer_than_eight1', 'value', static=True)
         self.pipeline.set_attribute('images', 'longer_than_eight2', text, static=True)
 
-        write = FitsWritingModule(file_name='test.fits',
-                                  name_in='write6',
-                                  output_dir=None,
-                                  data_tag='images',
-                                  data_range=None,
-                                  overwrite=True)
+        module = FitsWritingModule(file_name='test.fits',
+                                   name_in='write7',
+                                   output_dir=None,
+                                   data_tag='images',
+                                   data_range=None,
+                                   overwrite=True,
+                                   subset_size=None)
 
-        self.pipeline.add_module(write)
+        self.pipeline.add_module(module)
 
         with pytest.warns(UserWarning) as warning:
-            self.pipeline.run_module('write6')
+            self.pipeline.run_module('write7')
 
         assert len(warning) == 1
         assert warning[0].message.args[0] == 'Key \'hierarch longer_than_eight2\' with value ' \

--- a/tests/test_readwrite/test_fitswriting.py
+++ b/tests/test_readwrite/test_fitswriting.py
@@ -102,7 +102,7 @@ class TestFitsWritingModule:
         assert warning[0].message.args[0] == 'Filename already present. Use overwrite=True ' \
                                              'to overwrite an existing FITS file.'
 
-    def test_data_range(self):
+    def test_subset_size(self):
 
         module = FitsWritingModule(file_name='test.fits',
                                    name_in='write6',
@@ -115,6 +115,19 @@ class TestFitsWritingModule:
         self.pipeline.add_module(module)
         self.pipeline.run_module('write6')
 
+    def test_subset_size_data_range(self):
+
+        module = FitsWritingModule(file_name='test.fits',
+                                   name_in='write7',
+                                   output_dir=None,
+                                   data_tag='images',
+                                   data_range=(8, 18),
+                                   overwrite=True,
+                                   subset_size=10)
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('write7')
+
     def test_attribute_length(self):
 
         text = 'long_text_long_text_long_text_long_text_long_text_long_text_long_text_long_text'
@@ -124,7 +137,7 @@ class TestFitsWritingModule:
         self.pipeline.set_attribute('images', 'longer_than_eight2', text, static=True)
 
         module = FitsWritingModule(file_name='test.fits',
-                                   name_in='write7',
+                                   name_in='write8',
                                    output_dir=None,
                                    data_tag='images',
                                    data_range=None,
@@ -134,7 +147,7 @@ class TestFitsWritingModule:
         self.pipeline.add_module(module)
 
         with pytest.warns(UserWarning) as warning:
-            self.pipeline.run_module('write7')
+            self.pipeline.run_module('write8')
 
         assert len(warning) == 1
         assert warning[0].message.args[0] == 'Key \'hierarch longer_than_eight2\' with value ' \


### PR DESCRIPTION
When exporting a large dataset to a FITS file, it can be useful to split up the dataset into subsets because otherwise the FITS file might be too large to open it at once with DS9. Therefore, I have added the `subset_size` parameter to the `FitsWritingModule` which sets the number of images in a FITS file. The filenames are appended with a increasing index value. All images are exported if the value is set to None (=default). I have also added a test case and improve the documentation a bit of the module.