### PR TITLE
emcee v3.0 compatibility

### DIFF
--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -825,10 +825,11 @@ class MCMCsamplingModule(ProcessingModule):
 
         print('Sampling the posteriors with MCMC...')
 
-        with Pool() as pool:
+        with Pool(processes=cpu) as pool:
             sampler = emcee.EnsembleSampler(nwalkers=self.m_nwalkers,
                                             ndim=ndim,
                                             log_prob_fn=lnprob,
+                                            pool=pool,
                                             args=([self.m_bounds,
                                                    images,
                                                    psf,

--- a/pynpoint/processing/frameselection.py
+++ b/pynpoint/processing/frameselection.py
@@ -337,11 +337,11 @@ class FrameSelectionModule(ProcessingModule):
 
         if self.m_method == 'median':
             phot_ref = np.nanmedian(phot)
-            print(f'\nMedian = {phot_ref:.2f}')
+            print(f'Median = {phot_ref:.2f}')
 
         elif self.m_method == 'max':
             phot_ref = np.nanmax(phot)
-            print(f'\nMaximum = {phot_ref:.2f}')
+            print(f'Maximum = {phot_ref:.2f}')
 
         phot_std = np.nanstd(phot)
         print(f'Standard deviation = {phot_std:.2f}')

--- a/pynpoint/util/module.py
+++ b/pynpoint/util/module.py
@@ -241,6 +241,6 @@ def output_info(pipeline_module, output_shape) -> None:
 
         for i, item in enumerate(output_ports):
             if i < len(output_ports) - 1:
-                print(f' {item} {output_shape[output_ports[0]]},', end='')
+                print(f' {item} {output_shape[output_ports[i]]},', end='')
             else:
-                print(f' {item} {output_shape[output_ports[0]]}')
+                print(f' {item} {output_shape[output_ports[i]]}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 astropy ~= 3.1
-emcee ~= 2.2
+emcee ~= 3.0
 h5py ~= 2.9
 numba ~= 0.43
 numpy ~= 1.17

--- a/tests/test_processing/test_fluxposition.py
+++ b/tests/test_processing/test_fluxposition.py
@@ -331,19 +331,10 @@ class TestFluxPosition:
                                     sigma=(1e-3, 1e-1, 1e-2))
 
         self.pipeline.add_module(module)
-
-        with pytest.warns(FutureWarning) as warning:
-            self.pipeline.run_module('mcmc')
-
-        assert warning[0].message.args[0] == 'Using a non-tuple sequence for multidimensional ' \
-                                             'indexing is deprecated; use `arr[tuple(seq)]` ' \
-                                             'instead of `arr[seq]`. In the future this will be ' \
-                                             'interpreted as an array index, ' \
-                                             '`arr[np.array(seq)]`, which will result either ' \
-                                             'in an error or a different result.'
+        self.pipeline.run_module('mcmc')
 
         data = self.pipeline.get_data('mcmc')
-        data = data[:, 50:, :].reshape((-1, 3))
+        data = data[50:, :, :].reshape((-1, 3))
         assert np.allclose(np.median(data[:, 0]), 0.15, rtol=0., atol=0.1)
         assert np.allclose(np.median(data[:, 1]), 0., rtol=0., atol=1.0)
         assert np.allclose(np.median(data[:, 2]), 0.0, rtol=0., atol=1.)


### PR DESCRIPTION
Note that the shape of the output chain has changed from (nwalkers, nsteps, ndim) to (nsteps, nwalkers, ndim).