### PR TITLE
Additional test cases for the wavelet denoising module

### DIFF
--- a/pynpoint/processing/timedenoising.py
+++ b/pynpoint/processing/timedenoising.py
@@ -88,7 +88,7 @@ class DwtWaveletConfiguration:
 
         # check if wavelet is supported
         if wavelet not in supported:
-            raise ValueError('DWT supports only ' + str(supported) + ' as input wavelet.')
+            raise ValueError(f'DWT supports only {supported} as input wavelet.')
 
         self.m_wavelet = wavelet
 
@@ -177,7 +177,7 @@ class WaveletTimeDenoisingModule(ProcessingModule):
 
                 Parameters
                 ----------
-                signal_in :
+                signal_in : numpy.ndarray
                     1D input signal.
 
                 Returns
@@ -219,7 +219,7 @@ class WaveletTimeDenoisingModule(ProcessingModule):
 
                 Parameters
                 ----------
-                signal_in :
+                signal_in : numpy.ndarray
                     1D input signal.
 
                 Returns


### PR DESCRIPTION
Following issue #385, I have added some more test cases for the `WaveletTimeDenoisingModule` both with even- and off-sized images, for different padding values. However, the bug that is described in issue #385 has not appeared. Specifically, the shape of the output data is the same as the input data (which is also tested).