### PR TITLE
SystematicErrorModule

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -105,6 +105,7 @@ Flux and Position
 * :class:`~pynpoint.processing.fluxposition.FalsePositiveModule`: Compute the signal-to-noise ratio and false positive fraction.
 * :class:`~pynpoint.processing.fluxposition.MCMCsamplingModule` (CPU): Estimate the flux and position of a planet with MCMC sampling.
 * :class:`~pynpoint.processing.fluxposition.AperturePhotometryModule` (CPU): Compute the integrated flux at a position.
+* :class:`~pynpoint.processing.fluxposition.SystematicErrorModule`: Compute the systematic errors on the flux and position.
 
 Frame Selection
 ~~~~~~~~~~~~~~~

--- a/pynpoint/__init__.py
+++ b/pynpoint/__init__.py
@@ -35,7 +35,8 @@ from pynpoint.processing.fluxposition import FakePlanetModule, \
                                              SimplexMinimizationModule, \
                                              FalsePositiveModule, \
                                              MCMCsamplingModule, \
-                                             AperturePhotometryModule
+                                             AperturePhotometryModule, \
+                                             SystematicErrorModule
 
 from pynpoint.processing.frameselection import RemoveFramesModule, \
                                                FrameSelectionModule, \

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -981,8 +981,8 @@ class SystematicErrorModule(ProcessingModule):
                  aperture: float = 0.1,
                  tolerance: float = 0.01,
                  pca_number: int = 10,
-                 cent_size: float = None,
-                 edge_size: float = None,
+                 mask: Union[Tuple[float, float], Tuple[None, float],
+                             Tuple[float, None], Tuple[None, None]] = None,
                  extra_rot: float = 0.,
                  residuals: str = 'median') -> None:
         """
@@ -991,9 +991,10 @@ class SystematicErrorModule(ProcessingModule):
         name_in : str
             Unique name of the module instance.
         image_in_tag : str
-            Tag of the database entry with the science images that are read as input.
+            Tag of the database entry with the science images for which the systematic error is
+            estimated.
         psf_in_tag : str
-            Tag of the database entry with the reference PSF that is used as fake planet. Can be
+            Tag of the database entry with the PSF template that is used as fake planet. Can be
             either a single image or a stack of images equal in size to ``image_in_tag``.
         offset_out_tag : str
             Tag of the database entry at which the differences are stored between the injected and
@@ -1027,13 +1028,9 @@ class SystematicErrorModule(ProcessingModule):
             np.inf so the condition is always met.
         pca_number : int
             Number of principal components (PCs) used for the PSF subtraction.
-        cent_size : float
-            Radius of the central mask (arcsec). No mask is used when set to None. Masking is done
-            after the artificial planet is injected.
-        edge_size : float
-            Outer radius (arcsec) beyond which pixels are masked. No outer mask is used when set to
-            None. The radius will be set to half the image size if the argument is larger than half
-            the image size. Masking is done after the artificial planet is injected.
+        mask : tuple(float, float), None
+            Inner and outer mask radius (arcsec) which is applied before the PSF subtraction. Both
+            elements of the tuple can be set to None.
         extra_rot : float
             Additional rotation angle of the images in clockwise direction (deg).
         residuals : str
@@ -1060,8 +1057,7 @@ class SystematicErrorModule(ProcessingModule):
         self.m_merit = merit
         self.m_aperture = aperture
         self.m_tolerance = tolerance
-        self.m_cent_size = cent_size
-        self.m_edge_size = edge_size
+        self.m_mask = mask
         self.m_extra_rot = extra_rot
         self.m_residuals = residuals
         self.m_pca_number = pca_number
@@ -1131,8 +1127,8 @@ class SystematicErrorModule(ProcessingModule):
                                                sigma=0.,
                                                tolerance=self.m_tolerance,
                                                pca_number=self.m_pca_number,
-                                               cent_size=self.m_cent_size,
-                                               edge_size=self.m_edge_size,
+                                               cent_size=self.m_mask[0],
+                                               edge_size=self.m_mask[1],
                                                extra_rot=self.m_extra_rot,
                                                residuals='median')
 

--- a/tests/test_processing/test_fluxposition.py
+++ b/tests/test_processing/test_fluxposition.py
@@ -2,14 +2,13 @@ import os
 import warnings
 
 import h5py
-import pytest
 import numpy as np
 
 from pynpoint.core.pypeline import Pypeline
 from pynpoint.readwrite.fitsreading import FitsReadingModule
 from pynpoint.processing.fluxposition import FakePlanetModule, AperturePhotometryModule, \
                                              FalsePositiveModule, SimplexMinimizationModule, \
-                                             MCMCsamplingModule
+                                             MCMCsamplingModule, SystematicErrorModule
 
 from pynpoint.processing.stacksubset import DerotateAndStackModule
 from pynpoint.processing.psfpreparation import AngleInterpolationModule
@@ -344,3 +343,30 @@ class TestFluxPosition:
 
         attr = self.pipeline.get_attribute('mcmc', 'ACCEPTANCE', static=True)
         assert np.allclose(attr, 0.3, rtol=0., atol=0.2)
+
+    def test_systematic_error(self):
+
+        module = SystematicErrorModule(name_in='error',
+                                       image_in_tag='fake',
+                                       psf_in_tag='read',
+                                       offset_out_tag='offset',
+                                       position=(0.5, 90.),
+                                       magnitude=6.,
+                                       n_angles=2,
+                                       psf_scaling=1.,
+                                       merit='gaussian',
+                                       aperture=0.1,
+                                       tolerance=0.1,
+                                       pca_number=10,
+                                       cent_size=None,
+                                       edge_size=None,
+                                       extra_rot=0.,
+                                       residuals='median')
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('error')
+
+        data = self.pipeline.get_data('offset')
+        assert np.allclose(data[0, 0], -0.004192746397732816, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 0.004504673197196644, rtol=limit, atol=0.)
+        assert data.shape == (2, 3)

--- a/tests/test_processing/test_fluxposition.py
+++ b/tests/test_processing/test_fluxposition.py
@@ -358,8 +358,7 @@ class TestFluxPosition:
                                        aperture=0.1,
                                        tolerance=0.1,
                                        pca_number=10,
-                                       cent_size=None,
-                                       edge_size=None,
+                                       mask=(None, None),
                                        extra_rot=0.,
                                        residuals='median')
 


### PR DESCRIPTION
Added the `SystematicErrorModule` in `processing.fluxposition`, as well as test cases, which can be used to estimate the systematic error of the contrast and position measurements. It requires the contrast and position of the companion (e.g. from the `SimplexMinimizationModule`) to remove the companion flux. Next, it uses the same separation and contrast (but a range of position angles, 360 by default) to inject a fake companion and retrieve them with the `SimplexMinimizationModule`. The offset values between the injected and retrieved values are stored. The distribution of these offset value provide an estimate of the systematic uncertainty caused by remaining noise after the PSF subtraction and a potential bias intrinsic to PCA.