### PR TITLE
Nelder-Mead minimization in FalsePositiveModule and offset parameter

### DIFF
--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -577,16 +577,12 @@ class FalsePositiveModule(ProcessingModule):
             pos_x, pos_y = arg
 
             if self.m_offset is not None:
-                if pos_x < self.m_position[0] - self.m_offset:
+                if pos_x < self.m_position[0] - self.m_offset or \
+                        pos_x > self.m_position[0] + self.m_offset:
                     snr = 0.
 
-                elif pos_x > self.m_position[0] + self.m_offset:
-                    snr = 0.
-
-                elif pos_y < self.m_position[1] - self.m_offset:
-                    snr = 0.
-
-                elif pos_y > self.m_position[1] + self.m_offset:
+                elif pos_y < self.m_position[1] - self.m_offset or \
+                        pos_y > self.m_position[1] + self.m_offset:
                     snr = 0.
 
                 else:

--- a/tests/test_processing/test_fluxposition.py
+++ b/tests/test_processing/test_fluxposition.py
@@ -204,21 +204,44 @@ class TestFluxPosition:
         module = FalsePositiveModule(position=(31., 49.),
                                      aperture=0.1,
                                      ignore=True,
-                                     name_in='false',
+                                     name_in='false1',
                                      image_in_tag='res_mean',
-                                     snr_out_tag='snr_fpf',
+                                     snr_out_tag='snr_fpf1',
                                      optimize=False)
 
         self.pipeline.add_module(module)
-        self.pipeline.run_module('false')
+        self.pipeline.run_module('false1')
 
-        data = self.pipeline.get_data('snr_fpf')
+        data = self.pipeline.get_data('snr_fpf1')
         assert np.allclose(data[0, 0], 31.0, rtol=limit, atol=0.)
         assert np.allclose(data[0, 1], 49.0, rtol=limit, atol=0.)
         assert np.allclose(data[0, 2], 0.513710034941892, rtol=limit, atol=0.)
         assert np.allclose(data[0, 3], 93.01278750418334, rtol=limit, atol=0.)
         assert np.allclose(data[0, 4], 7.333740467578795, rtol=limit, atol=0.)
         assert np.allclose(data[0, 5], 4.5257622875993775e-06, rtol=limit, atol=0.)
+
+    def test_false_positive_optimize(self):
+
+        module = FalsePositiveModule(position=(31., 49.),
+                                     aperture=0.1,
+                                     ignore=True,
+                                     name_in='false2',
+                                     image_in_tag='res_mean',
+                                     snr_out_tag='snr_fpf2',
+                                     optimize=True,
+                                     offset=0.1,
+                                     tolerance=0.01)
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('false2')
+
+        data = self.pipeline.get_data('snr_fpf2')
+        assert np.allclose(data[0, 0], 30.90615234375, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 1], 49.0861328125, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 2], 0.5161240306986961, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 3], 92.74019185433872, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 4], 7.831022605121996, rtol=limit, atol=0.)
+        assert np.allclose(data[0, 5], 2.3375921055608217e-06, rtol=limit, atol=0.)
 
     def test_simplex_minimization_hessian(self):
 

--- a/tests/test_processing/test_fluxposition.py
+++ b/tests/test_processing/test_fluxposition.py
@@ -206,7 +206,8 @@ class TestFluxPosition:
                                      ignore=True,
                                      name_in='false',
                                      image_in_tag='res_mean',
-                                     snr_out_tag='snr_fpf')
+                                     snr_out_tag='snr_fpf',
+                                     optimize=False)
 
         self.pipeline.add_module(module)
         self.pipeline.run_module('false')


### PR DESCRIPTION
- Changed the minimization method in the `FalsePositiveModule` to Nelder-Mead.

- Instead of using `bounds` (which is not possible with Nelder-Mead), I have added an `offset` parameter. If the aperture position (with `optimize=True`) deviates by more than an `offset` number of pixels, the SNR is set to zero. The default value of `offset` is None in which case there is no restriction on the aperture position.

- With Nelder-Mead, the `tolerance` kwarg is an absolute tolerance. It's default value is 0.01 pix. 