### PR TITLE
Check for number of angles and images, changed int to ceil in stack_size

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ License
 
 Copyright 2014-2020 Tomas Stolker, Markus Bonse, Sascha Quanz, Adam Amara, and contributors.
 
-PynPoint is distributed under the GNU General Public License v3. See the LICENSE file for the terms and conditions.
+PynPoint is distributed under the MIT License. See the LICENSE file for the terms and conditions.
 
 Acknowledgements
 ----------------

--- a/pynpoint/core/processing.py
+++ b/pynpoint/core/processing.py
@@ -3,6 +3,7 @@ Interfaces for pipeline modules.
 """
 
 import os
+import math
 import time
 import warnings
 
@@ -619,7 +620,7 @@ class ProcessingModule(PypelineModule, metaclass=ABCMeta):
                                              num_proc=cpu,
                                              function=func,
                                              function_args=func_args,
-                                             stack_size=int(memory/cpu),
+                                             stack_size=math.ceil(memory/cpu),
                                              result_shape=result_shape,
                                              nimages=nimages)
 

--- a/pynpoint/util/psf.py
+++ b/pynpoint/util/psf.py
@@ -25,7 +25,7 @@ def pca_psf_subtraction(images: np.ndarray,
         Stack of images. Also used as reference images if `pca_sklearn` is set to None. Should be
         in the original 3D shape if `pca_sklearn` is set to None or in the 2D reshaped format if
         `pca_sklearn` is not set to None.
-    parang : numpy.ndarray
+    angles : numpy.ndarray
         Derotation angles (deg).
     pca_number : int
         Number of principal components used for the PSF model.
@@ -86,6 +86,11 @@ def pca_psf_subtraction(images: np.ndarray,
 
     # reshape to the original image size
     residuals = residuals.reshape(im_shape)
+
+    # check if the number of parang is equal to the number of images
+    if residuals.shape[0] != angles.shape[0]:
+        raise ValueError(f'The number of images ({residuals.shape[0]}) is not equal to the '
+                         f'number of parallactic angles ({angles.shape[0]}).')
 
     # derotate the images
     res_rot = np.zeros(residuals.shape)

--- a/tests/test_processing/test_psfsubtraction.py
+++ b/tests/test_processing/test_psfsubtraction.py
@@ -2,6 +2,7 @@ import os
 import warnings
 
 import h5py
+import pytest
 import numpy as np
 
 from pynpoint.core.pypeline import Pypeline
@@ -55,11 +56,11 @@ class TestPsfSubtraction:
 
     def test_read_data(self):
 
-        read = FitsReadingModule(name_in='read1',
-                                 image_tag='science',
-                                 input_dir=self.test_dir+'science')
+        module = FitsReadingModule(name_in='read1',
+                                   image_tag='science',
+                                   input_dir=self.test_dir+'science')
 
-        self.pipeline.add_module(read)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('read1')
 
         data = self.pipeline.get_data('science')
@@ -67,11 +68,11 @@ class TestPsfSubtraction:
         assert np.allclose(np.mean(data), 0.00010063896953157961, rtol=limit, atol=0.)
         assert data.shape == (80, 100, 100)
 
-        read = FitsReadingModule(name_in='read2',
-                                 image_tag='reference',
-                                 input_dir=self.test_dir+'reference')
+        module = FitsReadingModule(name_in='read2',
+                                   image_tag='reference',
+                                   input_dir=self.test_dir+'reference')
 
-        self.pipeline.add_module(read)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('read2')
 
         data = self.pipeline.get_data('reference')
@@ -81,10 +82,10 @@ class TestPsfSubtraction:
 
     def test_angle_interpolation(self):
 
-        angle = AngleInterpolationModule(name_in='angle',
-                                         data_tag='science')
+        module = AngleInterpolationModule(name_in='angle',
+                                          data_tag='science')
 
-        self.pipeline.add_module(angle)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('angle')
 
         data = self.pipeline.get_data('header_science/PARANG')
@@ -95,16 +96,16 @@ class TestPsfSubtraction:
 
     def test_psf_preparation(self):
 
-        prep = PSFpreparationModule(name_in='prep1',
-                                    image_in_tag='science',
-                                    image_out_tag='science_prep',
-                                    mask_out_tag=None,
-                                    norm=False,
-                                    resize=None,
-                                    cent_size=0.2,
-                                    edge_size=1.0)
+        module = PSFpreparationModule(name_in='prep1',
+                                      image_in_tag='science',
+                                      image_out_tag='science_prep',
+                                      mask_out_tag=None,
+                                      norm=False,
+                                      resize=None,
+                                      cent_size=0.2,
+                                      edge_size=1.0)
 
-        self.pipeline.add_module(prep)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('prep1')
 
         data = self.pipeline.get_data('science_prep')
@@ -114,16 +115,16 @@ class TestPsfSubtraction:
         assert np.allclose(np.mean(data), 4.534001223501053e-07, rtol=limit, atol=0.)
         assert data.shape == (80, 100, 100)
 
-        prep = PSFpreparationModule(name_in='prep2',
-                                    image_in_tag='reference',
-                                    image_out_tag='reference_prep',
-                                    mask_out_tag=None,
-                                    norm=False,
-                                    resize=None,
-                                    cent_size=0.2,
-                                    edge_size=1.0)
+        module = PSFpreparationModule(name_in='prep2',
+                                      image_in_tag='reference',
+                                      image_out_tag='reference_prep',
+                                      mask_out_tag=None,
+                                      norm=False,
+                                      resize=None,
+                                      cent_size=0.2,
+                                      edge_size=1.0)
 
-        self.pipeline.add_module(prep)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('prep2')
 
         data = self.pipeline.get_data('reference_prep')
@@ -179,20 +180,20 @@ class TestPsfSubtraction:
 
     def test_psf_subtraction_pca_single(self):
 
-        pca = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
-                                      name_in='pca_single',
-                                      images_in_tag='science',
-                                      reference_in_tag='science',
-                                      res_mean_tag='res_mean_single',
-                                      res_median_tag='res_median_single',
-                                      res_weighted_tag='res_weighted_single',
-                                      res_rot_mean_clip_tag='res_clip_single',
-                                      res_arr_out_tag='res_arr_single',
-                                      basis_out_tag='basis_single',
-                                      extra_rot=-15.,
-                                      subtract_mean=True)
+        module = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
+                                         name_in='pca_single',
+                                         images_in_tag='science',
+                                         reference_in_tag='science',
+                                         res_mean_tag='res_mean_single',
+                                         res_median_tag='res_median_single',
+                                         res_weighted_tag='res_weighted_single',
+                                         res_rot_mean_clip_tag='res_clip_single',
+                                         res_arr_out_tag='res_arr_single',
+                                         basis_out_tag='basis_single',
+                                         extra_rot=-15.,
+                                         subtract_mean=True)
 
-        self.pipeline.add_module(pca)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('pca_single')
 
         data = self.pipeline.get_data('res_mean_single')
@@ -221,20 +222,20 @@ class TestPsfSubtraction:
 
     def test_psf_subtraction_no_mean(self):
 
-        pca = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
-                                      name_in='pca_no_mean',
-                                      images_in_tag='science',
-                                      reference_in_tag='science',
-                                      res_mean_tag='res_mean_no_mean',
-                                      res_median_tag=None,
-                                      res_weighted_tag=None,
-                                      res_rot_mean_clip_tag=None,
-                                      res_arr_out_tag=None,
-                                      basis_out_tag='basis_no_mean',
-                                      extra_rot=0.,
-                                      subtract_mean=False)
+        module = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
+                                         name_in='pca_no_mean',
+                                         images_in_tag='science',
+                                         reference_in_tag='science',
+                                         res_mean_tag='res_mean_no_mean',
+                                         res_median_tag=None,
+                                         res_weighted_tag=None,
+                                         res_rot_mean_clip_tag=None,
+                                         res_arr_out_tag=None,
+                                         basis_out_tag='basis_no_mean',
+                                         extra_rot=0.,
+                                         subtract_mean=False)
 
-        self.pipeline.add_module(pca)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('pca_no_mean')
 
         data = self.pipeline.get_data('res_mean_no_mean')
@@ -247,20 +248,20 @@ class TestPsfSubtraction:
 
     def test_psf_subtraction_ref(self):
 
-        pca = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
-                                      name_in='pca_ref',
-                                      images_in_tag='science',
-                                      reference_in_tag='reference',
-                                      res_mean_tag='res_mean_ref',
-                                      res_median_tag=None,
-                                      res_weighted_tag=None,
-                                      res_rot_mean_clip_tag=None,
-                                      res_arr_out_tag=None,
-                                      basis_out_tag='basis_ref',
-                                      extra_rot=0.,
-                                      subtract_mean=True)
+        module = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
+                                         name_in='pca_ref',
+                                         images_in_tag='science',
+                                         reference_in_tag='reference',
+                                         res_mean_tag='res_mean_ref',
+                                         res_median_tag=None,
+                                         res_weighted_tag=None,
+                                         res_rot_mean_clip_tag=None,
+                                         res_arr_out_tag=None,
+                                         basis_out_tag='basis_ref',
+                                         extra_rot=0.,
+                                         subtract_mean=True)
 
-        self.pipeline.add_module(pca)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('pca_ref')
 
         data = self.pipeline.get_data('res_mean_ref')
@@ -273,20 +274,20 @@ class TestPsfSubtraction:
 
     def test_psf_subtraction_ref_no_mean(self):
 
-        pca = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
-                                      name_in='pca_ref_no_mean',
-                                      images_in_tag='science',
-                                      reference_in_tag='reference',
-                                      res_mean_tag='res_mean_ref_no_mean',
-                                      res_median_tag=None,
-                                      res_weighted_tag=None,
-                                      res_rot_mean_clip_tag=None,
-                                      res_arr_out_tag=None,
-                                      basis_out_tag='basis_ref_no_mean',
-                                      extra_rot=0.,
-                                      subtract_mean=False)
+        module = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
+                                         name_in='pca_ref_no_mean',
+                                         images_in_tag='science',
+                                         reference_in_tag='reference',
+                                         res_mean_tag='res_mean_ref_no_mean',
+                                         res_median_tag=None,
+                                         res_weighted_tag=None,
+                                         res_rot_mean_clip_tag=None,
+                                         res_arr_out_tag=None,
+                                         basis_out_tag='basis_ref_no_mean',
+                                         extra_rot=0.,
+                                         subtract_mean=False)
 
-        self.pipeline.add_module(pca)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('pca_ref_no_mean')
 
         data = self.pipeline.get_data('res_mean_ref_no_mean')
@@ -341,20 +342,20 @@ class TestPsfSubtraction:
 
     def test_psf_subtraction_no_mean_mask(self):
 
-        pca = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
-                                      name_in='pca_no_mean_mask',
-                                      images_in_tag='science_prep',
-                                      reference_in_tag='science_prep',
-                                      res_mean_tag='res_mean_no_mean_mask',
-                                      res_median_tag=None,
-                                      res_weighted_tag=None,
-                                      res_rot_mean_clip_tag=None,
-                                      res_arr_out_tag=None,
-                                      basis_out_tag='basis_no_mean_mask',
-                                      extra_rot=0.,
-                                      subtract_mean=False)
+        module = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
+                                         name_in='pca_no_mean_mask',
+                                         images_in_tag='science_prep',
+                                         reference_in_tag='science_prep',
+                                         res_mean_tag='res_mean_no_mean_mask',
+                                         res_median_tag=None,
+                                         res_weighted_tag=None,
+                                         res_rot_mean_clip_tag=None,
+                                         res_arr_out_tag=None,
+                                         basis_out_tag='basis_no_mean_mask',
+                                         extra_rot=0.,
+                                         subtract_mean=False)
 
-        self.pipeline.add_module(pca)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('pca_no_mean_mask')
 
         data = self.pipeline.get_data('res_mean_no_mean_mask')
@@ -367,20 +368,20 @@ class TestPsfSubtraction:
 
     def test_psf_subtraction_ref_mask(self):
 
-        pca = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
-                                      name_in='pca_ref_mask',
-                                      images_in_tag='science_prep',
-                                      reference_in_tag='reference_prep',
-                                      res_mean_tag='res_mean_ref_mask',
-                                      res_median_tag=None,
-                                      res_weighted_tag=None,
-                                      res_rot_mean_clip_tag=None,
-                                      res_arr_out_tag=None,
-                                      basis_out_tag='basis_ref_mask',
-                                      extra_rot=0.,
-                                      subtract_mean=True)
+        module = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
+                                         name_in='pca_ref_mask',
+                                         images_in_tag='science_prep',
+                                         reference_in_tag='reference_prep',
+                                         res_mean_tag='res_mean_ref_mask',
+                                         res_median_tag=None,
+                                         res_weighted_tag=None,
+                                         res_rot_mean_clip_tag=None,
+                                         res_arr_out_tag=None,
+                                         basis_out_tag='basis_ref_mask',
+                                         extra_rot=0.,
+                                         subtract_mean=True)
 
-        self.pipeline.add_module(pca)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('pca_ref_mask')
 
         data = self.pipeline.get_data('res_mean_ref_mask')
@@ -393,20 +394,20 @@ class TestPsfSubtraction:
 
     def test_psf_subtraction_ref_no_mean_mask(self):
 
-        pca = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
-                                      name_in='pca_ref_no_mean_mask',
-                                      images_in_tag='science_prep',
-                                      reference_in_tag='reference_prep',
-                                      res_mean_tag='res_mean_ref_no_mean_mask',
-                                      res_median_tag=None,
-                                      res_weighted_tag=None,
-                                      res_rot_mean_clip_tag=None,
-                                      res_arr_out_tag=None,
-                                      basis_out_tag='basis_ref_no_mean_mask',
-                                      extra_rot=0.,
-                                      subtract_mean=False)
+        module = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
+                                         name_in='pca_ref_no_mean_mask',
+                                         images_in_tag='science_prep',
+                                         reference_in_tag='reference_prep',
+                                         res_mean_tag='res_mean_ref_no_mean_mask',
+                                         res_median_tag=None,
+                                         res_weighted_tag=None,
+                                         res_rot_mean_clip_tag=None,
+                                         res_arr_out_tag=None,
+                                         basis_out_tag='basis_ref_no_mean_mask',
+                                         extra_rot=0.,
+                                         subtract_mean=False)
 
-        self.pipeline.add_module(pca)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('pca_ref_no_mean_mask')
 
         data = self.pipeline.get_data('res_mean_ref_no_mean_mask')
@@ -422,20 +423,20 @@ class TestPsfSubtraction:
         with h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a') as hdf_file:
             hdf_file['config'].attrs['CPU'] = 4
 
-        pca = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
-                                      name_in='pca_multi',
-                                      images_in_tag='science',
-                                      reference_in_tag='science',
-                                      res_mean_tag='res_mean_multi',
-                                      res_median_tag='res_median_multi',
-                                      res_weighted_tag='res_weighted_multi',
-                                      res_rot_mean_clip_tag='res_clip_multi',
-                                      res_arr_out_tag=None,
-                                      basis_out_tag='basis_multi',
-                                      extra_rot=-15.,
-                                      subtract_mean=True)
+        module = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
+                                         name_in='pca_multi',
+                                         images_in_tag='science',
+                                         reference_in_tag='science',
+                                         res_mean_tag='res_mean_multi',
+                                         res_median_tag='res_median_multi',
+                                         res_weighted_tag='res_weighted_multi',
+                                         res_rot_mean_clip_tag='res_clip_multi',
+                                         res_arr_out_tag=None,
+                                         basis_out_tag='basis_multi',
+                                         extra_rot=-15.,
+                                         subtract_mean=True)
 
-        self.pipeline.add_module(pca)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('pca_multi')
 
         data_single = self.pipeline.get_data('res_mean_single')
@@ -463,20 +464,20 @@ class TestPsfSubtraction:
         database = h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a')
         database['config'].attrs['CPU'] = 4
 
-        pca = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
-                                      name_in='pca_multi_mask',
-                                      images_in_tag='science_prep',
-                                      reference_in_tag='science_prep',
-                                      res_mean_tag='res_mean_multi_mask',
-                                      res_median_tag='res_median_multi_mask',
-                                      res_weighted_tag='res_weighted_multi_mask',
-                                      res_rot_mean_clip_tag='res_clip_multi_mask',
-                                      res_arr_out_tag=None,
-                                      basis_out_tag='basis_multi_mask',
-                                      extra_rot=-15.,
-                                      subtract_mean=True)
+        module = PcaPsfSubtractionModule(pca_numbers=range(1, 21),
+                                         name_in='pca_multi_mask',
+                                         images_in_tag='science_prep',
+                                         reference_in_tag='science_prep',
+                                         res_mean_tag='res_mean_multi_mask',
+                                         res_median_tag='res_median_multi_mask',
+                                         res_weighted_tag='res_weighted_multi_mask',
+                                         res_rot_mean_clip_tag='res_clip_multi_mask',
+                                         res_arr_out_tag=None,
+                                         basis_out_tag='basis_multi_mask',
+                                         extra_rot=-15.,
+                                         subtract_mean=True)
 
-        self.pipeline.add_module(pca)
+        self.pipeline.add_module(module)
         self.pipeline.run_module('pca_multi_mask')
 
         data_single = self.pipeline.get_data('res_mean_single_mask')
@@ -501,3 +502,26 @@ class TestPsfSubtraction:
         data_multi = self.pipeline.get_data('basis_multi_mask')
         assert np.allclose(data_single, data_multi, rtol=1e-5, atol=0.)
         assert data_single.shape == data_multi.shape
+
+    def test_psf_subtraction_len_parang(self):
+
+        database = h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a')
+        database['config'].attrs['CPU'] = 1
+
+        parang = self.pipeline.get_data('header_science/PARANG')
+        self.pipeline.set_attribute('science_prep', 'PARANG', np.append(parang, 0.), static=False)
+
+        module = PcaPsfSubtractionModule(pca_numbers=[5, ],
+                                         name_in='pca_len_parang',
+                                         images_in_tag='science_prep',
+                                         reference_in_tag='science_prep',
+                                         res_mean_tag='res_mean_len_parang',
+                                         extra_rot=0.)
+
+        self.pipeline.add_module(module)
+
+        with pytest.raises(ValueError) as error:
+            self.pipeline.run_module('pca_len_parang')
+
+        assert str(error.value) == 'The number of images (80) is not equal to the number of ' \
+                                   'parallactic angles (81).'


### PR DESCRIPTION
- Added a check in `pca_psf_subtraction` which compares the number of images and number of angles and prints an error if they are not the same. Also a unit test is included.

- Bug fix in `apply_function_to_images` which occurred when the number of images is much smaller than the `CPU` that is set. In that case the `stack_size` was rounded to zero so I changed the `int` to `math.ceil`.