### PR TITLE
Deleting data and attributes from output ports

### DIFF
--- a/pynpoint/core/processing.py
+++ b/pynpoint/core/processing.py
@@ -571,9 +571,6 @@ class ProcessingModule(PypelineModule, metaclass=ABCMeta):
 
         elif cpu == 1:
             # process images one-by-one with a single process if CPU is set to 1
-            image_out_port.del_all_attributes()
-            image_out_port.del_all_data()
-
             start_time = time.time()
 
             for i in range(nimages):
@@ -592,11 +589,8 @@ class ProcessingModule(PypelineModule, metaclass=ABCMeta):
                     image_out_port.append(result, data_dim=3)
 
         else:
-            print(message, end='')
-
             # process images in parallel in stacks of MEMORY/CPU images
-            image_out_port.del_all_attributes()
-            image_out_port.del_all_data()
+            print(message, end='')
 
             result = apply_function(tmp_data=image_in_port[0, :, :],
                                     func=func,

--- a/pynpoint/processing/background.py
+++ b/pynpoint/processing/background.py
@@ -541,9 +541,6 @@ class NoddingBackgroundModule(ProcessingModule):
             None
         """
 
-        self.m_image_out_port.del_all_data()
-        self.m_image_out_port.del_all_attributes()
-
         self._create_time_stamp_list()
 
         start_time = time.time()

--- a/pynpoint/processing/badpixel.py
+++ b/pynpoint/processing/badpixel.py
@@ -305,10 +305,6 @@ class BadPixelSigmaFilterModule(ProcessingModule):
 
             self.m_map_out_port = None
 
-        if self.m_map_out_port is not None:
-            self.m_map_out_port.del_all_data()
-            self.m_map_out_port.del_all_attributes()
-
         self.apply_function_to_images(_bad_pixel_sigma_filter,
                                       self.m_image_in_port,
                                       self.m_image_out_port,

--- a/pynpoint/processing/basic.py
+++ b/pynpoint/processing/basic.py
@@ -64,9 +64,6 @@ class SubtractImagesModule(ProcessingModule):
             None
         """
 
-        self.m_image_out_port.del_all_attributes()
-        self.m_image_out_port.del_all_data()
-
         if self.m_image_in1_port.get_shape() != self.m_image_in2_port.get_shape():
             raise ValueError('The shape of the two input tags has to be the same.')
 
@@ -141,9 +138,6 @@ class AddImagesModule(ProcessingModule):
             None
         """
 
-        self.m_image_out_port.del_all_attributes()
-        self.m_image_out_port.del_all_data()
-
         if self.m_image_in1_port.get_shape() != self.m_image_in2_port.get_shape():
             raise ValueError('The shape of the two input tags has to be the same.')
 
@@ -213,9 +207,6 @@ class RotateImagesModule(ProcessingModule):
         NoneType
             None
         """
-
-        self.m_image_out_port.del_all_attributes()
-        self.m_image_out_port.del_all_data()
 
         memory = self._m_config_port.get_attribute('MEMORY')
         nimages = self.m_image_in_port.get_shape()[0]
@@ -290,9 +281,6 @@ class RepeatImagesModule(ProcessingModule):
         NoneType
             None
         """
-
-        self.m_image_out_port.del_all_attributes()
-        self.m_image_out_port.del_all_data()
 
         nimages = self.m_image_in_port.get_shape()[0]
         memory = self._m_config_port.get_attribute('MEMORY')

--- a/pynpoint/processing/centering.py
+++ b/pynpoint/processing/centering.py
@@ -301,10 +301,6 @@ class FitCenterModule(ProcessingModule):
             None
         """
 
-        if self.m_mask_out_port:
-            self.m_mask_out_port.del_all_data()
-            self.m_mask_out_port.del_all_attributes()
-
         memory = self._m_config_port.get_attribute('MEMORY')
         cpu = self._m_config_port.get_attribute('CPU')
         pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
@@ -647,10 +643,6 @@ class ShiftImagesModule(ProcessingModule):
             None
         """
 
-        # delete all data stored in self.m_image_out_port
-        self.m_image_out_port.del_all_attributes()
-        self.m_image_out_port.del_all_data()
-
         constant = True
 
         # read the fit results from the self.m_fit_in_port if available
@@ -789,9 +781,6 @@ class WaffleCenteringModule(ProcessingModule):
                 center = (np.floor(center[0]), np.floor(center[1]))
 
             return center_frame, center
-
-        self.m_image_out_port.del_all_data()
-        self.m_image_out_port.del_all_attributes()
 
         center_shape = self.m_center_in_port.get_shape()
         im_shape = self.m_image_in_port.get_shape()

--- a/pynpoint/processing/darkflat.py
+++ b/pynpoint/processing/darkflat.py
@@ -103,9 +103,6 @@ class DarkCalibrationModule(ProcessingModule):
             None
         """
 
-        self.m_image_out_port.del_all_attributes()
-        self.m_image_out_port.del_all_data()
-
         memory = self._m_config_port.get_attribute('MEMORY')
         nimages = self.m_image_in_port.get_shape()[0]
         frames = memory_frames(memory, nimages)
@@ -178,9 +175,6 @@ class FlatCalibrationModule(ProcessingModule):
         NoneType
             None
         """
-
-        self.m_image_out_port.del_all_attributes()
-        self.m_image_out_port.del_all_data()
 
         memory = self._m_config_port.get_attribute('MEMORY')
         nimages = self.m_image_in_port.get_shape()[0]

--- a/pynpoint/processing/filter.py
+++ b/pynpoint/processing/filter.py
@@ -63,9 +63,6 @@ class GaussianFilterModule(ProcessingModule):
             None
         """
 
-        self.m_image_out_port.del_all_attributes()
-        self.m_image_out_port.del_all_data()
-
         memory = self._m_config_port.get_attribute('MEMORY')
         pixscale = self._m_config_port.get_attribute('PIXSCALE')
 

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -104,9 +104,6 @@ class FakePlanetModule(ProcessingModule):
             None
         """
 
-        self.m_image_out_port.del_all_data()
-        self.m_image_out_port.del_all_attributes()
-
         memory = self._m_config_port.get_attribute('MEMORY')
         parang = self.m_image_in_port.get_attribute('PARANG')
         pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
@@ -319,14 +316,6 @@ class SimplexMinimizationModule(ProcessingModule):
         NoneType
             None
         """
-
-        for item in self.m_res_out_port:
-            item.del_all_data()
-            item.del_all_attributes()
-
-        for item in self.m_flux_pos_port:
-            item.del_all_data()
-            item.del_all_attributes()
 
         parang = self.m_image_in_port.get_attribute('PARANG')
         pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
@@ -623,9 +612,6 @@ class FalsePositiveModule(ProcessingModule):
                                            ignore=self.m_ignore)
 
             return -snr
-
-        self.m_snr_out_port.del_all_data()
-        self.m_snr_out_port.del_all_attributes()
 
         pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
         self.m_aperture /= pixscale
@@ -1161,9 +1147,6 @@ class SystematicErrorModule(ProcessingModule):
             None
         """
 
-        self.m_offset_out_port.del_all_data()
-        self.m_offset_out_port.del_all_attributes()
-
         pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
         image = self.m_image_in_port[0, ]
 
@@ -1176,6 +1159,8 @@ class SystematicErrorModule(ProcessingModule):
                                   psf_scaling=-self.m_psf_scaling)
 
         module.connect_database(self._m_data_base)
+        module._m_output_ports[f'{self._m_name}_empty'].del_all_data()
+        module._m_output_ports[f'{self._m_name}_empty'].del_all_attributes()
         module.run()
 
         sep = float(self.m_position[0])
@@ -1193,6 +1178,8 @@ class SystematicErrorModule(ProcessingModule):
                                       image_out_tag=f'{self._m_name}_fake')
 
             module.connect_database(self._m_data_base)
+            module._m_output_ports[f'{self._m_name}_fake'].del_all_data()
+            module._m_output_ports[f'{self._m_name}_fake'].del_all_attributes()
             module.run()
 
             position = polar_to_cartesian(image, sep/pixscale, ang)
@@ -1218,6 +1205,10 @@ class SystematicErrorModule(ProcessingModule):
                                                offset=self.m_offset)
 
             module.connect_database(self._m_data_base)
+            module._m_output_ports[f'{self._m_name}_simplex'].del_all_data()
+            module._m_output_ports[f'{self._m_name}_simplex'].del_all_attributes()
+            module._m_output_ports[f'{self._m_name}_fluxpos'].del_all_data()
+            module._m_output_ports[f'{self._m_name}_fluxpos'].del_all_attributes()
             module.run()
 
             fluxpos_out_port = self.add_input_port(f'{self._m_name}_fluxpos')

--- a/pynpoint/processing/frameselection.py
+++ b/pynpoint/processing/frameselection.py
@@ -90,12 +90,6 @@ class RemoveFramesModule(ProcessingModule):
             None
         """
 
-        self.m_selected_out_port.del_all_data()
-        self.m_selected_out_port.del_all_attributes()
-
-        self.m_removed_out_port.del_all_data()
-        self.m_removed_out_port.del_all_attributes()
-
         if self.m_index_in_port is not None:
             self.m_frames = self.m_index_in_port.get_all()
 
@@ -269,16 +263,6 @@ class FrameSelectionModule(ProcessingModule):
             None
         """
 
-        self.m_selected_out_port.del_all_data()
-        self.m_selected_out_port.del_all_attributes()
-
-        self.m_removed_out_port.del_all_data()
-        self.m_removed_out_port.del_all_attributes()
-
-        if self.m_index_out_port is not None:
-            self.m_index_out_port.del_all_data()
-            self.m_index_out_port.del_all_attributes()
-
         pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
         nimages = self.m_image_in_port.get_shape()[0]
 
@@ -405,9 +389,6 @@ class RemoveLastFrameModule(ProcessingModule):
             None
         """
 
-        self.m_image_out_port.del_all_data()
-        self.m_image_out_port.del_all_attributes()
-
         ndit = self.m_image_in_port.get_attribute('NDIT')
         nframes = self.m_image_in_port.get_attribute('NFRAMES')
         index = self.m_image_in_port.get_attribute('INDEX')
@@ -494,9 +475,6 @@ class RemoveStartFramesModule(ProcessingModule):
         NoneType
             None
         """
-
-        self.m_image_out_port.del_all_data()
-        self.m_image_out_port.del_all_attributes()
 
         if self.m_image_out_port.tag == self.m_image_in_port.tag:
             raise ValueError('Input and output port should have a different tag.')
@@ -956,14 +934,6 @@ class SelectByAttributeModule(ProcessingModule):
             None
         """
 
-        if self.m_selected_out_port is not None:
-            self.m_selected_out_port.del_all_data()
-            self.m_selected_out_port.del_all_attributes()
-
-        if self.m_removed_out_port is not None:
-            self.m_removed_out_port.del_all_data()
-            self.m_removed_out_port.del_all_attributes()
-
         nimages = self.m_image_in_port.get_shape()[0]
         attribute = self.m_image_in_port.get_attribute(f'{self.m_attribute_tag}')
 
@@ -1057,12 +1027,6 @@ class ResidualSelectionModule(ProcessingModule):
         NoneType
             None
         """
-
-        self.m_selected_out_port.del_all_data()
-        self.m_selected_out_port.del_all_attributes()
-
-        self.m_removed_out_port.del_all_data()
-        self.m_removed_out_port.del_all_attributes()
 
         pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
         nimages = self.m_image_in_port.get_shape()[0]

--- a/pynpoint/processing/psfpreparation.py
+++ b/pynpoint/processing/psfpreparation.py
@@ -98,13 +98,6 @@ class PSFpreparationModule(ProcessingModule):
             None
         """
 
-        self.m_image_out_port.del_all_data()
-        self.m_image_out_port.del_all_attributes()
-
-        if self.m_mask_out_port is not None:
-            self.m_mask_out_port.del_all_data()
-            self.m_mask_out_port.del_all_attributes()
-
         # Get PIXSCALE and MEMORY attributes
         pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
         memory = self._m_config_port.get_attribute('MEMORY')
@@ -313,9 +306,6 @@ class SortParangModule(ProcessingModule):
         NoneType
             None
         """
-
-        self.m_image_out_port.del_all_data()
-        self.m_image_out_port.del_all_attributes()
 
         if self.m_image_in_port.tag == self.m_image_out_port.tag:
             raise ValueError('Input and output port should have a different tag.')
@@ -674,9 +664,6 @@ class SDIpreparationModule(ProcessingModule):
         NoneType
             None
         """
-
-        self.m_image_out_port.del_all_data()
-        self.m_image_out_port.del_all_attributes()
 
         wvl_factor = self.m_line_wvl/self.m_cnt_wvl
         width_factor = self.m_line_width/self.m_cnt_width

--- a/pynpoint/processing/psfsubtraction.py
+++ b/pynpoint/processing/psfsubtraction.py
@@ -243,28 +243,6 @@ class PcaPsfSubtractionModule(ProcessingModule):
                 stack = combine_residuals(method='clipped', res_rot=res_rot)
                 self.m_res_rot_mean_clip_out_port.append(stack, data_dim=3)
 
-    def _clear_output_ports(self):
-        if self.m_res_mean_out_port is not None:
-            self.m_res_mean_out_port.del_all_data()
-            self.m_res_mean_out_port.del_all_attributes()
-
-        if self.m_res_median_out_port is not None:
-            self.m_res_median_out_port.del_all_data()
-            self.m_res_median_out_port.del_all_attributes()
-
-        if self.m_res_weighted_out_port is not None:
-            self.m_res_weighted_out_port.del_all_data()
-            self.m_res_weighted_out_port.del_all_attributes()
-
-        if self.m_res_rot_mean_clip_out_port is not None:
-            self.m_res_rot_mean_clip_out_port.del_all_data()
-            self.m_res_rot_mean_clip_out_port.del_all_attributes()
-
-        if self.m_res_arr_out_ports is not None:
-            for pca_number in self.m_components:
-                self.m_res_arr_out_ports[pca_number].del_all_data()
-                self.m_res_arr_out_ports[pca_number].del_all_attributes()
-
     @typechecked
     def run(self) -> None:
         """
@@ -284,8 +262,6 @@ class PcaPsfSubtractionModule(ProcessingModule):
         if cpu > 1 and self.m_res_arr_out_ports is not None:
             warnings.warn(f'Multiprocessing not possible if \'res_arr_out_tag\' is not set '
                           f'to None.')
-
-        self._clear_output_ports()
 
         # get all data
         star_data = self.m_star_in_port.get_all()

--- a/pynpoint/processing/resizing.py
+++ b/pynpoint/processing/resizing.py
@@ -76,9 +76,6 @@ class CropImagesModule(ProcessingModule):
             None
         """
 
-        self.m_image_out_port.del_all_attributes()
-        self.m_image_out_port.del_all_data()
-
         # Get memory and number of images to split the frames into chunks
         memory = self._m_config_port.get_attribute('MEMORY')
         nimages = self.m_image_in_port.get_shape()[0]
@@ -255,9 +252,6 @@ class AddLinesModule(ProcessingModule):
             None
         """
 
-        self.m_image_out_port.del_all_attributes()
-        self.m_image_out_port.del_all_data()
-
         memory = self._m_config_port.get_attribute('MEMORY')
         nimages = self.m_image_in_port.get_shape()[0]
         frames = memory_frames(memory, nimages)
@@ -338,9 +332,6 @@ class RemoveLinesModule(ProcessingModule):
         NoneType
             None
         """
-
-        self.m_image_out_port.del_all_attributes()
-        self.m_image_out_port.del_all_data()
 
         memory = self._m_config_port.get_attribute('MEMORY')
         nimages = self.m_image_in_port.get_shape()[0]

--- a/pynpoint/processing/stacksubset.py
+++ b/pynpoint/processing/stacksubset.py
@@ -242,9 +242,6 @@ class StackCubesModule(ProcessingModule):
         if self.m_image_in_port.tag == self.m_image_out_port.tag:
             raise ValueError('Input and output port should have a different tag.')
 
-        self.m_image_out_port.del_all_data()
-        self.m_image_out_port.del_all_attributes()
-
         non_static = self.m_image_in_port.get_all_non_static_attributes()
         nframes = self.m_image_in_port.get_attribute('NFRAMES')
 
@@ -367,9 +364,6 @@ class DerotateAndStackModule(ProcessingModule):
 
             return nimages, frames, im_tot
 
-        self.m_image_out_port.del_all_data()
-        self.m_image_out_port.del_all_attributes()
-
         if self.m_image_in_port.tag == self.m_image_out_port.tag:
             raise ValueError('Input and output port should have a different tag.')
 
@@ -477,9 +471,6 @@ class CombineTagsModule(ProcessingModule):
         NoneType
             None
         """
-
-        self.m_image_out_port.del_all_data()
-        self.m_image_out_port.del_all_attributes()
 
         memory = self._m_config_port.get_attribute('MEMORY')
 

--- a/tests/test_core/test_pypeline.py
+++ b/tests/test_core/test_pypeline.py
@@ -246,8 +246,8 @@ class TestPypeline:
             pipeline.run()
 
         assert str(error.value) == 'Pipeline module \'write\' is looking for data under a tag ' \
-                                   'which is not created by a previous module or does not exist ' \
-                                   'in the database.'
+                                   'which is not created by a previous module or the data does ' \
+                                   'not exist in the database.'
 
         assert pipeline.validate_pipeline_module('test') is None
         assert pipeline._validate('module', 'tag') == (False, None)
@@ -261,7 +261,7 @@ class TestPypeline:
             pipeline.run_module('test')
 
         assert len(warning) == 1
-        assert warning[0].message.args[0] == 'Module \'test\' not found.'
+        assert warning[0].message.args[0] == 'Pipeline module \'test\' not found.'
 
         os.remove(self.test_dir+'PynPoint_database.hdf5')
 
@@ -287,8 +287,8 @@ class TestPypeline:
             pipeline.remove_module('test')
 
         assert len(warning) == 1
-        assert warning[0].message.args[0] == 'Module name \'test\' not found in the Pypeline ' \
-                                             'dictionary.'
+        assert warning[0].message.args[0] == 'Pipeline module name \'test\' not found in the ' \
+                                             'Pypeline dictionary.'
 
         os.remove(self.test_dir+'PynPoint_database.hdf5')
 


### PR DESCRIPTION
When running a `ProcessingModule`, any existing data and attributes were always removed from the output ports. This was previously coded in each module but now moved to the `run_module` method of `Pypeline`. I have updated all modules.

The data is removed when:
- The module is a `ProcessingModule`.
- The output port is not also used as input port.
- The tag of the output port is already used in the database.

A message is printed if any data is removed.