### PR TITLE
Compatibility of the MCMCsamplingModule with the Hessian minimization

### DIFF
--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -5,6 +5,8 @@ Coding a New Module
 
 .. _constructor:
 
+There are three different types of pipeline modules: :class:`~pynpoint.core.processing.ReadingModule`, :class:`~pynpoint.core.processing.WritingModule`, and :class:`~pynpoint.core.processing.ProcessingModule`. The concept is similar for these three modules so here we will explain only how to code a processing module.
+
 Class Constructor
 -----------------
 

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -26,8 +26,6 @@ The modular architecture of PynPoint allows for easy implementation of new pipel
 
    <a href="https://docs.python.org/3/library/abc.html" target="_blank">Abstract classes</a>
 
-There are three different types of pipeline modules: :class:`~pynpoint.core.processing.ReadingModule`, :class:`~pynpoint.core.processing.WritingModule`, and :class:`~pynpoint.core.processing.ProcessingModule`. The concept is similar for the three types of modules so here we will explain only how to code a processing module.
-
 .. _conventions:
 
 Conventions
@@ -52,4 +50,24 @@ Before we start writing a new PynPoint module, please take notice of the followi
 
    <a href="https://pypi.org/project/pycodestyle/" target="_blank">pycodestyle</a>
 
-Now we are ready to code!
+Unit tests
+----------
+
+PynPoint is a robust pipeline package with 95% of the code covered by |unittest|. Testing of the package is done by running ``make test`` in the cloned repository. This requires the installation of:
+
+   * |pytest|
+   * |pytest-cov|
+
+The unit tests ensure that the output from existing functionalities will not change whenever new code. With these things in mind, we are now ready to code!
+
+.. |unittest| raw:: html
+
+   <a href="https://docs.python.org/3/library/unittest.html" target="_blank">unit tests</a>
+
+.. |pytest| raw:: html
+
+   <a href="https://docs.pytest.org/en/latest/getting-started.html" target="_blank">pytest</a>
+
+.. |pytest-cov| raw:: html
+
+   <a href="https://pytest-cov.readthedocs.io/en/latest/readme.html" target="_blank">pytest-cov</a>

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -3,7 +3,9 @@ Thank you for your contribution to the PynPoint repo! Before submitting this PR,
 - [ ] To read the documentation page on the [Python guidelines](https://pynpoint.readthedocs.io/en/latest/python.html).
 - [ ] That your branch of the PR is up to date with the master branch of the upstream PynPoint repo.
 - [ ] To run both `pycodestyle` and `pylint` on the code that has been added and/or changed.
-- [ ] That the documentation is successfully build after running `make docs` in your local repo folder.
-- [ ] That all unit tests are finishing after running `make test` in your local repo folder.
+- [ ] That the documentation is successfully build after running `make docs` in your local repo folder. This requires the installation of `sphinx` and `sphinx_rtd_theme`.
+- [ ] That all unit tests are finishing after running `make test` in your local repo folder. This requires the installation of `pytest` and `pytest-cov`.
 - [ ] To add unit tests in case there are new pipeline modules and/or functionalities added.
-- [ ] Make sure that only text files have been added and changed in the commits of the PR. Binary files will clutter up the repo because even after removing such files they will remain in the repo history.
+- [ ] That only text files have been added and changed in the commits of the PR. Binary files will clutter up the repo because even after removing such files they will remain in the repo history.
+- [ ] To add and/or update the docstrings.
+- [ ] To add and/or update the typehints and typechecks.

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -846,9 +846,9 @@ class MCMCsamplingModule(ProcessingModule):
         elif isinstance(self.m_aperture, tuple):
             aperture = (self.m_aperture[1], self.m_aperture[0], self.m_aperture[2]/pixscale)
 
-        print(f'Aperture position [x, y] = [{aperture[1]}, {aperture[0]}]')
-        print(f'Aperture radius (pix) = {aperture[2]:.2f}')
-        print(f'Figure of merit = {self.m_merit}')
+        print(f'Aperture position [x, y]: [{aperture[1]}, {aperture[0]}]')
+        print(f'Aperture radius (pix): {aperture[2]:.2f}')
+        print(f'Figure of merit: {self.m_merit}')
 
         if self.m_merit == 'poisson':
             var_noise = None
@@ -865,9 +865,9 @@ class MCMCsamplingModule(ProcessingModule):
                                        sigma=0.)
 
             if self.m_merit == 'gaussian':
-                print(f'Gaussian standard deviation (counts) = {np.sqrt(var_noise):.2e}')
+                print(f'Gaussian standard deviation (counts): {np.sqrt(var_noise):.2e}')
             if self.m_merit == 'hessian':
-                print(f'Hessian standard deviation = {np.sqrt(var_noise):.2e}')
+                print(f'Hessian standard deviation: {np.sqrt(var_noise):.2e}')
 
         initial = np.zeros((self.m_nwalkers, ndim))
 

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -862,7 +862,7 @@ class MCMCsamplingModule(ProcessingModule):
         if self.m_merit == 'poisson':
             noise = None
 
-        elif self.m_merit == 'gaussian':
+        elif self.m_merit in ['gaussian', 'hessian']:
             noise = gaussian_noise(images=images,
                                    parang=parang,
                                    cent_size=self.m_mask[0],

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -859,17 +859,23 @@ class MCMCsamplingModule(ProcessingModule):
         elif isinstance(self.m_aperture, tuple):
             aperture = (self.m_aperture[1], self.m_aperture[0], self.m_aperture[2]/pixscale)
 
+        print(f'Aperture position [x, y] = [{aperture[1]}, {aperture[0]}]')
+        print(f'Aperture radius (pix) = {aperture[2]:.2f}')
+        print(f'Figure of merit = {self.m_merit}')
+
         if self.m_merit == 'poisson':
-            noise = None
+            var_noise = None
 
         elif self.m_merit in ['gaussian', 'hessian']:
-            noise = gaussian_noise(images=images,
-                                   parang=parang,
-                                   cent_size=self.m_mask[0],
-                                   edge_size=self.m_mask[1],
-                                   pca_number=self.m_pca_number,
-                                   residuals=self.m_residuals,
-                                   aperture=aperture)
+            var_noise = gaussian_noise(images=images,
+                                       parang=parang,
+                                       cent_size=self.m_mask[0],
+                                       edge_size=self.m_mask[1],
+                                       pca_number=self.m_pca_number,
+                                       residuals=self.m_residuals,
+                                       aperture=aperture)
+
+            print(f'Gaussian noise (counts) = {np.sqrt(var_noise):.2e}')
 
         initial = np.zeros((self.m_nwalkers, ndim))
 
@@ -897,7 +903,7 @@ class MCMCsamplingModule(ProcessingModule):
                                                    indices,
                                                    self.m_merit,
                                                    self.m_residuals,
-                                                   noise]))
+                                                   var_noise]))
 
             sampler.run_mcmc(initial, self.m_nsteps, progress=True)
 

--- a/pynpoint/processing/fluxposition.py
+++ b/pynpoint/processing/fluxposition.py
@@ -353,7 +353,7 @@ class SimplexMinimizationModule(ProcessingModule):
                        sklearn_pca: Optional[PCA],
                        var_noise: Optional[float]) -> float:
 
-          pos_y = arg[0]
+            pos_y = arg[0]
             pos_x = arg[1]
             mag = arg[2]
 

--- a/pynpoint/processing/resizing.py
+++ b/pynpoint/processing/resizing.py
@@ -83,7 +83,12 @@ class CropImagesModule(ProcessingModule):
 
         # Convert size parameter from arcseconds to pixels
         pixscale = self.m_image_in_port.get_attribute('PIXSCALE')
+        print(f'New image size (arcsec) = {self.m_size}')
         self.m_size = int(math.ceil(self.m_size / pixscale))
+        print(f'New image size (pixels) = {self.m_size}')
+
+        if center is not None:
+            print(f'New image center (x, y) = {self.m_center}')
 
         # Crop images chunk by chunk
         start_time = time.time()
@@ -100,7 +105,7 @@ class CropImagesModule(ProcessingModule):
             self.m_image_out_port.append(images, data_dim=3)
 
         # Save history and copy attributes
-        history = f'image size [pix] = {self.m_size}'
+        history = f'image size (pix) = {self.m_size}'
         self.m_image_out_port.add_history('CropImagesModule', history)
         self.m_image_out_port.copy_attributes(self.m_image_in_port)
         self.m_image_out_port.close_port()

--- a/pynpoint/processing/resizing.py
+++ b/pynpoint/processing/resizing.py
@@ -87,7 +87,7 @@ class CropImagesModule(ProcessingModule):
         self.m_size = int(math.ceil(self.m_size / pixscale))
         print(f'New image size (pixels) = {self.m_size}')
 
-        if center is not None:
+        if self.m_center is not None:
             print(f'New image center (x, y) = {self.m_center}')
 
         # Crop images chunk by chunk

--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -294,7 +294,27 @@ def merit_function(residuals: np.ndarray,
 
         hes_det = (hessian_rr*hessian_cc) - (hessian_rc*hessian_rc)
 
-        chi_square = np.sum(np.abs(hes_det[indices]))
+        # chi_square = np.sum(np.abs(hes_det[indices]))
+        chi_square = np.sum(hes_det[indices]**2)
+
+        if noise is not None:
+            hes_random = np.zeros(100)
+
+            for i in range(100):
+                im_ran = residuals+np.random.normal(loc=0., scale=1., size=residuals.shape)*noise
+
+                hessian_rr, hessian_rc, hessian_cc = hessian_matrix(image=im_ran,
+                                                                    sigma=sigma,
+                                                                    mode='constant',
+                                                                    cval=0.,
+                                                                    order='rc')
+
+                hes_tmp = (hessian_rr*hessian_cc) - (hessian_rc*hessian_rc)
+                hes_random[i] = np.sum(np.abs(hes_tmp[indices]))
+
+            noise = np.std(hes_det)
+
+            chi_square /= noise**2
 
     elif merit == 'poisson':
 

--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -284,8 +284,6 @@ def merit_function(residuals: np.ndarray,
 
     if merit == 'hessian':
 
-        # This is not the chi-square but simply the sum of the absolute values
-
         hessian_rr, hessian_rc, hessian_cc = hessian_matrix(image=residuals,
                                                             sigma=sigma,
                                                             mode='constant',
@@ -298,7 +296,7 @@ def merit_function(residuals: np.ndarray,
         chi_square = np.sum(hes_det[indices]**2)
 
         if noise is not None:
-            hes_random = np.zeros(100)
+            hes_sample = np.zeros(100)
 
             for i in range(100):
                 im_ran = residuals+np.random.normal(loc=0., scale=1., size=residuals.shape)*noise
@@ -310,11 +308,9 @@ def merit_function(residuals: np.ndarray,
                                                                     order='rc')
 
                 hes_tmp = (hessian_rr*hessian_cc) - (hessian_rc*hessian_rc)
-                hes_random[i] = np.sum(np.abs(hes_tmp[indices]))
+                hes_sample[i] = np.sum(np.abs(hes_tmp[indices]))
 
-            noise = np.std(hes_det)
-
-            chi_square /= noise**2
+            chi_square /= np.var(hes_sample)
 
     elif merit == 'poisson':
 

--- a/pynpoint/util/analysis.py
+++ b/pynpoint/util/analysis.py
@@ -253,7 +253,7 @@ def merit_function(residuals: np.ndarray,
                    merit: str,
                    aperture: Tuple[int, int, float],
                    sigma: float,
-                   noise: Union[float, None]) -> float:
+                   var_noise: Union[float, None]) -> float:
     """
     Function to calculate the figure of merit at a given position in the image residuals.
 
@@ -268,13 +268,13 @@ def merit_function(residuals: np.ndarray,
     sigma : float
         Standard deviation (pix) of the Gaussian kernel which is used to smooth the residuals
         before the chi-square is calculated.
-    noise : float, None
-        Variance of the noise which is required when `merit` is set to 'gaussian'.
+    var_noise : float, None
+        Variance of the noise which is required when `merit` is set to 'gaussian' or 'hessian'.
 
     Returns
     -------
     float
-        Chi-square ('poisson' and 'gaussian') or sum of the absolute values ('hessian').
+        Chi-square value.
     """
 
     rr_grid = pixel_distance(im_shape=residuals.shape,
@@ -292,25 +292,7 @@ def merit_function(residuals: np.ndarray,
 
         hes_det = (hessian_rr*hessian_cc) - (hessian_rc*hessian_rc)
 
-        # chi_square = np.sum(np.abs(hes_det[indices]))
-        chi_square = np.sum(hes_det[indices]**2)/noise
-
-        # if noise is not None:
-        #     hes_sample = np.zeros(100)
-        #
-        #     for i in range(100):
-        #         im_ran = residuals+np.random.normal(loc=0., scale=1., size=residuals.shape)*noise
-        #
-        #         hessian_rr, hessian_rc, hessian_cc = hessian_matrix(image=im_ran,
-        #                                                             sigma=sigma,
-        #                                                             mode='constant',
-        #                                                             cval=0.,
-        #                                                             order='rc')
-        #
-        #         hes_tmp = (hessian_rr*hessian_cc) - (hessian_rc*hessian_rc)
-        #         hes_sample[i] = np.sum(np.abs(hes_tmp[indices]))
-        #
-        #     chi_square /= np.var(hes_sample)
+        chi_square = np.sum(hes_det[indices]**2)/var_noise
 
     elif merit == 'poisson':
 
@@ -321,7 +303,7 @@ def merit_function(residuals: np.ndarray,
 
     elif merit == 'gaussian':
 
-        chi_square = np.sum(residuals[indices]**2)/noise
+        chi_square = np.sum(residuals[indices]**2)/var_noise
 
     else:
 

--- a/pynpoint/util/mcmc.py
+++ b/pynpoint/util/mcmc.py
@@ -30,7 +30,7 @@ def lnprob(param: np.ndarray,
            indices: np.ndarray,
            merit: str,
            residuals: str,
-           noise: Union[float, None]) -> float:
+           var_noise: Union[float, None]) -> float:
     """
     Function for the log posterior function. Should be placed at the highest level of the
     Python module to be pickable for the multiprocessing.
@@ -75,8 +75,8 @@ def lnprob(param: np.ndarray,
         Poisson distribution is assumed for the variance of each pixel value.
     residuals : str
         Method used for combining the residuals ('mean', 'median', 'weighted', or 'clipped').
-    noise : float, None
-        Variance of the noise which is required when `merit` is set to 'gaussian'.
+    var_noise : float, None
+        Variance of the noise which is required when `merit` is set to 'gaussian' or 'hessian'.
 
     Returns
     -------
@@ -139,7 +139,7 @@ def lnprob(param: np.ndarray,
                                     merit=merit,
                                     aperture=aperture,
                                     sigma=0.,
-                                    noise=noise)
+                                    var_noise=var_noise)
 
         return -0.5*chi_square
 

--- a/tests/test_processing/test_fluxposition.py
+++ b/tests/test_processing/test_fluxposition.py
@@ -268,16 +268,16 @@ class TestFluxPosition:
 
         data = self.pipeline.get_data('simplex_res')
         assert np.allclose(data[0, 50, 31], 0.00013866444247059368, rtol=limit, atol=0.)
-        assert np.allclose(data[35, 50, 31], 3.482226033356121e-05, rtol=limit, atol=0.)
-        assert np.allclose(np.mean(data), 3.125137239656066e-07, rtol=limit, atol=0.)
+        assert np.allclose(data[35, 50, 31], 3.445557381447193e-05, rtol=limit, atol=0.)
+        assert np.allclose(np.mean(data), 3.1111919894652305e-07, rtol=limit, atol=0.)
         assert data.shape == (36, 101, 101)
 
         data = self.pipeline.get_data('flux_position')
-        assert np.allclose(data[35, 0], 31.420497036174158, rtol=limit, atol=0.)
-        assert np.allclose(data[35, 1], 50.03219573166646, rtol=limit, atol=0.)
-        assert np.allclose(data[35, 2], 0.5016473331983896, rtol=limit, atol=0.)
-        assert np.allclose(data[35, 3], 89.90071436787039, rtol=limit, atol=0.)
-        assert np.allclose(data[35, 4], 6.012537296489204, rtol=limit, atol=0.)
+        assert np.allclose(data[35, 0], 31.695095810580824, rtol=limit, atol=0.)
+        assert np.allclose(data[35, 1], 49.94989598578772, rtol=limit, atol=0.)
+        assert np.allclose(data[35, 2], 0.49423426455813924, rtol=limit, atol=0.)
+        assert np.allclose(data[35, 3], 90.15682908536053, rtol=limit, atol=0.)
+        assert np.allclose(data[35, 4], 5.889773588736068, rtol=limit, atol=0.)
         assert data.shape == (36, 6)
 
     def test_simplex_minimization_reference(self):


### PR DESCRIPTION
Changed the minimization function of the Hessian. Instead of minimizing the (pixel) sum of the absolute values of the determinant of the Hessian, it now minimizes the (pixel) sum of the squared values of the determinant of the Hessian, divided by the variance of the determinant of the Hessian. This should have no impact on the results from the `SimplexMinimizationModule` and `SystematicErrorModule` but enables this function to be used by the `MCMCsamplingModule`.

Similar to the `merit='gaussian'` argument, the variance is calculated once at the start of the MCMC by derotating in opposite direction and selecting pixels within an annulus at the planet separation.

I am not fully sure if it statistically makes sense to calculate the error on the determinant of the Hessian though... but it seems to work and potentially provides less biased results in case of strong (speckle) residuals. Comments welcome!

Added some documentation about the use of unit tests and updated the PR template.