### PR TITLE
Changed the URL of the isochrone data

### DIFF
--- a/tests/test_processing/test_limits.py
+++ b/tests/test_processing/test_limits.py
@@ -133,8 +133,7 @@ class TestLimits:
         with h5py.File(self.test_dir+'PynPoint_database.hdf5', 'a') as hdf_file:
             hdf_file['contrast_limits'] = limits
 
-        url = 'https://phoenix.ens-lyon.fr/Grids/AMES-Cond/ISOCHRONES/' \
-              'model.AMES-Cond-2000.M-0.0.NaCo.Vega'
+        url = 'https://people.phys.ethz.ch/~stolkert/pynpoint/model.AMES-Cond-2000.M-0.0.NaCo.Vega'
 
         filename = self.test_dir + 'model.AMES-Cond-2000.M-0.0.NaCo.Vega'
 


### PR DESCRIPTION
The https://phoenix.ens-lyon.fr/Grids website is offline so I have moved the isochrone file to my personal page. The isochrone data is required for the unit tests of `MassLimitsModule`.

