### PR TITLE
SDI support for DerotateAndStackModule

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -129,7 +129,7 @@ Frame Selection
 Image Resizing
 ~~~~~~~~~~~~~~
 
-* :class:`~pynpoint.processing.resizing.CropImagesModule`: Crop the images.
+* :class:`~pynpoint.processing.resizing.CropImagesModule` (IFS): Crop the images.
 * :class:`~pynpoint.processing.resizing.ScaleImagesModule` (CPU): Resample the images (spatially and/or in flux).
 * :class:`~pynpoint.processing.resizing.AddLinesModule`: Add pixel lines on the sides of the images.
 * :class:`~pynpoint.processing.resizing.RemoveLinesModule`: Remove pixel lines from the sides of the images.
@@ -144,7 +144,7 @@ PCA Background Subtraction
 PSF Preparation
 ~~~~~~~~~~~~~~~
 
-* :class:`~pynpoint.processing.psfpreparation.PSFpreparationModule`: Mask the images before the PSF subtraction.
+* :class:`~pynpoint.processing.psfpreparation.PSFpreparationModule` (IFS): Mask the images before the PSF subtraction.
 * :class:`~pynpoint.processing.psfpreparation.AngleInterpolationModule`: Interpolate the parallactic angles between the start and end values.
 * :class:`~pynpoint.processing.psfpreparation.AngleCalculationModule`: Calculate the parallactic angles.
 * :class:`~pynpoint.processing.psfpreparation.SortParangModule` (IFS): Sort the images by parallactic angle.
@@ -161,5 +161,5 @@ Stacking
 
 * :class:`~pynpoint.processing.stacksubset.StackAndSubsetModule`: Stack and/or select a random subset of the images.
 * :class:`~pynpoint.processing.stacksubset.StackCubesModule`: Collapse each original data cube separately.
-* :class:`~pynpoint.processing.stacksubset.DerotateAndStackModule`: Derotate and/or stack the images.
+* :class:`~pynpoint.processing.stacksubset.DerotateAndStackModule` (IFS): Derotate and/or stack the images.
 * :class:`~pynpoint.processing.stacksubset.CombineTagsModule`: Combine multiple database tags into a single dataset.

--- a/pynpoint/processing/stacksubset.py
+++ b/pynpoint/processing/stacksubset.py
@@ -5,7 +5,7 @@ Pipeline modules for stacking and subsampling of images.
 import time
 import warnings
 
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -228,7 +228,7 @@ class StackCubesModule(ProcessingModule):
             None
         """
 
-        super(StackCubesModule, self).__init__(name_in=name_in)
+        super(StackCubesModule, self).__init__(name_in)
 
         self.m_image_in_port = self.add_input_port(image_in_tag)
         self.m_image_out_port = self.add_output_port(image_out_tag)
@@ -238,7 +238,7 @@ class StackCubesModule(ProcessingModule):
     @typechecked
     def run(self) -> None:
         """
-        Run method of the module. Uses the NFRAMES attribute to select the images of each cube,
+        Run method of the module. Uses the ``NFRAMES`` attribute to select the images of each cube,
         calculates the mean or median of each cube, and saves the data and attributes.
 
         Returns
@@ -298,7 +298,7 @@ class StackCubesModule(ProcessingModule):
 class DerotateAndStackModule(ProcessingModule):
     """
     Pipeline module for derotating and/or stacking (i.e., taking the median or average) of the
-    images.
+    images, either along the time or the wavelengths dimension.
     """
 
     @typechecked
@@ -319,17 +319,17 @@ class DerotateAndStackModule(ProcessingModule):
             Tag of the database entry that is read as input.
         image_out_tag : str
             Tag of the database entry that is written as output. The output is either 2D
-            (*stack=False*) or 3D (*stack=True*).
+            (``stack=False``) or 3D (``stack=True``).
         derotate : bool
-            Derotate the images with the PARANG attribute.
+            Derotate the images with the ``PARANG`` attribute.
         stack : str
             Type of stacking applied after optional derotation ('mean', 'median', or None for no
             stacking).
         extra_rot : float
             Additional rotation angle of the images in clockwise direction (deg).
-        dimension: str
-            Dimension in which the images are stacked. Can either be 'time' or 'wavelength'. If
-            ndim = 3, dimension is always set to 'time'.
+        dimension : str
+            Dimension along which the images are stacked. Can either be 'time' or 'wavelength'. If
+            the ``image_in_tag`` has three dimensions then ``dimension`` is always fixed to 'time'.
 
         Returns
         -------
@@ -337,7 +337,7 @@ class DerotateAndStackModule(ProcessingModule):
             None
         """
 
-        super(DerotateAndStackModule, self).__init__(name_in=name_in)
+        super(DerotateAndStackModule, self).__init__(name_in)
 
         self.m_image_in_port = self.add_input_port(image_in_tag)
         self.m_image_out_port = self.add_output_port(image_out_tag)
@@ -350,8 +350,9 @@ class DerotateAndStackModule(ProcessingModule):
     @typechecked
     def run(self) -> None:
         """
-        Run method of the module. Uses the PARANG attributes to derotate the images (if *derotate*
-        is set to True) and applies an optional mean or median stacking afterwards.
+        Run method of the module. Uses the ``PARANG`` attributes to derotate the images (if
+        ``derotate`` is set to ``True``) and applies an optional mean or median stacking
+        along the time or wavelengths dimension afterwards.
 
         Returns
         -------
@@ -361,48 +362,55 @@ class DerotateAndStackModule(ProcessingModule):
 
         @typechecked
         def _initialize(ndim: int,
-                        npix: int) -> Tuple[int, np.ndarray, Optional[np.ndarray], Optional[np.ndarray]]:
+                        npix: int) -> Tuple[int, np.ndarray, Optional[np.ndarray],
+                                            Optional[np.ndarray]]:
 
             if ndim == 2:
                 nimages = 1
+
             elif ndim == 3:
                 nimages = self.m_image_in_port.get_shape()[-3]
 
                 if self.m_stack == 'median':
                     frames = np.array([0, nimages])
+
                 else:
                     frames = memory_frames(memory, nimages)
 
             elif ndim == 4:
                 nimages = self.m_image_in_port.get_shape()[-3]
                 nwave = self.m_image_in_port.get_shape()[-4]
+
                 if self.m_dimension == 'time':
                     frames = np.linspace(0, nwave, nwave+1)
+
                 elif self.m_dimension == 'wavelength':
                     frames = np.linspace(0, nimages, nimages+1)
+
                 else:
-                    raise ValueError('Set dimension eith to \'wavlength\' or \'time\'.')
+                    raise ValueError('The dimension should be set to \'time\' or \'wavelength\'.')
 
             if self.m_stack == 'mean':
                 if ndim == 4:
                     if self.m_dimension == 'time':
                         im_tot = np.zeros((nwave, npix, npix))
+
                     elif self.m_dimension == 'wavelength':
                         im_tot = np.zeros((nimages, npix, npix))
+
                 else:
                     im_tot = np.zeros((npix, npix))
+
             else:
                 im_tot = None
 
             if self.m_stack is None and ndim == 4:
                 im_none = np.zeros((nwave, nimages, npix, npix))
+
             else:
                 im_none = None
 
             return nimages, frames, im_tot, im_none
-
-        if self.m_image_in_port.tag == self.m_image_out_port.tag:
-            raise ValueError('Input and output port should have a different tag.')
 
         memory = self._m_config_port.get_attribute('MEMORY')
 
@@ -427,44 +435,55 @@ class DerotateAndStackModule(ProcessingModule):
                 # Process all time frames per exposure at once
                 if self.m_dimension == 'time':
                     images = self.m_image_in_port[i, :, ]
+
                 elif self.m_dimension == 'wavelength':
                     images = self.m_image_in_port[:, i, ]
 
             if self.m_derotate:
                 if ndim == 4:
                     if self.m_dimension == 'time':
-                        angles = -parang+self.m_extra_rot
+                        angles = -1.*parang + self.m_extra_rot
+
                     elif self.m_dimension == 'wavelength':
-                        nwaves = self.m_image_in_port.get_shape()[-4]
-                        angles = -np.ones((nwaves))*parang[i]+self.m_extra_rot
+                        n_wavel = self.m_image_in_port.get_shape()[-4]
+                        angles = np.full(n_wavel, -1.*parang[i]) + self.m_extra_rot
+
                 else:
                     angles = -parang[frames[i]:frames[i+1]]+self.m_extra_rot
+
                 images = rotate_images(images, angles)
 
             if self.m_stack is None:
                 if ndim == 2:
                     self.m_image_out_port.set_all(images[np.newaxis, ...])
+
                 elif ndim == 3:
                     self.m_image_out_port.append(images, data_dim=3)
+
                 elif ndim == 4:
                     if self.m_dimension == 'time':
                         im_none[i] = images
+
                     elif self.m_dimension == 'wavelength':
                         im_none[:, i] = images
 
             elif self.m_stack == 'mean':
                 if ndim == 4:
                     im_tot[i] = np.sum(images, axis=0)
+
                 else:
                     im_tot += np.sum(images, axis=0)
 
         if self.m_stack == 'mean':
             if ndim == 4:
                 im_stack = im_tot/float(im_tot.shape[0])
+
                 if self.m_dimension == 'time':
                     self.m_image_out_port.set_all(im_stack[:, np.newaxis, ...])
+
                 elif self.m_dimension == 'wavelength':
                     self.m_image_out_port.set_all(im_stack[np.newaxis, ...])
+
             else:
                 im_stack = im_tot/float(nimages)
                 self.m_image_out_port.set_all(im_stack[np.newaxis, ...])
@@ -472,12 +491,15 @@ class DerotateAndStackModule(ProcessingModule):
         elif self.m_stack == 'median':
             if ndim == 4:
                 images = self.m_image_in_port[:]
+
                 if self.m_dimension == 'time':
                     im_stack = np.median(images, axis=1)
                     self.m_image_out_port.set_all(im_stack[:, np.newaxis, ...])
+
                 elif self.m_dimension == 'wavelength':
                     im_stack = np.median(images, axis=0)
                     self.m_image_out_port.set_all(im_stack[np.newaxis, ...])
+
             else:
                 im_stack = np.median(images, axis=0)
                 self.m_image_out_port.set_all(im_stack[np.newaxis, ...])
@@ -485,6 +507,7 @@ class DerotateAndStackModule(ProcessingModule):
         elif self.m_stack is None and ndim == 4:
             if self.m_dimension == 'time':
                 self.m_image_out_port.set_all(im_none)
+
             elif self.m_dimension == 'wavelength':
                 self.m_image_out_port.set_all(im_none)
 
@@ -529,7 +552,7 @@ class CombineTagsModule(ProcessingModule):
             None
         """
 
-        super(CombineTagsModule, self).__init__(name_in=name_in)
+        super(CombineTagsModule, self).__init__(name_in)
 
         self.m_image_out_port = self.add_output_port(image_out_tag)
 

--- a/pynpoint/processing/stacksubset.py
+++ b/pynpoint/processing/stacksubset.py
@@ -318,8 +318,9 @@ class DerotateAndStackModule(ProcessingModule):
         image_in_tag : str
             Tag of the database entry that is read as input.
         image_out_tag : str
-            Tag of the database entry that is written as output. The output is either 2D
-            (``stack=False``) or 3D (``stack=True``).
+            Tag of the database entry that is written as output. The shape of the output data is
+            equal to the data from image_in_tag except, if stack is not None, the stacked
+            dimension has a size of 1.
         derotate : bool
             Derotate the images with the ``PARANG`` attribute.
         stack : str

--- a/pynpoint/processing/stacksubset.py
+++ b/pynpoint/processing/stacksubset.py
@@ -432,11 +432,14 @@ class DerotateAndStackModule(ProcessingModule):
             
             elif self.m_stack == 'median' and ndim == 4:
                 im_stack = np.median(images, axis=0)
-                self.m_image_out_port.append(im_stack[np.newaxis, ...], data_dim=4)
+                self.m_image_out_port.append(im_stack, data_dim=3)
 
         if self.m_stack == 'mean':
             im_stack = im_tot/float(nimages)
-            self.m_image_out_port.set_all(im_stack[np.newaxis, ...])
+            if ndim == 4:
+                self.m_image_out_port.set_all(im_stack)
+            else:
+                self.m_image_out_port.set_all(im_stack[np.newaxis, ...])
 
         elif self.m_stack == 'median' and ndim in [2, 3]:
             im_stack = np.median(images, axis=0)

--- a/pynpoint/processing/stacksubset.py
+++ b/pynpoint/processing/stacksubset.py
@@ -421,7 +421,7 @@ class DerotateAndStackModule(ProcessingModule):
                     self.m_image_out_port.set_all(images[np.newaxis, ...])
                 elif ndim == 3:
                     self.m_image_out_port.append(images, data_dim=3)
-                elif ndim ==4:
+                elif ndim == 4:
                     self.m_image_out_port.append(images, data_dim=4)
 
             elif self.m_stack == 'mean':
@@ -429,7 +429,7 @@ class DerotateAndStackModule(ProcessingModule):
                     im_tot[i] = np.sum(images, axis=0)
                 else:
                     im_tot += np.sum(images, axis=0)
-            
+
             elif self.m_stack == 'median' and ndim == 4:
                 im_stack = np.median(images, axis=0)
                 self.m_image_out_port.append(im_stack, data_dim=3)

--- a/pynpoint/processing/stacksubset.py
+++ b/pynpoint/processing/stacksubset.py
@@ -319,8 +319,8 @@ class DerotateAndStackModule(ProcessingModule):
             Tag of the database entry that is read as input.
         image_out_tag : str
             Tag of the database entry that is written as output. The shape of the output data is
-            equal to the data from image_in_tag except, if stack is not None, the stacked
-            dimension has a size of 1.
+            equal to the data from ``image_in_tag``. If the argument of ``stack`` is not None,
+            then the size of the collapsed dimension is equal to 1.
         derotate : bool
             Derotate the images with the ``PARANG`` attribute.
         stack : str

--- a/tests/test_processing/test_stacksubsample.py
+++ b/tests/test_processing/test_stacksubsample.py
@@ -189,13 +189,17 @@ class TestStackSubset:
         assert np.mean(data) == pytest.approx(0.0861160094566323, rel=self.limit, abs=0.)
         assert data.shape == (1, 11, 11)
 
+        data = self.pipeline.get_data('derotate2')
+        assert np.mean(data) == pytest.approx(0.0861160094566323, rel=self.limit, abs=0.)
+        assert data.shape == (1, 11, 11)
+
         module = DerotateAndStackModule(name_in='derotate_ifs1',
                                         image_in_tag='images_ifs',
                                         image_out_tag='derotate_ifs1',
                                         derotate=True,
                                         stack='mean',
                                         extra_rot=0.,
-                                        dimension = 'time')
+                                        dimension='time')
 
         self.pipeline.add_module(module)
         self.pipeline.run_module('derotate_ifs1')
@@ -210,7 +214,7 @@ class TestStackSubset:
                                         derotate=False,
                                         stack='median',
                                         extra_rot=0.,
-                                        dimension = 'wavelength')
+                                        dimension='wavelength')
 
         self.pipeline.add_module(module)
         self.pipeline.run_module('derotate_ifs2')
@@ -218,6 +222,21 @@ class TestStackSubset:
         data = self.pipeline.get_data('derotate_ifs2')
         assert np.mean(data) == pytest.approx(0.055939644983170146, rel=self.limit, abs=0.)
         assert data.shape == (1, 10, 21, 21)
+
+        module = DerotateAndStackModule(name_in='derotate_ifs3',
+                                        image_in_tag='images_ifs',
+                                        image_out_tag='derotate_ifs3',
+                                        derotate=True,
+                                        stack=None,
+                                        extra_rot=0.,
+                                        dimension='wavelength')
+
+        self.pipeline.add_module(module)
+        self.pipeline.run_module('derotate_ifs3')
+
+        data = self.pipeline.get_data('derotate_ifs3')
+        assert np.mean(data) == pytest.approx(0.056535012036597686, rel=self.limit, abs=0.)
+        assert data.shape == (3, 10, 21, 21)
 
     def test_combine_tags(self) -> None:
 

--- a/tests/test_processing/test_stacksubsample.py
+++ b/tests/test_processing/test_stacksubsample.py
@@ -194,28 +194,30 @@ class TestStackSubset:
                                         image_out_tag='derotate_ifs1',
                                         derotate=True,
                                         stack='mean',
-                                        extra_rot=0.)
+                                        extra_rot=0.,
+                                        dimension = 'time')
 
         self.pipeline.add_module(module)
         self.pipeline.run_module('derotate_ifs1')
 
         data = self.pipeline.get_data('derotate_ifs1')
-        assert np.mean(data) == pytest.approx(0.056535012036597686, rel=self.limit, abs=0.)
-        assert data.shape == (3, 21, 21)
+        assert np.mean(data) == pytest.approx(0.18845004012199226, rel=self.limit, abs=0.)
+        assert data.shape == (3, 1, 21, 21)
 
         module = DerotateAndStackModule(name_in='derotate_ifs2',
                                         image_in_tag='images_ifs',
                                         image_out_tag='derotate_ifs2',
                                         derotate=False,
                                         stack='median',
-                                        extra_rot=0.)
+                                        extra_rot=0.,
+                                        dimension = 'wavelength')
 
         self.pipeline.add_module(module)
         self.pipeline.run_module('derotate_ifs2')
 
         data = self.pipeline.get_data('derotate_ifs2')
-        assert np.mean(data) == pytest.approx(0.037075807614651415, rel=self.limit, abs=0.)
-        assert data.shape == (3, 21, 21)
+        assert np.mean(data) == pytest.approx(0.055939644983170146, rel=self.limit, abs=0.)
+        assert data.shape == (1, 10, 21, 21)
 
     def test_combine_tags(self) -> None:
 


### PR DESCRIPTION
I added IFS (4D data) support to the DerotateAndStackModule incl. unit tests.

What needs to be discussed is the output format of 4D data after stacking. Previously, the Module simply collapsed the time axis
 - e.g. (10, 291, 291) -> (1, 291, 291).

For 4D data, two outputs are possible:
- Case 1: (39, 10, 291, 291) -> (39, 1, 291, 291)
- Case 2: (39, 10, 291, 291) -> (39, 291, 291)

Case 2 might be less intuitve but has the advantage that the DerotateAndStackModule can now also be used to stack the data along the wavelength dimension. If the output form should be case 1 then we should add a parameter to the DerotateAndStackModule to stack along the wavelegnth axis.

Please tell me which one you prefere (currently case 2 is implemented).